### PR TITLE
frontend: Add feedback via update popup for release fetch

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -7,8 +7,16 @@ import UpdatePopup from './UpdatePopup';
 
 export default function ReleaseNotes() {
   const { desktopApi } = window;
-  const [releaseNotes, setReleaseNotes] = React.useState<string>();
+  const [releaseNotes, setReleaseNotes] = React.useState<string>('');
   const [releaseDownloadURL, setReleaseDownloadURL] = React.useState<string | null>(null);
+  const [fetchingRelease, setFetchingRelease] = React.useState<boolean>(false);
+  const [releaseFetchFailed, setReleaseFetchFailed] = React.useState<boolean>(false);
+  const [skipFetch, setSkipFetch] = React.useState(false);
+
+  // network controller this makes sure if the octockit request is still lying around we
+  // abort it on fetch release skip press button click
+  const controller = new AbortController();
+  const signal = controller.signal;
 
   React.useEffect(() => {
     if (desktopApi) {
@@ -22,16 +30,24 @@ export default function ReleaseNotes() {
           }
 
           const octokit = new Octokit({
-            timeout: 5000,
+            timeout: 10000,
+            signal,
           });
 
           async function fetchRelease() {
+            // attach a timeout which checks after 5 second of fetching release
+            // if the release request was not successful
+            const timeoutID = setTimeout(() => {
+              setFetchingRelease(true);
+            }, 5000);
+
             const githubReleaseURL = `GET /repos/{owner}/{repo}/releases`;
             // get me all the releases -> default decreasing order of releases
             const response = await octokit.request(githubReleaseURL, {
               owner: 'kinvolk',
               repo: 'headlamp',
             });
+
             // Get the latest release that is not headlamp-plugin or headlamp-helm.
             const latestRelease = response.data.find(
               release => !release.name?.startsWith('headlamp-')
@@ -50,25 +66,28 @@ export default function ReleaseNotes() {
             let releaseNotes = '';
             if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
               // get the release notes for the version with which the app was built with
-
               const githubReleaseURL = `GET /repos/{owner}/{repo}/releases/tags/v${currentBuildAppVersion}`;
               try {
                 const response = await octokit.request(githubReleaseURL, {
                   owner: 'kinvolk',
                   repo: 'headlamp',
                 });
-
                 const [notes] = response.data.body.split('<!-- end-release-notes -->');
                 if (!!notes) {
                   releaseNotes = notes;
                 }
               } catch (err) {
+                setReleaseFetchFailed(true);
                 console.error(
                   `Error getting release notes for version ${currentBuildAppVersion}:`,
                   err
                 );
               }
             }
+
+            // If all of the above was done before we need to warn the user, we don't need to warn them.
+            clearTimeout(timeoutID);
+            setFetchingRelease(false);
 
             // set the store version to the current so that we don't show release notes on
             // every start of app
@@ -84,13 +103,13 @@ export default function ReleaseNotes() {
           const isUpdateCheckingDisabled = JSON.parse(
             localStorage.getItem('disable_update_check') || 'false'
           );
-          if (!isUpdateCheckingDisabled) {
+          if (!isUpdateCheckingDisabled && !fetchingRelease && !skipFetch) {
             fetchRelease();
           }
         }
       );
     }
-  }, []);
+  }, [fetchingRelease, skipFetch]);
 
   React.useEffect(() => {
     desktopApi?.send('appConfig');
@@ -98,9 +117,21 @@ export default function ReleaseNotes() {
 
   return (
     <>
-      {releaseDownloadURL && <UpdatePopup releaseDownloadURL={releaseDownloadURL} />}
+      {
+        <UpdatePopup
+          releaseDownloadURL={releaseDownloadURL || ''}
+          fetchingRelease={fetchingRelease}
+          releaseFetchFailed={releaseFetchFailed}
+          skipUpdateHandler={() => {
+            // abort the octockit request to fetch github release
+            controller.abort();
+            setSkipFetch(false);
+            setFetchingRelease(false);
+          }}
+        />
+      }
       {releaseNotes && (
-        <ReleaseNotesModal appVersion={helpers.getAppVersion()} releaseNotes={releaseNotes} />
+        <ReleaseNotesModal releaseNotes={releaseNotes} appVersion={helpers.getAppVersion()} />
       )}
     </>
   );

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 
 export interface ReleaseNotesModalProps {
-  releaseNotes?: string;
+  releaseNotes: string;
   appVersion: string | null;
 }
 
@@ -28,6 +28,7 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
     minWidth: '50%',
     minHeight: '50%',
     overflow: 'auto',
+    maxWidth: '80%',
   };
 
   return (
@@ -50,7 +51,7 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
           className="markdown-body"
           style={{ color: theme.palette.text.primary, fontFamily: 'inherit' }}
         >
-          {releaseNotes && <ReactMarkdown>{releaseNotes}</ReactMarkdown>}
+          <ReactMarkdown>{releaseNotes}</ReactMarkdown>
         </Box>
       </Paper>
     </Modal>

--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
-import React from 'react';
-import UpdatePopup, { UpdatePopupProps } from './UpdatePopup';
+import UpdatePopup from './UpdatePopup';
 
 export default {
   title: 'common/ReleaseNotes/UpdatePopup',
@@ -8,7 +7,12 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<UpdatePopupProps> = args => <UpdatePopup {...args} />;
+const Template: Story<{
+  releaseDownloadURL?: string | null;
+  fetchingRelease?: boolean;
+  releaseFetchFailed?: boolean;
+  skipUpdateHandler: () => void;
+}> = args => <UpdatePopup {...args} />;
 
 export const Show = Template.bind({});
 Show.args = {
@@ -18,5 +22,4 @@ Show.args = {
 export const Closed = Template.bind({});
 Closed.args = {
   releaseDownloadURL: 'https://example.com',
-  open: false,
 };

--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
@@ -1,6 +1,16 @@
-import { Button, Snackbar } from '@material-ui/core';
+import { Icon } from '@iconify/react';
+import { Box, Button, makeStyles, Snackbar } from '@material-ui/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    '& .MuiSnackbarContent-root': {
+      backgroundColor: 'rgb(49, 49, 49)',
+      color: '#fff',
+    },
+  },
+}));
 
 function UpdatePopup(props: {
   releaseDownloadURL?: string | null;
@@ -8,13 +18,15 @@ function UpdatePopup(props: {
   releaseFetchFailed?: boolean;
   skipUpdateHandler: () => void;
 }) {
+  const classes = useStyles();
   const [show, setShow] = React.useState(true);
   const { releaseDownloadURL, fetchingRelease, releaseFetchFailed, skipUpdateHandler } = props;
   const { t } = useTranslation('frequent');
 
-  if (fetchingRelease) {
+  if (fetchingRelease && !releaseDownloadURL) {
     return (
       <Snackbar
+        className={classes.root}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',
@@ -28,7 +40,9 @@ function UpdatePopup(props: {
         action={
           <React.Fragment>
             <Button
-              color="primary"
+              style={{
+                color: 'rgb(255, 242, 0)',
+              }}
               onClick={() => {
                 skipUpdateHandler();
               }}
@@ -41,9 +55,10 @@ function UpdatePopup(props: {
     );
   }
 
-  if (releaseFetchFailed) {
+  if (releaseFetchFailed && !releaseDownloadURL) {
     return (
       <Snackbar
+        className={classes.root}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',
@@ -68,6 +83,7 @@ function UpdatePopup(props: {
         vertical: 'bottom',
         horizontal: 'right',
       }}
+      className={classes.root}
       open={show}
       autoHideDuration={100000}
       ContentProps={{
@@ -76,21 +92,42 @@ function UpdatePopup(props: {
       message={t('release|An update is available')}
       action={
         <React.Fragment>
-          <Button color="secondary" onClick={() => window.open(releaseDownloadURL)}>
-            {t('frequent|More')}
-          </Button>
-          <Button
-            color="inherit"
-            onClick={() => {
-              localStorage.setItem('disable_update_check', 'true');
-              setShow(false);
-            }}
-          >
-            {t('Do not notify again')}
-          </Button>
-          <Button color="primary" onClick={() => setShow(false)}>
-            {t('frequent|Close')}
-          </Button>
+          <Box display={'flex'} alignItems="center">
+            <Box ml={-1}>
+              <Button
+                onClick={() => window.open(releaseDownloadURL)}
+                style={{
+                  color: 'inherit',
+                  textTransform: 'none',
+                }}
+              >
+                {t('frequent|Read more')}
+              </Button>
+            </Box>
+            <Box mb={0.5}>
+              <Button
+                style={{
+                  color: 'rgb(255, 242, 0)',
+                }}
+                onClick={() => {
+                  localStorage.setItem('disable_update_check', 'true');
+                  setShow(false);
+                }}
+              >
+                <Icon icon={'mdi:bell-off-outline'} width="20" />
+              </Button>
+            </Box>
+            <Box>
+              <Button
+                style={{
+                  color: 'rgb(255, 242, 0)',
+                }}
+                onClick={() => setShow(false)}
+              >
+                {t('frequent|Dismiss')}
+              </Button>
+            </Box>
+          </Box>
         </React.Fragment>
       }
     />

--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
@@ -1,21 +1,66 @@
 import { Button, Snackbar } from '@material-ui/core';
 import React from 'react';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export interface UpdatePopupProps {
-  releaseDownloadURL: string;
-  open: boolean;
-}
-
-function UpdatePopup(props: UpdatePopupProps) {
-  const { releaseDownloadURL, open } = props;
+function UpdatePopup(props: {
+  releaseDownloadURL?: string | null;
+  fetchingRelease?: boolean;
+  releaseFetchFailed?: boolean;
+  skipUpdateHandler: () => void;
+}) {
+  const [show, setShow] = React.useState(true);
+  const { releaseDownloadURL, fetchingRelease, releaseFetchFailed, skipUpdateHandler } = props;
   const { t } = useTranslation('frequent');
-  const [show, setShow] = useState(open);
 
-  useEffect(() => {
-    setShow(open);
-  }, [open]);
+  if (fetchingRelease) {
+    return (
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        autoHideDuration={5000}
+        message={t('release|Fetching release information…')}
+        ContentProps={{
+          'aria-describedby': 'updatePopup',
+        }}
+        open={fetchingRelease}
+        action={
+          <React.Fragment>
+            <Button
+              color="primary"
+              onClick={() => {
+                skipUpdateHandler();
+              }}
+            >
+              {t('frequent|Skip')}
+            </Button>
+          </React.Fragment>
+        }
+      />
+    );
+  }
+
+  if (releaseFetchFailed) {
+    return (
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        open={releaseFetchFailed}
+        message={t('release|Failed to fetch release information')}
+        ContentProps={{
+          'aria-describedby': 'updatePopup',
+        }}
+        autoHideDuration={6000}
+      />
+    );
+  }
+
+  if (!releaseDownloadURL) {
+    return null;
+  }
 
   return (
     <Snackbar

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.stories.storyshot
@@ -9,13 +9,3 @@ exports[`Storyshots common/ReleaseNotes/ReleaseNotesModal Show 1`] = `
 `;
 
 exports[`Storyshots common/ReleaseNotes/ReleaseNotesModal Show No Notes 1`] = `<div />`;
-
-exports[`Storyshots common/ReleaseNotesModal Closed 1`] = `<div />`;
-
-exports[`Storyshots common/ReleaseNotesModal Show 1`] = `
-<div
-  aria-hidden="true"
-/>
-`;
-
-exports[`Storyshots common/ReleaseNotesModal Show No Notes 1`] = `<div />`;

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/UpdatePopup.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/UpdatePopup.stories.storyshot
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots common/ReleaseNotes/UpdatePopup Closed 1`] = `<div />`;
-
-exports[`Storyshots common/ReleaseNotes/UpdatePopup Show 1`] = `
+exports[`Storyshots common/ReleaseNotes/UpdatePopup Closed 1`] = `
 <div>
   <div
-    class="MuiSnackbar-root MuiSnackbar-anchorOriginBottomRight"
+    class="MuiSnackbar-root MuiSnackbar-anchorOriginBottomRight makeStyles-root"
   >
     <div
       aria-describedby="updatePopup"
@@ -22,48 +20,154 @@ exports[`Storyshots common/ReleaseNotes/UpdatePopup Show 1`] = `
       <div
         class="MuiSnackbarContent-action"
       >
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary"
-          tabindex="0"
-          type="button"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          <span
-            class="MuiButton-label"
+          <div
+            class="MuiBox-root MuiBox-root"
           >
-            More
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-colorInherit"
-          tabindex="0"
-          type="button"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              style="text-transform: none;"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Read more
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div
+            class="MuiBox-root MuiBox-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              style="color: rgb(255, 242, 0);"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <span />
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div
+            class="MuiBox-root MuiBox-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              style="color: rgb(255, 242, 0);"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Dismiss
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots common/ReleaseNotes/UpdatePopup Show 1`] = `
+<div>
+  <div
+    class="MuiSnackbar-root MuiSnackbar-anchorOriginBottomRight makeStyles-root"
+  >
+    <div
+      aria-describedby="updatePopup"
+      class="MuiPaper-root MuiSnackbarContent-root MuiPaper-elevation6"
+      direction="up"
+      role="alert"
+      style="opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <div
+        class="MuiSnackbarContent-message"
+      >
+        An update is available
+      </div>
+      <div
+        class="MuiSnackbarContent-action"
+      >
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          <span
-            class="MuiButton-label"
+          <div
+            class="MuiBox-root MuiBox-root"
           >
-            Do not notify again
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              style="text-transform: none;"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Read more
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div
+            class="MuiBox-root MuiBox-root"
           >
-            Close
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              style="color: rgb(255, 242, 0);"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <span />
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div
+            class="MuiBox-root MuiBox-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              style="color: rgb(255, 242, 0);"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Dismiss
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We have a 5 second window for a update fetch, this patch adds feedback for all the actions that happen in that 5 sec window like fetching release and also if the release fetch failed and shows them in the update Snackbar

