### PR TITLE
helm: update chart URL to headlamp-k8s namespace

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -9,7 +9,7 @@ Headlamp is an easy-to-use and extensible Kubernetes web UI.
 ## TL;DR
 
 ```console
-$ helm repo add headlamp https://kinvolk.github.io/headlamp/
+$ helm repo add headlamp https://headlamp-k8s.github.io/headlamp/
 $ helm install my-headlamp headlamp/headlamp --namespace kube-system
 ```
 

--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.title="Headlamp" \
     com.docker.desktop.extension.api.version=">= 0.2.0" \
     com.docker.extension.screenshots='[{"alt":"Cluster overview","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/cluster_overview.png"},{"alt":"Cluster Chooser","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/cluster_chooser.png"},{"alt":"Nodes list","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/nodes.png"},{"alt":"Resource Editor","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/resource_edition.png"},{"alt":"Editor Documentation","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/editor_documentation.png"},{"alt":"Terminal","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/terminal.png"}]' \
     com.docker.extension.detailed-description="Headlamp is an easy-to-use and extensible Kubernetes web UI. Headlamp was created to be a Kubernetes web UI that has the traditional functionality of other web UIs/dashboards available (i.e. to list and view resources) as well as other features." \
-    com.docker.extension.publisher-url="https://kinvolk.github.io/headlamp" \
+    com.docker.extension.publisher-url="https://headlamp-k8s.github.io/headlamp" \
     com.docker.extension.additional-urls="https://github.com/kinvolk/headlamp" \
     com.docker.extension.changelog="Please visit https://github.com/kinvolk/headlamp/releases for detailed changelog" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/kinvolk/headlamp/main/frontend/public/apple-touch-icon.png" \


### PR DESCRIPTION
This only updates the instances of the `kinvolk.github.io` URLs to `headlamp-k8s.github.io` as GitHub Pages doesn't do automatic redirects which means the docs don't work to add the Helm repo.

Any `github.com/kinvolk/headlamp` references have been left as-is.