### PR TITLE
Replace kinvolk by headlamp-k8s in a lot of content

### DIFF
--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -21,7 +21,7 @@ jobs:
         path: build-helper
     - uses: actions/checkout@v2.3.3
       with:
-        repository: kinvolk/headlamp
+        repository: headlamp-k8s/headlamp
         ref: ${{ github.event.inputs.buildBranch }}
         path: headlamp
     - name: Setup nodejs

--- a/.github/workflows/docker-extension-release.yml
+++ b/.github/workflows/docker-extension-release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: kinvolk/headlamp-extension
+  IMAGE_NAME: headlamp-k8s/headlamp-extension
 jobs:
   build_and_push_docker_extension:
     name: Build docker extension

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -37,15 +37,15 @@ jobs:
             * Docs change 2
 
             <!-- end-release-notes -->
-            **Container image:** :whale:  [ghcr.io/kinvolk/headlamp:v${{ github.event.inputs.releaseName }}](https://github.com/kinvolk/headlamp/pkgs/container/headlamp)
+            **Container image:** :whale:  [ghcr.io/headlamp-k8s/headlamp:v${{ github.event.inputs.releaseName }}](https://github.com/headlamp-k8s/headlamp/pkgs/container/headlamp)
             **Desktop Apps:**
 
             :penguin:  [Flatpak / Linux (AMD64)](https://flathub.org/apps/details/io.kinvolk.Headlamp)
-            :penguin:  Linux AppImage [AMD64](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-x64.AppImage), [ARM64](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-arm64.AppImage),  [ARMv7l](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-armv7l.AppImage)
-            :penguin: Linux Tarball [AMD64](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-x64.tar.gz), [ARM64](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-arm64.tar.gz), [ARMv7l](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-armv7l.tar.gz)
-            :penguin: Debian / Linux [AMD64](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/headlamp_${{ github.event.inputs.releaseName }}-1_amd64.deb)
-            :green_apple:  [Mac (AMD64)](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-mac-x64.dmg)
-            :green_apple: [Mac (ARM/M1)](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-mac-arm64.dmg)
-            :blue_square:  [Windows (AMD64)](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-win-x64.exe)
+            :penguin:  Linux AppImage [AMD64](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-x64.AppImage), [ARM64](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-arm64.AppImage),  [ARMv7l](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-armv7l.AppImage)
+            :penguin: Linux Tarball [AMD64](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-x64.tar.gz), [ARM64](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-arm64.tar.gz), [ARMv7l](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-linux-armv7l.tar.gz)
+            :penguin: Debian / Linux [AMD64](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/headlamp_${{ github.event.inputs.releaseName }}-1_amd64.deb)
+            :green_apple:  [Mac (AMD64)](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-mac-x64.dmg)
+            :green_apple: [Mac (ARM/M1)](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-mac-arm64.dmg)
+            :blue_square:  [Windows (AMD64)](https://github.com/headlamp-k8s/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-win-x64.exe)
         env:
           GITHUB_REPOSITORY: $GITHUB_REPOSITORY

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO111MODULE
 
 SERVER_EXE_EXT ?=
 DOCKER_CMD ?= docker
-DOCKER_REPO ?= ghcr.io/kinvolk
+DOCKER_REPO ?= ghcr.io/headlamp-k8s
 DOCKER_EXT_REPO ?= docker.io/kinvolk
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Headlamp was created to be a Kubernetes web UI that has the traditional function
 web UIs/dashboards available (i.e. to list and view resources) as well as other features.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/videos/headlamp_quick_run.gif" width="80%">
+  <img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/videos/headlamp_quick_run.gif" width="80%">
 </div>
 
 ## Features
@@ -25,16 +25,16 @@ web UIs/dashboards available (i.e. to list and view resources) as well as other 
 
 <table>
     <tr>
-        <td width="33%"><img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/cluster_overview.png"></td>
-        <td width="33%"><img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/cluster_chooser.png"></td>
+        <td width="33%"><img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_overview.png"></td>
+        <td width="33%"><img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_chooser.png"></td>
     </tr>
     <tr>
-        <td width="33%"><img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/nodes.png"></td>
-        <td width="33%"><img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/resource_edition.png"></td>
+        <td width="33%"><img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/nodes.png"></td>
+        <td width="33%"><img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/resource_edition.png"></td>
     </tr>
     <tr>
-        <td width="33%"><img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/editor_documentation.png"></td>
-        <td width="33%"><img src="https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/terminal.png"></td>
+        <td width="33%"><img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/editor_documentation.png"></td>
+        <td width="33%"><img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/terminal.png"></td>
     </tr>
 </table>
 
@@ -80,7 +80,7 @@ in the Kubernetes Slack.
 ## Roadmap
 
 If you are interested in the direction of the project, we maintain a
-[Roadmap](https://github.com/kinvolk/headlamp/projects/2) for it with the
+[Roadmap](https://github.com/headlamp-k8s/headlamp/projects/2) for it with the
 biggest changes planned so far.
 
 ## License

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -323,12 +323,12 @@ function getDefaultAppMenu(): AppMenu[] {
         {
           label: i18n.t('Open an Issue'),
           id: 'original-open-issue',
-          url: 'https://github.com/kinvolk/headlamp/issues',
+          url: 'https://github.com/headlamp-k8s/headlamp/issues',
         },
         {
           label: i18n.t('About'),
           id: 'original-about',
-          url: 'https://github.com/kinvolk/headlamp',
+          url: 'https://github.com/headlamp-k8s/headlamp',
         },
       ],
     },

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.15.0",
   "description": "Easy-to-use and extensible Kubernetes web UI",
   "main": "electron/main.js",
-  "homepage": "https://github.com/kinvolk/headlamp/#readme",
+  "homepage": "https://github.com/headlamp-k8s/headlamp/#readme",
   "productName": "Headlamp",
   "scripts": {
     "compile-electron": "babel electron --out-dir electron/ --extensions .ts",

--- a/app/windows/chocolatey/headlamp.nuspec
+++ b/app/windows/chocolatey/headlamp.nuspec
@@ -4,16 +4,16 @@
   <metadata>
     <id>headlamp</id>
     <version>0.15.0</version>
-    <packageSourceUrl>https://github.com/kinvolk/headlamp/tree/main/app/windows/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/headlamp-k8s/headlamp/tree/main/app/windows/chocolatey</packageSourceUrl>
     <title>Headlamp</title>
     <authors>Kinvolk</authors>
-    <projectUrl>https://github.com/kinvolk/headlamp/</projectUrl>
-    <iconUrl>http://rawcdn.githack.com/kinvolk/headlamp/main/frontend/public/apple-touch-icon.png</iconUrl>
-    <licenseUrl>https://github.com/kinvolk/headlamp/blob/main/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/headlamp-k8s/headlamp/</projectUrl>
+    <iconUrl>http://rawcdn.githack.com/headlamp-k8s/headlamp/main/frontend/public/apple-touch-icon.png</iconUrl>
+    <licenseUrl>https://github.com/headlamp-k8s/headlamp/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/kinvolk/headlamp/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/headlamp-k8s/headlamp/</projectSourceUrl>
     <docsUrl>https://headlamp.dev/docs/latest/</docsUrl>
-    <bugTrackerUrl>https://github.com/kinvolk/headlamp/issues</bugTrackerUrl>
+    <bugTrackerUrl>https://github.com/headlamp-k8s/headlamp/issues</bugTrackerUrl>
     <tags>headlamp kubernetes ui gui dashboard devops</tags>
     <summary>An easy-to-use and extensible graphical UI for Kubernetes.</summary>
     <description><![CDATA[
@@ -44,7 +44,7 @@ permissions, you may not be able to view your cluster resources correctly.
 
 See the documentation on [how to easily get a Service Account token](https://headlamp.dev/docs/latest/installation#create-a-service-account-token) for your cluster.
 ]]></description>
-    <releaseNotes>See release notes at the [Github releases page](https://github.com/kinvolk/headlamp/releases)</releaseNotes>
+    <releaseNotes>See release notes at the [Github releases page](https://github.com/headlamp-k8s/headlamp/releases)</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/app/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/app/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $headlampVersion = '0.15.0'
-$url = "https://github.com/kinvolk/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
+$url = "https://github.com/headlamp-k8s/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
 $checksum = '3dcee47552506f265b4b855f51f5e2d9286133c4d8beca9dad5022eccf03edf8'
 
 $packageArgs = @{

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kinvolk/headlamp/backend/pkg/config"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/config"
 )
 
 func main() {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/kinvolk/headlamp/backend
+module github.com/headlamp-k8s/headlamp/backend
 
 go 1.12
 

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kinvolk/headlamp/backend/pkg/config"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: headlamp
 description: Headlamp is an easy-to-use and extensible Kubernetes web UI.
-icon: https://raw.githubusercontent.com/kinvolk/headlamp/main/docs/headlamp_light.svg
-home: https://github.com/kinvolk/headlamp/tree/main/deploy/helm
+icon: https://raw.githubusercontent.com/headlamp-k8s/headlamp/main/docs/headlamp_light.svg
+home: https://github.com/headlamp-k8s/headlamp/tree/main/deploy/helm
 type: application
 keywords:
   - kubernetes
@@ -10,7 +10,7 @@ keywords:
   - kinvolk
   - headlamp
 sources:
-  - https://github.com/kinvolk/headlamp
+  - https://github.com/headlamp-k8s/headlamp
   - https://kinvolk.io/
 maintainers:
   - name: kinvolk

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -4,7 +4,7 @@
 
 Headlamp is an easy-to-use and extensible Kubernetes web UI.
 
-**Homepage:** <https://github.com/kinvolk/headlamp/tree/main/charts/headlamp>
+**Homepage:** <https://github.com/headlamp-k8s/headlamp/tree/main/charts/headlamp>
 
 ## TL;DR
 
@@ -22,7 +22,7 @@ $ helm install my-headlamp headlamp/headlamp --namespace kube-system
 
 ## Source Code
 
-* <https://github.com/kinvolk/headlamp>
+* <https://github.com/headlamp-k8s/headlamp>
 * <https://kinvolk.io/>
 
 ### Headlamp parameters
@@ -35,7 +35,7 @@ $ helm install my-headlamp headlamp/headlamp --namespace kube-system
 | fullnameOverride | string | `""` | Overrides the full name of the chart |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent |
 | image.registry | string | `"ghcr.io"` | Container image registry |
-| image.repository | string | `"kinvolk/headlamp"` | Container image name |
+| image.repository | string | `"headlamp-k8s/headlamp"` | Container image name |
 | image.tag | string | `""` | Container image tag, If "" uses appVersion in Chart.yaml |
 | imagePullSecrets | list | `[]` | An optional list of references to secrets in the same namespace to use for pulling any of the images used |
 | ingress.annotations | object | `{}` | Annotations for Ingress resource |

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Container image registry
   registry: ghcr.io
   # -- Container image name
-  repository: kinvolk/headlamp
+  repository: headlamp-k8s/headlamp
   # -- Image pull policy. One of Always, Never, IfNotPresent
   pullPolicy: IfNotPresent
   # -- Container image tag, If "" uses appVersion in Chart.yaml

--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -1,18 +1,18 @@
-FROM ghcr.io/kinvolk/headlamp:v0.13.0 as headlamp
+FROM ghcr.io/headlamp-k8s/headlamp:v0.15.0 as headlamp
 
-FROM scratch 
+FROM scratch
 
 LABEL org.opencontainers.image.title="Headlamp" \
     org.opencontainers.image.description="An easy-to-use and extensible web UI for Kubernetes." \
     org.opencontainers.image.vendor="kinvolk" \
     com.docker.desktop.extension.api.version=">= 0.2.0" \
-    com.docker.extension.screenshots='[{"alt":"Cluster overview","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/cluster_overview.png"},{"alt":"Cluster Chooser","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/cluster_chooser.png"},{"alt":"Nodes list","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/nodes.png"},{"alt":"Resource Editor","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/resource_edition.png"},{"alt":"Editor Documentation","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/editor_documentation.png"},{"alt":"Terminal","url":"https://raw.githubusercontent.com/kinvolk/headlamp/screenshots/screenshots/terminal.png"}]' \
+    com.docker.extension.screenshots='[{"alt":"Cluster overview","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_overview.png"},{"alt":"Cluster Chooser","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_chooser.png"},{"alt":"Nodes list","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/nodes.png"},{"alt":"Resource Editor","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/resource_edition.png"},{"alt":"Editor Documentation","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/editor_documentation.png"},{"alt":"Terminal","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/terminal.png"}]' \
     com.docker.extension.detailed-description="Headlamp is an easy-to-use and extensible Kubernetes web UI. Headlamp was created to be a Kubernetes web UI that has the traditional functionality of other web UIs/dashboards available (i.e. to list and view resources) as well as other features." \
     com.docker.extension.publisher-url="https://headlamp-k8s.github.io/headlamp" \
-    com.docker.extension.additional-urls="https://github.com/kinvolk/headlamp" \
-    com.docker.extension.changelog="Please visit https://github.com/kinvolk/headlamp/releases for detailed changelog" \
-    com.docker.desktop.extension.icon="https://raw.githubusercontent.com/kinvolk/headlamp/main/frontend/public/apple-touch-icon.png" \
-    com.docker.extension.additional-urls='[{"title":"Repository","url":"https://github.com/kinvolk/headlamp"},{"title":"Documentation","url":"https://headlamp.dev/docs/latest/"}]'
+    com.docker.extension.additional-urls="https://github.com/headlamp-k8s/headlamp" \
+    com.docker.extension.changelog="Please visit https://github.com/headlamp-k8s/headlamp/releases for detailed changelog" \
+    com.docker.desktop.extension.icon="https://raw.githubusercontent.com/headlamp-k8s/headlamp/main/frontend/public/apple-touch-icon.png" \
+    com.docker.extension.additional-urls='[{"title":"Repository","url":"https://github.com/headlamp-k8s/headlamp"},{"title":"Documentation","url":"https://headlamp.dev/docs/latest/"}]'
 
 COPY headlamp.svg .
 COPY metadata.json .

--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   headlamp:
-    image: ghcr.io/kinvolk/headlamp:v0.13.0
+    image: ghcr.io/headlamp-k8s/headlamp:v0.13.0
     command: ["--kubeconfig","/headlamp/config/config"]
     restart: unless-stopped
     volumes:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ read those guidelines.
 
 ## Filing an issue or feature request
 
-Please use the [project's issue tracker](https://github.com/kinvolk/headlamp/issues) for filing any bugs you find or features
+Please use the [project's issue tracker](https://github.com/headlamp-k8s/headlamp/issues) for filing any bugs you find or features
 you think are useful.
 
 ## Translations

--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -112,24 +112,24 @@ make image
 
 ### Running the container image
 
-With docker you can run the Headlamp image(`ghcr.io/kinvolk/headlamp:latest`).
+With docker you can run the Headlamp image(`ghcr.io/headlamp-k8s/headlamp:latest`).
 Note, the mount arguments add folders that are referenced in the ~/.kube
 folders - you may need to add other folders if your config refers
 to more folders.
 
 ```bash
-docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube ghcr.io/kinvolk/headlamp:latest /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
+docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube ghcr.io/headlamp-k8s/headlamp:latest /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
 ```
 
-If you want to make a new container image called `kinvolk/headlamp:development`
+If you want to make a new container image called `headlamp-k8s/headlamp:development`
 you can run it like this:
 
 ```bash
 $ DOCKER_IMAGE_VERSION=development make image
 ...
-Successfully tagged kinvolk/headlamp:development
+Successfully tagged headlamp-k8s/headlamp:development
 
-$ docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube kinvolk/headlamp:development /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
+$ docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube headlamp-k8s/headlamp:development /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
 ```
 
 Then go to https://localhost:4466 in your browser.
@@ -156,7 +156,7 @@ $ DOCKER_IMAGE_VERSION=development make image
 #### Create a deployment yaml.
 
 ```bash
-$ kubectl create deployment headlamp -n kube-system --image=kinvolk/headlamp:development -o yaml --dry-run -- /headlamp/headlamp-server -html-static-dir /headlamp/frontend -in-cluster -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
+$ kubectl create deployment headlamp -n kube-system --image=headlamp-k8s/headlamp:development -o yaml --dry-run -- /headlamp/headlamp-server -html-static-dir /headlamp/frontend -in-cluster -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
 ```
 
 To use the local container image we change the `imagePullPolicy` to Never.
@@ -190,7 +190,7 @@ spec:
             - /headlamp/frontend
             - -in-cluster
             - -plugins-dir=/headlamp/plugins
-          image: kinvolk/headlamp:development
+          image: headlamp-k8s/headlamp:development
           name: headlamp
           imagePullPolicy: Never
           resources: {}

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -45,7 +45,7 @@ committed to git, but is shown on the website at
 
 Components can be discovered, developed and tested inside the 'storybook'.
 
-From within the [Headlamp](https://github.com/kinvolk/headlamp/) repo run:
+From within the [Headlamp](https://github.com/headlamp-k8s/headlamp/) repo run:
 
 ```bash
 make storybook

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -7,7 +7,7 @@ weight: 300
 ## Tested Kubernetes Platforms
 
 This section shows the different platforms where Headlamp has been tested (in-cluster) or is intended to be tested, and useful observations about it.
-If you have tested Headlamp on a different flavor or Kubernetes, please file a PR or [issue](https://github.com/kinvolk/headlamp/issues/new/choose) to add your remarks to the list.
+If you have tested Headlamp on a different flavor or Kubernetes, please file a PR or [issue](https://github.com/headlamp-k8s/headlamp/issues/new/choose) to add your remarks to the list.
 
 The "works" column refers to the overall Kubernetes related functionality when running in the respective platform; it may have 3 different values:
 - ✔️ : Has been tried and works fine to the extent of what has been tested
@@ -16,13 +16,13 @@ The "works" column refers to the overall Kubernetes related functionality when r
 
 Platform<div style="min-width: 300px"></div>    | Works | Comments
 ----------------------------------------------|:-----:|------------------------------------------------------------------------------------------
-[Amazon EKS](https://aws.amazon.com/eks/)                     |  ✔️     | - As [reported](https://github.com/kinvolk/headlamp/issues/266)
+[Amazon EKS](https://aws.amazon.com/eks/)                     |  ✔️     | - As [reported](https://github.com/headlamp-k8s/headlamp/issues/266)
 [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/)        | ❔    | - Have you tried Headlamp on this platform? Please report your experience.
 [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) | ❔    | - Have you tried Headlamp on this platform? Please report your experience.
 [K3s](https://k3s.io/)                                         | ✔️     | - Simple to install / expose with the regular [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/).
 [Kind](https://kind.sigs.k8s.io/)                              | ✔️     | - Simple to install / expose with the regular [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/).
 [Lokomotive](https://kinvolk.io/lokomotive-kubernetes/)                     | ✔️     | - Works with the regular in-cluster instructions <br> - There's also the [Lokomotive Web UI](https://kinvolk.io/docs/lokomotive/latest/configuration-reference/components/web-ui/) as a component, which is
-[Microsoft AKS](https://azure.microsoft.com/)                  | ✔️     | Testing (not suitable for production):<br/>- Deploy Headlamp from the [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/)<br/>- [Enable the http_application_routing addon](https://docs.microsoft.com/en-us/azure/aks/http-application-routing#use-http-routing) (this creates a DNS zone)<br/>- Use the DNS zone name as the domain for Headlamp, i.e. if it is `1234567.eastus.aksapp.io`, then apply [Headlamp's ingress](https://raw.githubusercontent.com/kinvolk/headlamp/main/kubernetes-headlamp-ingress-sample.yaml) using `headlamp.1234567.eastus.aksapp.io` as the path and use ``kubernetes.io/ingress.class: addon-http-application-routing`` as the ingress class annotation.<br/><br/>For production, please follow the [intructions to deploy with an HTTPS ingress controller](https://docs.microsoft.com/en-us/azure/aks/ingress-tls).
+[Microsoft AKS](https://azure.microsoft.com/)                  | ✔️     | Testing (not suitable for production):<br/>- Deploy Headlamp from the [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/)<br/>- [Enable the http_application_routing addon](https://docs.microsoft.com/en-us/azure/aks/http-application-routing#use-http-routing) (this creates a DNS zone)<br/>- Use the DNS zone name as the domain for Headlamp, i.e. if it is `1234567.eastus.aksapp.io`, then apply [Headlamp's ingress](https://raw.githubusercontent.com/headlamp-k8s/headlamp/main/kubernetes-headlamp-ingress-sample.yaml) using `headlamp.1234567.eastus.aksapp.io` as the path and use ``kubernetes.io/ingress.class: addon-http-application-routing`` as the ingress class annotation.<br/><br/>For production, please follow the [intructions to deploy with an HTTPS ingress controller](https://docs.microsoft.com/en-us/azure/aks/ingress-tls).
 [Minikube](https://minikube.sigs.k8s.io/)                     | ✔️     | - For exposing with an ingress, enable ingresses with `minikube addons enable ingress` <br> - There are docs about the [development](../development/) with Minikube.|
 [Vultr Kubernetes Engine](https://www.vultr.com/kubernetes/)                     |  ✔️     |  - Simple to install / expose with the regular [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/).
 

--- a/e2e-tests/kubernetes-headlamp-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-ci.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: headlamp
         imagePullPolicy: Never
-        image: ghcr.io/kinvolk/headlamp:latest
+        image: ghcr.io/headlamp-k8s/headlamp:latest
         args:
           - "-in-cluster"
           - "-plugins-dir=/headlamp/plugins"

--- a/plugins/headlamp-plugin/template/README.md
+++ b/plugins/headlamp-plugin/template/README.md
@@ -1,6 +1,6 @@
 # $${name}
 
-This is the default template README for [Headlamp Plugins](https://github.com/kinvolk/headlamp).
+This is the default template README for [Headlamp Plugins](https://github.com/headlamp-k8s/headlamp).
 
 - The description of your plugin should go here.
 - You should also edit the package.json file meta data (like name and description).


### PR DESCRIPTION
We have recently moved the org from kinvolk to headlamp-k8s but we
left certain things still mentioning the kinvolk org because there
are redirects in place, but they don't work for certain things like
git clones, container registries, etc.
