### PR TITLE
Fix notifications

### DIFF
--- a/frontend/src/components/App/Notifications/List.stories.tsx
+++ b/frontend/src/components/App/Notifications/List.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { createStore } from 'redux';
+import helpers from '../../../helpers';
+import { Notification } from '../../../lib/notification';
+import { INITIAL_STATE as FILTER_INITIAL_STATE } from '../../../redux/reducers/filter';
+import { INITIAL_STATE as UI_INITIAL_STATE } from '../../../redux/reducers/ui';
+import { TestContext } from '../../../test';
+import NotificationList from './List';
+
+function createNotifications() {
+  const notifications = [];
+  for (let i = 0; i < 100; i++) {
+    notifications.push(
+      new Notification({
+        message: `Notification ${i}`,
+        date: '2022-08-01',
+      })
+    );
+  }
+
+  helpers.storeNotifications(notifications);
+}
+
+createNotifications();
+
+// eslint-disable-next-line no-unused-vars
+const store = createStore(
+  (state = { filter: { ...FILTER_INITIAL_STATE }, ui: { ...UI_INITIAL_STATE } }) => state,
+  {
+    filter: { ...FILTER_INITIAL_STATE },
+    ui: {
+      ...UI_INITIAL_STATE,
+      notifications: helpers.loadNotifications(),
+    },
+  }
+);
+
+export default {
+  title: 'Notifications',
+  component: NotificationList,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <TestContext store={store}>
+          <Story />
+        </TestContext>
+      );
+    },
+  ],
+} as Meta;
+
+const Template: Story = () => {
+  return <NotificationList />;
+};
+
+export const List = Template.bind({});

--- a/frontend/src/components/App/Notifications/__snapshots__/List.stories.storyshot
+++ b/frontend/src/components/App/Notifications/__snapshots__/List.stories.storyshot
@@ -1,0 +1,1085 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Notifications Version Dialog 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    <div
+      class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item"
+      >
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Notifications
+        </h1>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                >
+                  <button
+                    aria-label="Show filter"
+                    class="MuiButtonBase-root MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <span />
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <span />
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
+        <table
+          class="MuiTable-root makeStyles-table"
+        >
+          <tbody
+            class="MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 0"
+                  >
+                    Notification 0
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.899Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 1"
+                  >
+                    Notification 1
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 2"
+                  >
+                    Notification 2
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 3"
+                  >
+                    Notification 3
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 4"
+                  >
+                    Notification 4
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 5"
+                  >
+                    Notification 5
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 6"
+                  >
+                    Notification 6
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 7"
+                  >
+                    Notification 7
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 8"
+                  >
+                    Notification 8
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 9"
+                  >
+                    Notification 9
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 10"
+                  >
+                    Notification 10
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 11"
+                  >
+                    Notification 11
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 12"
+                  >
+                    Notification 12
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 13"
+                  >
+                    Notification 13
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                    style="font-weight: bold; cursor: pointer;"
+                    title="Notification 14"
+                  >
+                    Notification 14
+                  </p>
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                   
+                </div>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
+                  title="2023-01-19T08:41:09.901Z"
+                >
+                  3 months
+                  <span />
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <button
+                  aria-label="Mark as read"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
+                  title="Mark as read"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div
+          class="MuiTablePagination-root"
+        >
+          <div
+            class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters"
+          >
+            <div
+              class="MuiTablePagination-spacer"
+            />
+            <p
+              class="MuiTypography-root MuiTablePagination-caption MuiTypography-body2 MuiTypography-colorInherit"
+              id="mui-66118"
+            >
+              Rows per page:
+            </p>
+            <div
+              class="MuiInputBase-root MuiTablePagination-input MuiTablePagination-selectRoot"
+            >
+              <div
+                aria-haspopup="listbox"
+                aria-labelledby="mui-66118 mui-98515"
+                class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
+                id="mui-98515"
+                role="button"
+                tabindex="0"
+              >
+                15
+              </div>
+              <input
+                aria-hidden="true"
+                class="MuiSelect-nativeInput"
+                tabindex="-1"
+                value="15"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </div>
+            <p
+              class="MuiTypography-root MuiTablePagination-caption MuiTypography-body2 MuiTypography-colorInherit"
+            >
+              1-15 of 100
+            </p>
+            <div
+              class="MuiTablePagination-actions"
+            >
+              <button
+                aria-label="previous page"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-disabled MuiButtonBase-disabled"
+                disabled=""
+                tabindex="-1"
+                title="Previous page"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label="next page"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                tabindex="0"
+                title="Next page"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -191,7 +191,9 @@ function storeNotifications(notifications: Notification[], options: Notification
 }
 
 function loadNotifications(): Notification[] {
-  return JSON.parse(localStorage.getItem('notifications') || '[]');
+  const notifications = JSON.parse(localStorage.getItem('notifications') || '[]');
+  // Ensure we return real Notification objects.
+  return notifications.map((n: any) => Notification.fromJSON(n));
 }
 
 const exportFunctions = {

--- a/frontend/src/lib/notification.tsx
+++ b/frontend/src/lib/notification.tsx
@@ -67,6 +67,24 @@ export class Notification {
   get message() {
     return this._message;
   }
+
+  static fromJSON(json: any) {
+    return Object.assign(new Notification(), json);
+  }
+
+  // Avoid marshalling the entire object to JSON, as well as
+  // private properties with the _ prefix.
+  toJSON() {
+    return {
+      id: this.id,
+      seen: this.seen,
+      url: this.url,
+      date: this.date,
+      deleted: this.deleted,
+      cluster: this.cluster,
+      message: this.message,
+    };
+  }
 }
 
 export function setNotificationsInStore(notifications: Notification[] | Notification) {


### PR DESCRIPTION
The message was being stored as _message in the local storage due to being its variable name in the class and it would not get correctly assigned nor would the stored notifications be unmarshalled as Notification objects.
    
This patch fixes that and guarantees that the notifications' marshalling is under control.

How to test:
 [ ] Verify that the notifications do have a title when they before didn't.