### PR TITLE
frontend: Use ISO format for dates tests

### DIFF
--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.stories.storyshot
@@ -64,7 +64,7 @@ exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
           >
-            6/2/2021, 12:00:00 AM UTC
+            2021-06-02T00:00:00.000Z
           </span>
         </td>
       </tr>
@@ -188,7 +188,7 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
           >
-            6/2/2021, 12:00:00 AM UTC
+            2021-06-02T00:00:00.000Z
           </span>
         </td>
       </tr>
@@ -372,7 +372,7 @@ exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
           >
-            6/2/2021, 12:00:00 AM UTC
+            2021-06-02T00:00:00.000Z
           </span>
         </td>
       </tr>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
@@ -104,7 +104,7 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
         >
           <p
             class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-            title="12/15/2021, 2:57:13 PM UTC"
+            title="2021-12-15T14:57:13.000Z"
           >
             3mo
             <span />
@@ -220,7 +220,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
         >
           <p
             class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-            title="12/15/2021, 2:57:13 PM UTC"
+            title="2021-12-15T14:57:13.000Z"
           >
             3mo
             <span />
@@ -251,7 +251,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
         >
           <p
             class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-            title="12/15/2021, 2:57:13 PM UTC"
+            title="2021-12-15T14:57:13.000Z"
           >
             3mo
             <span />
@@ -282,7 +282,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
         >
           <p
             class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-            title="12/15/2021, 2:57:13 PM UTC"
+            title="2021-12-15T14:57:13.000Z"
           >
             3mo
             <span />
@@ -313,7 +313,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
         >
           <p
             class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-            title="12/15/2021, 2:57:13 PM UTC"
+            title="2021-12-15T14:57:13.000Z"
           >
             3mo
             <span />

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -230,7 +230,7 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        12/15/2021, 2:57:13 PM UTC
+                        2021-12-15T14:57:13.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
@@ -155,7 +155,7 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Ast 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -476,7 +476,7 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Minute 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -129,7 +129,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        4/25/2020, 12:00:00 AM UTC
+                        2020-04-25T00:00:00.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
@@ -166,7 +166,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -203,7 +203,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -240,7 +240,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -277,7 +277,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -314,7 +314,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -155,7 +155,7 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        10/20/2022, 11:10:58 AM UTC
+                        2022-10-20T11:10:58.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
@@ -267,7 +267,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -337,7 +337,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -407,7 +407,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -477,7 +477,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -547,7 +547,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -161,7 +161,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -361,7 +361,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -401,7 +401,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -446,7 +446,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -491,7 +491,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -879,7 +879,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -1072,7 +1072,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1118,7 +1118,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1164,7 +1164,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1210,7 +1210,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1581,7 +1581,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -1781,7 +1781,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1821,7 +1821,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1867,7 +1867,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -1913,7 +1913,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -2397,7 +2397,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -2590,7 +2590,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -2630,7 +2630,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -2676,7 +2676,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -2722,7 +2722,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -3082,7 +3082,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -3275,7 +3275,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -3315,7 +3315,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -3355,7 +3355,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -3395,7 +3395,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -3804,7 +3804,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -3997,7 +3997,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -4042,7 +4042,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -4087,7 +4087,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -4132,7 +4132,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />

--- a/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
@@ -226,7 +226,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2022, 12:00:00 AM UTC"
+                  title="2022-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -282,7 +282,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2022, 12:00:00 AM UTC"
+                  title="2022-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -338,7 +338,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2022, 12:00:00 AM UTC"
+                  title="2022-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -401,7 +401,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2022, 12:00:00 AM UTC"
+                  title="2022-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -464,7 +464,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2022, 12:00:00 AM UTC"
+                  title="2022-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -520,7 +520,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2022, 12:00:00 AM UTC"
+                  title="2022-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -180,7 +180,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        1/1/2022, 12:00:00 AM UTC
+                        2022-01-01T00:00:00.000Z
                       </span>
                     </td>
                   </tr>
@@ -373,7 +373,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -413,7 +413,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -453,7 +453,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />
@@ -493,7 +493,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                     >
                       <p
                         class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                        title="1/1/2022, 12:05:00 AM UTC"
+                        title="2022-01-01T00:05:00.000Z"
                       >
                         3 months
                         <span />

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
@@ -155,7 +155,7 @@ exports[`Storyshots pdb/PDBDetailsView Default 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        10/6/2022, 5:17:14 AM UTC
+                        2022-10-06T05:17:14.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
@@ -201,7 +201,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -247,7 +247,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -293,7 +293,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -339,7 +339,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -385,7 +385,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
@@ -135,7 +135,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesDetailsView Default 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        10/26/2022, 1:46:17 PM UTC
+                        2022-10-26T13:46:17.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
@@ -149,7 +149,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -185,7 +185,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -221,7 +221,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -257,7 +257,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -293,7 +293,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -155,7 +155,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                       >
-                        10/25/2022, 11:48:48 AM UTC
+                        2022-10-25T11:48:48.000Z
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
@@ -185,7 +185,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -236,7 +236,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -287,7 +287,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -338,7 +338,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />
@@ -389,7 +389,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               >
                 <p
                   class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
-                  title="1/1/2020, 12:00:00 AM UTC"
+                  title="2020-01-01T00:00:00.000Z"
                 >
                   3mo
                   <span />

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -78,6 +78,7 @@ export function localeDate(date: DateParam) {
     options.timeZone = 'UTC';
     options.hour12 = true;
     locale = 'en-US';
+    return new Date(date).toISOString();
   } else {
     options.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   }


### PR DESCRIPTION
Node has changes how they format the dates when using "toLocaleString",
introducing a special character (U+202f) instead of a space.
Our first instinct was to lower the Node version and wait for a fix,
but according to [1], Node doesn't seem to be reverting it soon and
mentions one shouldn't use localized strings for testing...

So, in order to avoid this, this patch makes the dates show up in
ISO format.

[1] https://github.com/nodejs/node/issues/46123
