### PR TITLE
Support http proxy from the kubeconfig

### DIFF
--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -21,6 +21,7 @@ type Cluster struct {
 	config   *clientcmdapi.Cluster
 	AuthType string                 `json:"auth_type"`
 	Metadata map[string]interface{} `json:"meta_data"`
+	ProxyURL string                 `json:"proxy_url"`
 }
 
 type ClusterReq struct {

--- a/backend/cmd/kubeconfig.go
+++ b/backend/cmd/kubeconfig.go
@@ -76,7 +76,7 @@ func GetContextsFromKubeConfigFile(kubeConfigPath string) ([]Context, error) {
 			}
 		}
 
-		cluster := Cluster{key, clusterConfig.Server, clusterConfig, authType, nil}
+		cluster := Cluster{key, clusterConfig.Server, clusterConfig, authType, nil, clusterConfig.ProxyURL}
 
 		contexts = append(contexts, Context{key, cluster, authInfo})
 	}


### PR DESCRIPTION
This patch adds support for using an HTTP proxy with clusters that
have it set up in their kubeconfig.

This is related to #916 .
@yolossn I am not sure if this is enough. Maybe you can help test this out.