### PR TITLE
frontend: Skip a11y alert by default

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,7 +88,7 @@
   },
   "scripts": {
     "prestart": "npm run make-version",
-    "start": "react-scripts start",
+    "start": "echo 'Use REACT_APP_SKIP_A11Y=false if you want to enable the a11y checker alert'; cross-env REACT_APP_SKIP_A11Y=true react-scripts start",
     "prebuild": "npm run make-version",
     "build": "if-env PUBLIC_URL react-scripts build || cross-env PUBLIC_URL=./ react-scripts build --max_old_space_size=768 && rimraf build/frontend/index.baseUrl.html",
     "test": "cross-env UNDER_TEST=true react-scripts test",


### PR DESCRIPTION
The purpose of the a11y alert we have when running Headlamp in
default mode is so we find regressions in a11y. However, we do have
some a11y issues as of now and the popup is just shown every time at
the beginning of running Headlamp, which prompts everyone to just
dismiss it automatically hence defeating its purpose of showing up
right when a11y regressions happen. All this means a11y issues keep
growing, which render the alert just an annoyance.

So this patch disables the alert for now until we fix the a11y
issues.

fixes #981 

How to test:
1. Run Headlamp with `make run-frontend` -> there should be no a11y alert.
