### PR TITLE
frontend: Add pluginLib.Crd for exposing lib/k8s/crd

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -19,6 +19,7 @@ import Registry, {
 
 window.pluginLib = {
   ApiProxy: require('../lib/k8s/apiProxy'),
+  Crd: require('../lib/k8s/crd'),
   K8s: require('../lib/k8s'),
   CommonComponents: require('../components/common'),
   MuiCore: require('@material-ui/core'),


### PR DESCRIPTION
So plugins can use it.

window.pluginLib.Crd should be available.

This is required so tests can use lib/k8s/crd. To make it more convenient for future headlamp-plugin versions, the headlamp needs to expose this. Related to https://github.com/headlamp-k8s/headlamp/pull/795