### PR TITLE
Fix portforward list

### DIFF
--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -41,6 +41,7 @@ export default function PortForwardingList() {
   const [portForwardInAction, setPortForwardInAction] = React.useState<any>(null);
   const { enqueueSnackbar } = useSnackbar();
   const classes = useStyles();
+  const cluster = getCluster();
   const { t, i18n } = useTranslation(['resource', 'frequent', 'glossary']);
   const optionsTranslated = React.useMemo(
     () => ({
@@ -277,7 +278,7 @@ export default function PortForwardingList() {
             },
           },
         ]}
-        data={portforwards}
+        data={portforwards.filter((pf: any) => pf.cluster === cluster)}
       />
     </SectionBox>
   );


### PR DESCRIPTION
We were not filtering out the list view of portforward based on the cluster they are part of, this patch fixes that and only shows portforwards that are part of the current cluster.