### PR TITLE
Docker desktop setup instructions and change exposed port

### DIFF
--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/headlamp-k8s/headlamp:v0.15.0 as headlamp
+FROM ghcr.io/headlamp-k8s/headlamp:v0.15.1 as headlamp
 
 FROM scratch
 

--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -1,11 +1,10 @@
 version: '3'
-
 services:
   headlamp:
-    image: ghcr.io/headlamp-k8s/headlamp:v0.13.0
-    command: ["--kubeconfig","/headlamp/config/config"]
+    image: ghcr.io/kinvolk/headlamp:v0.13.0
+    command: ["--kubeconfig","/headlamp/config/config", "--port","64446"]
     restart: unless-stopped
     volumes:
       - ~/.kube/:/headlamp/config:ro
     ports:
-      - 4466:4466
+      - 64446:64446

--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   headlamp:
-    image: ghcr.io/kinvolk/headlamp:v0.13.0
+    image: ghcr.io/headlamp-k8s/headlamp:v0.15.1
     command: ["--kubeconfig","/headlamp/config/config", "--port","64446"]
     restart: unless-stopped
     volumes:

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -261,9 +261,14 @@ export function PureAuthChooser({
             <Box alignItems="center" textAlign="center">
               <Box m={2}>
                 <Empty>
-                  {t('Failed to get authentication information: {{ errorMessage }}', {
-                    errorMessage: error!.message,
-                  })}
+                  {error && error.message === 'Bad Gateway'
+                    ? t(
+                        'Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}',
+                        { errorMessage: error!.message }
+                      )
+                    : t('Failed to get authentication information: {{ errorMessage }}', {
+                        errorMessage: error!.message,
+                      })}
                 </Empty>
               </Box>
               <ColorButton onClick={handleTryAgain}>{t('frequent|Try Again')}</ColorButton>

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -37,6 +37,20 @@ function isElectron(): boolean {
   return false;
 }
 
+/**
+ * isDockerDesktop checks if ddClient is available in the window object
+ * if it is available then it is running in docker desktop
+ *
+ *
+ * @returns true if Headlamp is running inside docker desktop
+ */
+function isDockerDesktop(): boolean {
+  if (window?.ddClient === undefined) {
+    return false;
+  }
+  return true;
+}
+
 export function getFilterValueByNameFromURL(key: string, location: any): string[] {
   const searchParams = new URLSearchParams(location.search);
 
@@ -84,9 +98,10 @@ function isDevMode(): boolean {
 }
 
 /**
- * @returns URL depending on dev-mode/electron, base-url, and window.location.origin.
+ * @returns URL depending on dev-mode/electron/docker desktop, base-url, and window.location.origin.
  *
  * @example isDevMode | isElectron returns 'http://localhost:4466/'
+ * @example isDockerDesktop returns 'http://localhost:64446/'
  * @example base-url set as '/headlamp' returns '/headlamp/'
  * @example isDevMode | isElectron and base-url is set
  *          it returns 'http://localhost:4466/headlamp/'
@@ -98,6 +113,9 @@ function getAppUrl(): string {
     exportFunctions.isDevMode() || exportFunctions.isElectron()
       ? 'http://localhost:4466'
       : window.location.origin;
+  if (exportFunctions.isDockerDesktop()) {
+    url = 'http://localhost:64446';
+  }
 
   const baseUrl = exportFunctions.getBaseUrl();
   url += baseUrl ? baseUrl + '/' : '/';
@@ -110,6 +128,7 @@ declare global {
     headlampBaseUrl?: string;
     Buffer: typeof Buffer;
     clusterConfigFetchHandler: ReturnType<typeof setInterval>;
+    ddClient: any | undefined;
   }
 }
 
@@ -201,6 +220,7 @@ const exportFunctions = {
   isDevMode,
   getAppUrl,
   isElectron,
+  isDockerDesktop,
   getAppVersion,
   setAppVersion,
   setRecentCluster,

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -14,5 +14,6 @@
   "Use A Token": "Use A Token",
   "Failed to get authentication information: {{ errorMessage }}": "Failed to get authentication information: {{ errorMessage }}",
   "No permissions to list pods.": "No permissions to list pods.",
-  "Redirecting to main page…": "Redirecting to main page…"
+  "Redirecting to main page…": "Redirecting to main page…",
+  "Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}": "Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}"
 }

--- a/frontend/src/i18n/locales/es/auth.json
+++ b/frontend/src/i18n/locales/es/auth.json
@@ -14,5 +14,6 @@
   "Use A Token": "Use un token",
   "Failed to get authentication information: {{ errorMessage }}": "Fallo al obtener la información de autenticación: {{ errorMessage }}",
   "No permissions to list pods.": "Sin permisos para listar pods.",
-  "Redirecting to main page…": "Redireccionando a la página principal…"
+  "Redirecting to main page…": "Redireccionando a la página principal…",
+  "Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}": ""
 }

--- a/frontend/src/i18n/locales/pt/auth.json
+++ b/frontend/src/i18n/locales/pt/auth.json
@@ -14,5 +14,6 @@
   "Use A Token": "Use um token",
   "Failed to get authentication information: {{ errorMessage }}": "Falha ao obter informação de autenticação: {{ errorMessage }}",
   "No permissions to list pods.": "Sem permissões para listar pods",
-  "Redirecting to main page…": "A redireccionar para a página principal…"
+  "Redirecting to main page…": "A redireccionar para a página principal…",
+  "Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}": ""
 }


### PR DESCRIPTION
Steps to test
[[Hard Mode]]
- `docker build . -t ghcr.io/kinvolk/headlamp:v0.15.0` in project home directory
- `cd  docker-extension`
- `docker build . -t headlamp-dd`
-  `docker extension install headlamp-dd`
-  Go to docker desktop dashboard and test

[[Easy mode]] 
- `docker extension install yolossn/headlamp-dd-extension`
-  Go to docker desktop dashboard and test

Flows:
1. The user has a `~/.kube/config` file with a proper cluster config -> Headlamp opens to the dashboard UI directly
2. The user has a `~/.kube/config` file but the cluster is not accessible -> The user gets the following message
`Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}`
3. The user doesn't have a `~/.kube/config` file, the user is shown a message to setup kubernetes cluster or load a kube config file.