### PR TITLE
frontend: Fix doc viewer breaking

### DIFF
--- a/frontend/src/components/common/Resource/DocsViewer.tsx
+++ b/frontend/src/components/common/Resource/DocsViewer.tsx
@@ -4,11 +4,15 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import TreeItem from '@material-ui/lab/TreeItem';
 import TreeView from '@material-ui/lab/TreeView';
+import * as buffer from 'buffer';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import getDocDefinitions from '../../../lib/docs';
 import Empty from '../EmptyContent';
 import Loader from '../Loader';
+
+// Buffer class is not polyffiled with CRA(v5) so we manually do it here
+window.Buffer = buffer.Buffer;
 
 const useStyles = makeStyles(() => ({
   root: {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,4 +1,3 @@
-import * as buffer from 'buffer';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
@@ -13,8 +12,6 @@ if (process.env.NODE_ENV !== 'production') {
     axe = axe.default; //changed to esm module sometimes?
   }
   const axeCore = require('axe-core');
-  // Buffer class is not polyffiled with CRA(v5) so we manually do it here
-  window.Buffer = buffer.Buffer;
 
   if (process.env.REACT_APP_SKIP_A11Y !== 'true') {
     axe(React, ReactDOM, 500, undefined, undefined, (results: typeof axeCore.AxeResults) => {


### PR DESCRIPTION
With a recent CRA update node related modules are not shipped with CRA anymore. This broke the doc viewer as it was using the buffer module. We already had a patch earlier that added the polyfill but one problem with polyfilling it in a place like index.tsx is that when building the frontend for production, the polyfill is not included. The correct place to polyfill is to include it at the place where it is being used.