### PR TITLE
Fix sidebar on locale

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -69,19 +69,19 @@ export default function Sidebar() {
   const { t, i18n } = useTranslation(['glossary', 'frequent']);
   const specialSidebarOptions: SidebarItemProps[] = [
     {
-      name: t('frequent|back'),
+      name: 'clusters',
       icon: 'mdi:hexagon-multiple',
       label: t('glossary|Cluster'),
       url: '/',
     },
     {
-      name: t('frequent|notifications'),
+      name: 'notifications',
       icon: 'mdi:bell',
       label: t('frequent|Notifications'),
       url: '/notifications',
     },
     {
-      name: t('frequent|settings'),
+      name: 'settings',
       icon: 'mdi:cog',
       label: t('frequent|Settings'),
       url: '/settings',


### PR DESCRIPTION
How to test:
- Go to settings, choose a non-English locale
- Go to the cluster chooser or some other area
- Click settings again, and then click the Settings sidebar entry or the Notifications one -> it should still show the special sidebar (Cluster + Notifications + Settings) as opposed to the regular sidebar