### PR TITLE
frontend: Disable a11y alert by default

### DIFF
--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -71,7 +71,9 @@ components via eslint or via unit tests.
 
 Any issues found are reported in the developer console.
 
-To disable the alert message during development, use the following:
+To enable the alert message during development, use the following:
 ```bash
-REACT_APP_SKIP_A11Y=true make run-frontend
+REACT_APP_SKIP_A11Y=false make run-frontend
 ```
+
+This shows an alert when an a11y issue is detected.

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV !== 'production') {
   }
   const axeCore = require('axe-core');
 
-  if (process.env.REACT_APP_SKIP_A11Y !== 'true') {
+  if (process.env.REACT_APP_SKIP_A11Y === 'false') {
     axe(React, ReactDOM, 500, undefined, undefined, (results: typeof axeCore.AxeResults) => {
       if (results.violations.length > 0) {
         console.error('axe results', results);
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV !== 'production') {
           alreadyWarned = true;
           alert(
             'Accessibility issues found. See developer console. ' +
-              '`REACT_APP_SKIP_A11Y=true make run-frontend` to disable alert.'
+              '`REACT_APP_SKIP_A11Y=false make run-frontend` to enable alert.'
           );
         }
       }


### PR DESCRIPTION
Still allow enabling the alert with
`REACT_APP_SKIP_A11Y=false make run-frontend`

When running `make run-frontend` the alert will not be shown.