### PR TITLE
frontend: Format age column in event list (in resources' section)

### DIFF
--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KubeObject } from '../../lib/k8s/cluster';
-import Event from '../../lib/k8s/event';
-import { timeAgo } from '../../lib/util';
-import { SectionBox, SimpleTable } from '../common';
+import Event, { KubeEvent } from '../../lib/k8s/event';
+import { localeDate, timeAgo } from '../../lib/util';
+import { HoverInfoLabel, SectionBox, SimpleTable } from '../common';
 
 export interface ObjectEventListProps {
   object: KubeObject;
@@ -39,17 +39,6 @@ export default function ObjectEventList(props: ObjectEventListProps) {
             },
           },
           {
-            label: t('frequent|Age'),
-            getter: item => {
-              if (item.count > 1) {
-                return `${timeAgo(item.lastTimestamp)} (${item.count} times over ${timeAgo(
-                  item.firstTimestamp
-                )})`;
-              }
-              return item.age;
-            },
-          },
-          {
             label: t('frequent|From'),
             getter: item => {
               return item.source.component;
@@ -60,6 +49,40 @@ export default function ObjectEventList(props: ObjectEventListProps) {
             getter: item => {
               return item.message;
             },
+          },
+          {
+            label: t('frequent|Age'),
+            getter: item => {
+              if (item.count > 1) {
+                return `${timeAgo(item.lastTimestamp)} (${item.count} times over ${timeAgo(
+                  item.firstTimestamp
+                )})`;
+              }
+              const eventDate = timeAgo(item.lastTimestamp, { format: 'mini' });
+              let label: string;
+              if (item.count > 1) {
+                label = t(
+                  'resource|{{ eventDate }} ({{ count }} times since {{ firstEventDate }})',
+                  {
+                    eventDate,
+                    count: item.count,
+                    firstEventDate: timeAgo(item.firstTimestamp),
+                  }
+                );
+              } else {
+                label = eventDate;
+              }
+
+              return (
+                <HoverInfoLabel
+                  label={label}
+                  hoverInfo={localeDate(item.lastTimestamp)}
+                  icon="mdi:calendar"
+                />
+              );
+            },
+            sort: (n1: KubeEvent, n2: KubeEvent) =>
+              new Date(n2.lastTimestamp).getTime() - new Date(n1.lastTimestamp).getTime(),
           },
         ]}
         data={events}


### PR DESCRIPTION
This patch fixes how the age columns is getting calculated and also
moves it to be the last column, in order to be consistent with how we
order the columns across Headlamp.
