### PR TITLE
Update settings/notifications view sidebar and navigation

### DIFF
--- a/frontend/src/components/App/Notifications/List.tsx
+++ b/frontend/src/components/App/Notifications/List.tsx
@@ -91,6 +91,7 @@ export default function NotificationList() {
           actions={[<NotificationActionMenu />]}
         />
       }
+      backLink
     >
       {checkIfAllNotificationsDeleted() ? (
         <Empty>{t(`notifications|You don't have any notifications right now`)}</Empty>

--- a/frontend/src/components/App/settings/index.tsx
+++ b/frontend/src/components/App/settings/index.tsx
@@ -229,6 +229,7 @@ export default function Settings() {
           />,
         ],
       }}
+      backLink
     >
       <NameValueTable
         valueCellProps={{ className: classes.valueCol }}

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -70,8 +70,9 @@ export default function Sidebar() {
   const specialSidebarOptions: SidebarItemProps[] = [
     {
       name: t('frequent|back'),
-      icon: 'mdi:arrow-left',
-      label: t('frequent|Back'),
+      icon: 'mdi:hexagon-multiple',
+      label: t('glossary|Cluster'),
+      url: '/',
     },
     {
       name: t('frequent|notifications'),

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -170,12 +170,6 @@ export default function SidebarItem(props: SidebarItemProps) {
     linkClass += ' ' + classes.linkSmallWidth;
   }
 
-  function handleSpecificClickForBackSidebarOption() {
-    if (name === 'back') {
-      // todo: Handle the case when there is no history present
-      window.history.back();
-    }
-  }
   return hide ? null : (
     <React.Fragment>
       <ListItemLink
@@ -189,7 +183,6 @@ export default function SidebarItem(props: SidebarItemProps) {
         icon={icon}
         name={label}
         search={search}
-        onClick={handleSpecificClickForBackSidebarOption}
         {...other}
       />
       {subList.length > 0 && (

--- a/frontend/src/components/common/BackLink/BackLink.tsx
+++ b/frontend/src/components/common/BackLink/BackLink.tsx
@@ -1,0 +1,38 @@
+import { Icon } from '@iconify/react';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router-dom';
+
+export interface BackLinkProps {
+  /** The location to go back to. If not provided, the browser's history will be used. */
+  to?: string | ReturnType<typeof useLocation>;
+}
+
+export default function BackLink(props: BackLinkProps) {
+  const { to: backLink = '' } = props;
+  const { t } = useTranslation(['frequent']);
+  const history = useHistory();
+
+  // We only want to update when the backLink changes (not the history).
+  React.useEffect(() => {}, [backLink]);
+
+  return (
+    <Button
+      startIcon={<Icon icon="mdi:chevron-left" />}
+      size="small"
+      onClick={() => {
+        // If there is no back link, go back in history.
+        if (!backLink) {
+          history.goBack();
+          return;
+        }
+
+        history.push(backLink);
+      }}
+    >
+      <Typography style={{ paddingTop: '3px' }}>{t('frequent|Back')}</Typography>
+    </Button>
+  );
+}

--- a/frontend/src/components/common/BackLink/index.tsx
+++ b/frontend/src/components/common/BackLink/index.tsx
@@ -1,0 +1,3 @@
+export * from './BackLink';
+import BackLink from './BackLink';
+export default BackLink;

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@iconify/react';
-import { Button, InputLabel, Theme } from '@material-ui/core';
+import { InputLabel, Theme } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
 import Grid, { GridProps } from '@material-ui/core/Grid';
@@ -15,7 +15,7 @@ import _ from 'lodash';
 import * as monaco from 'monaco-editor';
 import React, { isValidElement, PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
-import { generatePath, NavLinkProps, useHistory, useLocation } from 'react-router-dom';
+import { generatePath, NavLinkProps, useLocation } from 'react-router-dom';
 import { labelSelectorToQuery } from '../../../lib/k8s';
 import {
   KubeCondition,
@@ -99,8 +99,6 @@ export function MainInfoSection(props: MainInfoSectionProps) {
   } = props;
   const headerActions = useTypedSelector(state => state.ui.views.details.headerActions);
   const { t } = useTranslation('frequent');
-  const history = useHistory();
-
   const header = typeof headerSection === 'function' ? headerSection(resource) : headerSection;
 
   const allActions = (function stateActions() {
@@ -139,54 +137,42 @@ export function MainInfoSection(props: MainInfoSectionProps) {
       })()
     );
 
-  return (
-    <>
-      {(backLink || backLink === '' || resource) && (
-        <Button
-          startIcon={<Icon icon="mdi:chevron-left" />}
-          size="small"
-          onClick={() => {
-            // Empty string means go back using the history.
-            if (backLink === '') {
-              history.goBack();
-              return;
-            }
-            if (typeof backLink === 'string') {
-              history.push(backLink);
-              return;
-            }
+  function getBackLink() {
+    if (!!backLink || backLink === '') {
+      return backLink;
+    }
 
-            history.push(backLink || createRouteURL(resource.listRoute));
-          }}
-        >
-          <Typography style={{ paddingTop: '3px' }}>{t('frequent|Back')}</Typography>
-        </Button>
-      )}
-      <SectionBox
-        aria-busy={resource === null}
-        aria-live="polite"
-        title={
-          <SectionHeader
-            title={title || (resource ? resource.kind : '')}
-            headerStyle={headerStyle}
-            actions={allActions}
-          />
-        }
-      >
-        {resource === null ? (
-          !!error ? (
-            <Empty color="error">{error.toString()}</Empty>
-          ) : (
-            <Loader title={t('frequent|Loading resource data')} />
-          )
+    if (!!resource) {
+      return createRouteURL(resource.listRoute);
+    }
+  }
+
+  return (
+    <SectionBox
+      aria-busy={resource === null}
+      aria-live="polite"
+      title={
+        <SectionHeader
+          title={title || (resource ? resource.kind : '')}
+          headerStyle={headerStyle}
+          actions={allActions}
+        />
+      }
+      backLink={getBackLink()}
+    >
+      {resource === null ? (
+        !!error ? (
+          <Empty color="error">{error.toString()}</Empty>
         ) : (
-          <React.Fragment>
-            {header}
-            <MetadataDisplay resource={resource} extraRows={extraInfo} />
-          </React.Fragment>
-        )}
-      </SectionBox>
-    </>
+          <Loader title={t('frequent|Loading resource data')} />
+        )
+      ) : (
+        <React.Fragment>
+          {header}
+          <MetadataDisplay resource={resource} extraRows={extraInfo} />
+        </React.Fragment>
+      )}
+    </SectionBox>
   );
 }
 

--- a/frontend/src/components/common/SectionBox.tsx
+++ b/frontend/src/components/common/SectionBox.tsx
@@ -1,12 +1,15 @@
 import Box, { BoxProps } from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import React from 'react';
+import BackLink, { BackLinkProps } from './BackLink';
 import SectionHeader, { SectionHeaderProps } from './SectionHeader';
 
 export interface SectionBoxProps extends Omit<BoxProps, 'title'> {
   title?: React.ReactNode;
   headerProps?: Omit<SectionHeaderProps, 'title'>;
   outterBoxProps?: Omit<BoxProps, 'title'>;
+  //** The location to go back to. If provided as an empty string, the browser's history will be used. If not provided (default)), then no back button is used. */
+  backLink?: BackLinkProps['to'] | boolean;
 }
 
 export function SectionBox(props: SectionBoxProps) {
@@ -15,10 +18,13 @@ export function SectionBox(props: SectionBoxProps) {
     children,
     headerProps = { noPadding: false, headerStyle: 'subsection' },
     outterBoxProps = {},
+    backLink,
     ...otherProps
   } = props;
 
   let titleElem: React.ReactNode;
+  // If backLink is a boolean, then we want to use the browser's history if true.
+  const actualBackLink = typeof backLink === 'boolean' ? (!!backLink ? '' : undefined) : backLink;
 
   if (typeof title === 'string') {
     titleElem = <SectionHeader title={title as string} {...headerProps} />;
@@ -27,14 +33,17 @@ export function SectionBox(props: SectionBoxProps) {
   }
 
   return (
-    <Box py={0} {...outterBoxProps}>
-      {title && titleElem}
-      <Paper>
-        <Box px={2} {...otherProps}>
-          {React.Children.toArray(children)}
-        </Box>
-      </Paper>
-    </Box>
+    <>
+      {actualBackLink !== undefined && <BackLink to={actualBackLink} />}
+      <Box py={0} {...outterBoxProps}>
+        {title && titleElem}
+        <Paper>
+          <Box px={2} {...otherProps}>
+            {React.Children.toArray(children)}
+          </Box>
+        </Paper>
+      </Box>
+    </>
   );
 }
 

--- a/frontend/src/components/common/index.test.ts
+++ b/frontend/src/components/common/index.test.ts
@@ -17,6 +17,7 @@ const avoidCheck = [
 
 const checkExports = [
   'ActionButton',
+  'BackLink',
   'Chart',
   'ConfirmDialog',
   'Dialog',

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,5 +1,6 @@
 export * from './ActionButton';
 export { default as ActionButton } from './ActionButton';
+export * from './BackLink';
 export * from './Chart';
 export * from './Dialog';
 export * from './EmptyContent';
@@ -28,5 +29,5 @@ export { default as Tabs } from './Tabs';
 export * from './Terminal';
 export { default as Terminal } from './Terminal';
 export * from './TimezoneSelect';
-export { default as TimezoneSelect } from './TimezoneSelect';
+export { default as BackLink, default as TimezoneSelect } from './TimezoneSelect';
 export * from './Tooltip';


### PR DESCRIPTION
Now that we have a settings and notifications view, the sidebar's back link button can be very confusing to use.
So these changes implement the new design, which allows to go back or to go to the home view where the user can choose the cluster.

![Screenshot showing the replaced back sidebar item by the new cluster one](https://user-images.githubusercontent.com/1029635/214113453-80f7add2-6c25-48ff-bb1d-b804a7faf3c5.png)
