### PR TITLE
Allow Overriding token management

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,8 +2,16 @@
  * This module was taken from the k8dash project.
  */
 
+import store from '../redux/stores/store';
+
 export function getToken(cluster: string) {
-  return getTokens()[cluster];
+  const getTokenMethodToUse = store.getState().ui.functionsToOverride.getToken;
+  const tokenMethodToUse =
+    getTokenMethodToUse ||
+    function () {
+      return getTokens()[cluster];
+    };
+  return tokenMethodToUse(cluster);
 }
 
 export function getUserInfo(cluster: string) {
@@ -20,9 +28,14 @@ function getTokens() {
 }
 
 export function setToken(cluster: string, token: string | null) {
-  const tokens = getTokens();
-  tokens[cluster] = token;
-  localStorage.tokens = JSON.stringify(tokens);
+  const setTokenMethodToUse = store.getState().ui.functionsToOverride.setToken;
+  if (setTokenMethodToUse) {
+    setTokenMethodToUse(cluster, token);
+  } else {
+    const tokens = getTokens();
+    tokens[cluster] = token;
+    localStorage.tokens = JSON.stringify(tokens);
+  }
 }
 
 export function deleteTokens() {

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -13,6 +13,7 @@ import {
   setClusterChooserButtonComponent,
   setDetailsView,
   setDetailsViewHeaderAction,
+  setFunctionsToOverride,
   setRoute,
   setRouteFilter,
   setSidebarItem,
@@ -383,4 +384,34 @@ export function registerAppLogo(logo: AppLogoType) {
  */
 export function registerClusterChooser(chooser: ClusterChooserType) {
   store.dispatch(setClusterChooserButtonComponent(chooser));
+}
+
+/**
+ * Override headlamp setToken method
+ * @param override - The setToken override method to use.
+ *
+ * @example
+ * ```ts
+ * registerSetTokenFunction((cluster: string, token: string | null) => {
+ * // set token logic here
+ * });
+ */
+export function registerSetTokenFunction(
+  override: (cluster: string, token: string | null) => void
+) {
+  store.dispatch(setFunctionsToOverride({ setToken: override }));
+}
+
+/**
+ * Override headlamp getToken method
+ * @param override - The getToken override method to use.
+ *
+ * @example
+ * ```ts
+ * registerGetTokenFunction(() => {
+ * // set token logic here
+ * });
+ */
+export function registerGetTokenFunction(override: (cluster: string) => string | undefined) {
+  store.dispatch(setFunctionsToOverride({ getToken: override }));
 }

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -32,6 +32,7 @@ export const UI_VERSION_DIALOG_OPEN = 'UI_VERSION_DIALOG_OPEN';
 export const UI_BRANDING_SET_APP_LOGO = 'UI_BRANDING_SET_APP_LOGO';
 export const UI_SET_CLUSTER_CHOOSER_BUTTON = 'UI_SET_CLUSTER_CHOOSER_BUTTON';
 export const UI_HIDE_APP_BAR = 'UI_HIDE_APP_BAR';
+export const UI_FUNCTIONS_OVERRIDE = 'UI_FUNCTIONS_OVERRIDE';
 
 export interface BrandingProps {
   logo: AppLogoType;
@@ -189,4 +190,12 @@ export function setClusterChooserButtonComponent(component: ClusterChooserType) 
 
 export function setVersionDialogOpen(isVersionDialogOpen: boolean) {
   return { type: UI_VERSION_DIALOG_OPEN, isVersionDialogOpen };
+}
+
+export type FunctionsToOverride = {
+  [key: string]: (...args: any) => any;
+};
+
+export function setFunctionsToOverride(override: FunctionsToOverride) {
+  return { type: UI_FUNCTIONS_OVERRIDE, override };
 }

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -8,10 +8,12 @@ import { ClusterChooserType, DetailsViewSectionType } from '../../plugin/registr
 import {
   Action,
   BrandingProps,
+  FunctionsToOverride,
   HeaderActionType,
   UI_APP_BAR_SET_ACTION,
   UI_BRANDING_SET_APP_LOGO,
   UI_DETAILS_VIEW_SET_HEADER_ACTION,
+  UI_FUNCTIONS_OVERRIDE,
   UI_HIDE_APP_BAR,
   UI_INITIALIZE_PLUGIN_VIEWS,
   UI_PLUGINS_LOADED,
@@ -67,6 +69,7 @@ export interface UIState {
   notifications: Notification[];
   clusterChooserButtonComponent?: ClusterChooserType;
   hideAppBar?: boolean;
+  functionsToOverride: FunctionsToOverride;
 }
 
 function setInitialSidebarOpen() {
@@ -125,6 +128,7 @@ export const INITIAL_STATE: UIState = {
   },
   notifications: [],
   hideAppBar: false,
+  functionsToOverride: {},
 };
 
 function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
@@ -289,6 +293,15 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
     }
     case UI_VERSION_DIALOG_OPEN: {
       newFilters.isVersionDialogOpen = action.isVersionDialogOpen;
+      break;
+    }
+    case UI_FUNCTIONS_OVERRIDE: {
+      const functionToOverride = action.override;
+      for (const key in functionToOverride) {
+        if (functionToOverride.hasOwnProperty(key)) {
+          newFilters.functionsToOverride[key] = functionToOverride[key];
+        }
+      }
       break;
     }
     default:


### PR DESCRIPTION
We want to have the ability for the plugins to override the getToken and setToken methods and this patch provides the mechanism to do that.


