### PR TITLE
frontend: Fix formatting owner references for CRs

### DIFF
--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -69,7 +69,8 @@ export function MetadataDisplay(props: MetadataDisplayProps) {
         }
         return (
           <>
-            `${ownerRef.kind}: ${ownerRef.name}`{i < numItems - 1 && <br />}
+            {`${ownerRef.kind}: ${ownerRef.name}`}
+            {i < numItems - 1 && <br />}
           </>
         );
       })


### PR DESCRIPTION
how to test:
- [ ] Go to a CR that has an owner reference and check that there's no `$` showing up in the UI