### PR TITLE
backend: Read token from the kube config file

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -873,6 +873,14 @@ func (c *HeadlampConfig) handleClusterRequests(router *mux.Router) {
 			return
 		}
 
+		// Try to add the Authorization header if it's not already set from the client.
+		if r.Header.Get("Authorization") == "" {
+			token := c.contextProxies[clusterName].context.authInfo.Token
+			if token != "" {
+				r.Header.Add("Authorization", "Bearer "+token)
+			}
+		}
+
 		handler := proxyHandler(server, ctxtProxy.proxy)
 		handler(w, r)
 	})


### PR DESCRIPTION
This may be needed for something users who have set up the token in the kubeconfig file.

How to test:
  1. Duplicate the context for a cluster you have running + copy its user auth info as well (all in kube config);
  2. Remove any client-certificate* data in the user auth info, and set the `token: ` field to be a valid token.
  3. Access that cluster in the UI -> Headlamp should not as for a token