### PR TITLE
frontend: Add a warning filter  switch to events table

### DIFF
--- a/frontend/src/components/App/Notifications/__snapshots__/List.stories.storyshot
+++ b/frontend/src/components/App/Notifications/__snapshots__/List.stories.storyshot
@@ -35,11 +35,18 @@ exports[`Storyshots Notifications List 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Notifications
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Notifications
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"
@@ -54,7 +61,7 @@ exports[`Storyshots Notifications List 1`] = `
               class="MuiBox-root MuiBox-root"
             >
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center"
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/App/settings/__snapshots__/Settings.stories.storyshot
+++ b/frontend/src/components/App/settings/__snapshots__/Settings.stories.storyshot
@@ -35,11 +35,18 @@ exports[`Storyshots Settings General 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          General
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            General
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -1,3 +1,4 @@
+import { FormControlLabel, Switch } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
@@ -65,6 +66,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function EventsSection() {
+  const EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY = 'EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY';
   const classes = useStyles();
   const { t } = useTranslation('glossary');
   const location = useLocation();
@@ -72,6 +74,10 @@ function EventsSection() {
   const eventsFilter = queryParams.get('eventsFilter');
   const dispatch = useDispatch();
   const filterFunc = useFilterFunc(['.jsonData.involvedObject.kind']);
+  const warningActionFilterFunc = (event: Event) => event.jsonData.type === 'Warning';
+  const [isWarningEventSwitchChecked, setIsWarningEventSwitchChecked] = React.useState(
+    Boolean(localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY))
+  );
 
   React.useEffect(() => {
     if (!eventsFilter) {
@@ -99,7 +105,24 @@ function EventsSection() {
   }
 
   return (
-    <SectionBox title={<SectionFilterHeader title={t('Events')} />}>
+    <SectionBox
+      title={
+        <SectionFilterHeader
+          title={t('Events')}
+          titleSideActions={[
+            <FormControlLabel
+              checked={isWarningEventSwitchChecked}
+              label={t('Warnings')}
+              control={<Switch color="primary" />}
+              onChange={(event, checked) => {
+                localStorage.setItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY, checked.toString());
+                setIsWarningEventSwitchChecked(checked);
+              }}
+            />,
+          ]}
+        />
+      }
+    >
       <ResourceTable
         resourceClass={Event}
         columns={[
@@ -131,6 +154,7 @@ function EventsSection() {
           'age',
         ]}
         filterFunction={filterFunc}
+        actionFilterFunction={isWarningEventSwitchChecked ? warningActionFilterFunc : null}
       />
     </SectionBox>
   );

--- a/frontend/src/components/common/SectionFilterHeader.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.tsx
@@ -18,6 +18,7 @@ import SectionHeader, { SectionHeaderProps } from './SectionHeader';
 interface SectionFilterHeaderProps extends SectionHeaderProps {
   noNamespaceFilter?: boolean;
   noSearch?: boolean;
+  preRenderFromFilterActions?: React.ReactNode[];
 }
 
 export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
@@ -25,6 +26,7 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
     noNamespaceFilter = false,
     noSearch = false,
     actions: propsActions = [],
+    preRenderFromFilterActions,
     ...headerProps
   } = props;
   const filter = useTypedSelector(state => state.filter);
@@ -104,6 +106,9 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
   }, [hasSearch]);
 
   let actions: React.ReactNode[] = [];
+  if (preRenderFromFilterActions && !showFilters.show) {
+    actions.push(...preRenderFromFilterActions);
+  }
 
   if (!showFilters.show) {
     actions.push(
@@ -165,7 +170,7 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
             ? actions
             : [
                 <Box>
-                  <Grid container spacing={1}>
+                  <Grid container spacing={1} alignItems="center">
                     {actions.map((action, i) => (
                       <Grid item key={i}>
                         {action}

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
 import { Variant } from '@material-ui/core/styles/createTypography';
@@ -28,6 +29,7 @@ export interface SectionHeaderProps {
   actions?: React.ReactNode[] | null;
   noPadding?: boolean;
   headerStyle?: HeaderStyle;
+  titleSideActions?: React.ReactNode[];
 }
 
 export default function SectionHeader(props: SectionHeaderProps) {
@@ -50,11 +52,20 @@ export default function SectionHeader(props: SectionHeaderProps) {
       spacing={2}
     >
       {props.title && (
-        <Grid item>
-          <Typography variant={titleVariants[headerStyle]} noWrap className={classes.sectionTitle}>
-            {props.title}
-          </Typography>
-        </Grid>
+        <>
+          <Grid item>
+            <Box display="flex">
+              <Typography
+                variant={titleVariants[headerStyle]}
+                noWrap
+                className={classes.sectionTitle}
+              >
+                {props.title}
+              </Typography>
+              <Box ml={1}>{props.titleSideActions}</Box>
+            </Box>
+          </Grid>
+        </>
       )}
       {actions.length > 0 && (
         <Grid item>

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -76,7 +76,8 @@ export interface SimpleTableProps {
         [dataProp: number]: any;
       }[]
     | null;
-  filterFunction?: (...args: any[]) => boolean;
+  filterFunction?: ((...args: any[]) => boolean) | null;
+  actionFilterFunction?: ((...args: any[]) => boolean) | null;
   rowsPerPage?: number[];
   emptyMessage?: string;
   errorMessage?: string | null;
@@ -153,6 +154,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     columns,
     data,
     filterFunction = null,
+    actionFilterFunction = null,
     emptyMessage = null,
     page: initialPage = 0,
     // @todo: This is a workaround due to how the pagination is built by default.
@@ -312,6 +314,10 @@ export default function SimpleTable(props: SimpleTableProps) {
   let filteredData = displayData;
   if (filterFunction) {
     filteredData = displayData.filter(filterFunction);
+  }
+
+  if (actionFilterFunction) {
+    filteredData = filteredData.filter(actionFilterFunction);
   }
 
   function sortClickHandler(isIncreasingOrder: boolean, index: number) {

--- a/frontend/src/components/common/__snapshots__/SectionBox.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.stories.storyshot
@@ -30,11 +30,18 @@ exports[`Storyshots SectionBox Header Props 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          This is a section title with a main style
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            This is a section title with a main style
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
     </div>
     <div
@@ -59,11 +66,18 @@ exports[`Storyshots SectionBox Titled 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h2
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          This is a section title default
-        </h2>
+          <h2
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+          >
+            This is a section title default
+          </h2>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
     </div>
     <div
@@ -88,11 +102,18 @@ exports[`Storyshots SectionBox Titled Children 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h2
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          This is a section title
-        </h2>
+          <h2
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+          >
+            This is a section title
+          </h2>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
     </div>
     <div

--- a/frontend/src/components/common/__snapshots__/SectionHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.stories.storyshot
@@ -8,11 +8,18 @@ exports[`Storyshots SectionHeader Actions 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h3
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        This one has actions
-      </h3>
+        <h3
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+        >
+          This one has actions
+        </h3>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"
@@ -48,11 +55,18 @@ exports[`Storyshots SectionHeader Main 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        This is a section title main
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          This is a section title main
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -66,11 +80,18 @@ exports[`Storyshots SectionHeader Normal 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h3
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        This is a section title normal
-      </h3>
+        <h3
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+        >
+          This is a section title normal
+        </h3>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -84,11 +105,18 @@ exports[`Storyshots SectionHeader Normal No Padding 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h3
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        No padding on this normal title
-      </h3>
+        <h3
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+        >
+          No padding on this normal title
+        </h3>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -102,11 +130,18 @@ exports[`Storyshots SectionHeader Subsection 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h2
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        This is a section title subsection
-      </h2>
+        <h2
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+        >
+          This is a section title subsection
+        </h2>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -263,11 +263,18 @@ exports[`Storyshots SimpleTable Label Search 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        Test
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"
@@ -535,11 +542,18 @@ exports[`Storyshots SimpleTable Name Search 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        Test
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"
@@ -783,11 +797,18 @@ exports[`Storyshots SimpleTable Namespace Search 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        Test
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"
@@ -1031,11 +1052,18 @@ exports[`Storyshots SimpleTable Namespace Select 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        Test
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"
@@ -1313,11 +1341,18 @@ exports[`Storyshots SimpleTable Number Search 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        Test
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"
@@ -1844,11 +1879,18 @@ exports[`Storyshots SimpleTable UID Search 1`] = `
     <div
       class="MuiGrid-root MuiGrid-item"
     >
-      <h1
-        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      <div
+        class="MuiBox-root MuiBox-root"
       >
-        Test
-      </h1>
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                CustomResourceDefinition
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  CustomResourceDefinition
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -204,11 +211,18 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Accepted Names
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Accepted Names
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -301,11 +315,18 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Versions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Versions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -387,11 +408,18 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -429,11 +457,18 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Objects
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Objects
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -581,11 +616,18 @@ exports[`Storyshots crd/CustomResourceDefinition List 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Custom Resource Definitions
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Custom Resource Definitions
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -101,11 +101,18 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                MyCustomResource
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  MyCustomResource
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
@@ -35,11 +35,18 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Ast 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          CronJob
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            CronJob
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"
@@ -210,11 +217,18 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Ast 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Jobs
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Jobs
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"
@@ -315,11 +329,18 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Minute 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          CronJob
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            CronJob
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"
@@ -490,11 +511,18 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Minute 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Jobs
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Jobs
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Endpoint
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Endpoint
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -138,11 +145,18 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Subsets
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Subsets
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -168,11 +182,18 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 >
-                  <h4
-                    class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h4 MuiTypography-noWrap"
+                  <div
+                    class="MuiBox-root MuiBox-root"
                   >
-                    Addresses
-                  </h4>
+                    <h4
+                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h4 MuiTypography-noWrap"
+                    >
+                      Addresses
+                    </h4>
+                    <div
+                      class="MuiBox-root MuiBox-root"
+                    />
+                  </div>
                 </div>
               </div>
               <table
@@ -259,11 +280,18 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 >
-                  <h4
-                    class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h4 MuiTypography-noWrap"
+                  <div
+                    class="MuiBox-root MuiBox-root"
                   >
-                    Ports
-                  </h4>
+                    <h4
+                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h4 MuiTypography-noWrap"
+                    >
+                      Ports
+                    </h4>
+                    <div
+                      class="MuiBox-root MuiBox-root"
+                    />
+                  </div>
                 </div>
               </div>
               <table
@@ -424,11 +452,18 @@ exports[`Storyshots endpoints/EndpointsDetailsView Error 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Endpoint
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Endpoint
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -515,11 +550,18 @@ exports[`Storyshots endpoints/EndpointsDetailsView No Item Yet 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Endpoint
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Endpoint
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Endpoints
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Endpoints
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                HorizontalPodAutoscaler
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  HorizontalPodAutoscaler
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -345,11 +352,18 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Events
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Events
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Horizontal Pod Autoscalers
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Horizontal Pod Autoscalers
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -264,11 +271,18 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -505,11 +519,18 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -538,11 +559,18 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      terminated
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        terminated
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table
@@ -745,11 +773,18 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -958,11 +993,18 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -1207,11 +1249,18 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -1240,11 +1289,18 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      myapp-container
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        myapp-container
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table
@@ -1430,11 +1486,18 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -1650,11 +1713,18 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -1893,11 +1963,18 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -1926,11 +2003,18 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      liveness
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        liveness
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table
@@ -2229,11 +2313,18 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -2442,11 +2533,18 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -2685,11 +2783,18 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -2718,11 +2823,18 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      imagepullbackoff
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        imagepullbackoff
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table
@@ -2897,11 +3009,18 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -3110,11 +3229,18 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -3341,11 +3467,18 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -3374,11 +3507,18 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      nginx
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        nginx
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table
@@ -3602,11 +3742,18 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -3815,11 +3962,18 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -4061,11 +4215,18 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -4094,11 +4255,18 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      successful
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        successful
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table

--- a/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Pods
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Pods
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -46,11 +46,18 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Pod
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  Pod
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -293,11 +300,18 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Conditions
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Conditions
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -524,11 +538,18 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Containers
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -557,11 +578,18 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item"
                   >
-                    <h3
-                      class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                    <div
+                      class="MuiBox-root MuiBox-root"
                     >
-                      nginx
-                    </h3>
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        nginx
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
                   </div>
                 </div>
                 <table

--- a/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots pods/VolumeDetails Volume Details 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h2
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Volumes
-        </h2>
+          <h2
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+          >
+            Volumes
+          </h2>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
     </div>
     <div

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots pdb/PDBDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                PodDisruptionBudget
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  PodDisruptionBudget
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -304,11 +311,18 @@ exports[`Storyshots pdb/PDBDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Events
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Events
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Pod Disruption Budget
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Pod Disruption Budget
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots PriorityClasses/PriorityClassesDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                PriorityClass
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  PriorityClass
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -255,11 +262,18 @@ exports[`Storyshots PriorityClasses/PriorityClassesDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h2
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                Events
-              </h2>
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Events
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          PriorityClass
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            PriorityClass
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -44,11 +44,18 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
             <div
               class="MuiGrid-root MuiGrid-item"
             >
-              <h1
-                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              <div
+                class="MuiBox-root MuiBox-root"
               >
-                ResourceQuota
-              </h1>
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+                >
+                  ResourceQuota
+                </h1>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
             </div>
             <div
               class="MuiGrid-root MuiGrid-item"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
@@ -11,11 +11,18 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item"
       >
-        <h1
-          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        <div
+          class="MuiBox-root MuiBox-root"
         >
-          Resource Quotas
-        </h1>
+          <h1
+            class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+          >
+            Resource Quotas
+          </h1>
+          <div
+            class="MuiBox-root MuiBox-root"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"


### PR DESCRIPTION
Users want to filter simply by clicking a switch to list all the warning type events, this patch adds that to the events table.