### PR TITLE
Add accessible namespaces

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -16,6 +16,7 @@ import { useHistory } from 'react-router-dom';
 import helpers from '../../helpers';
 import { getToken, setToken } from '../../lib/auth';
 import { useCluster, useClustersConf } from '../../lib/k8s';
+import { createRouteURL } from '../../lib/router';
 import {
   HeaderActionType,
   setVersionDialogOpen,
@@ -201,6 +202,7 @@ export function PureTopBar({
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const openSideBar = !!(isSidebarOpenUserSelected === undefined ? false : isSidebarOpen);
 
@@ -252,7 +254,6 @@ export function PureTopBar({
           handleMenuClose();
         }}
         disabled={!hasToken}
-        dense
       >
         <ListItemIcon>
           <Icon icon="mdi:logout" />
@@ -262,12 +263,25 @@ export function PureTopBar({
       <MenuItem
         component="a"
         onClick={() => {
+          history.push(createRouteURL('settingsCluster', { cluster: cluster! }));
+          handleMenuClose();
+        }}
+      >
+        <ListItemIcon>
+          <Icon icon="mdi:cog-box" />
+        </ListItemIcon>
+        <ListItemText>{t('settings|Cluster settings')}</ListItemText>
+      </MenuItem>
+      <MenuItem
+        component="a"
+        onClick={() => {
           dispatch(setVersionDialogOpen(true));
           handleMenuClose();
         }}
-        dense
-        className={classes.versionLink}
       >
+        <ListItemIcon>
+          <Icon icon="mdi:information-outline" />
+        </ListItemIcon>
         <ListItemText>
           {helpers.getProductName()} {helpers.getVersion()['VERSION']}
         </ListItemText>

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -15,6 +15,7 @@ import { ApiError, testAuth } from '../../lib/k8s/apiProxy';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import { ClusterDialog } from '../cluster/Chooser';
 import { DialogTitle } from '../common/Dialog';
+import HeadlampLink from '../common/Link';
 
 export default function AuthToken() {
   const history = useHistory();
@@ -89,6 +90,7 @@ export function PureAuthToken({
   onCloseError,
 }: PureAuthTokenProps) {
   const { t } = useTranslation('auth');
+  const cluster = getCluster();
   const focusedRef = React.useCallback(node => {
     if (node !== null) {
       // node.setAttribute('tabindex', '-1');
@@ -135,6 +137,11 @@ export function PureAuthToken({
           </Box>
           <div style={{ flex: '1 0 0' }}></div>
         </DialogActions>
+        <Box overflow="hidden" textAlign="center">
+          <HeadlampLink routeName="settingsCluster" params={{ clusterID: cluster || '' }}>
+            {t('settings|Cluster settings')}
+          </HeadlampLink>
+        </Box>
         <DialogActions>
           {showActions && (
             <>

--- a/frontend/src/components/account/AuthToken.stories.tsx
+++ b/frontend/src/components/account/AuthToken.stories.tsx
@@ -1,15 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import { TestContext } from '../../test';
 import { PureAuthToken, PureAuthTokenProps } from './Auth';
-
-// eslint-disable-next-line no-unused-vars
-const store = createStore((state = { config: {}, ui: { notifications: [] } }, action) => state, {
-  config: {},
-  ui: {
-    notifications: [],
-  },
-});
 
 export default {
   title: 'AuthToken',
@@ -23,9 +14,9 @@ export default {
   decorators: [
     Story => {
       return (
-        <Provider store={store}>
+        <TestContext>
           <Story />
-        </Provider>
+        </TestContext>
       );
     },
   ],

--- a/frontend/src/components/authchooser/AuthChooser.stories.tsx
+++ b/frontend/src/components/authchooser/AuthChooser.stories.tsx
@@ -1,15 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import { TestContext } from '../../test';
 import { PureAuthChooser, PureAuthChooserProps } from './index';
-
-// eslint-disable-next-line no-unused-vars
-const store = createStore((state = { config: {}, ui: { notifications: [] } }, action) => state, {
-  config: {},
-  ui: {
-    notifications: [],
-  },
-});
 
 export default {
   title: 'AuthChooser',
@@ -23,9 +14,9 @@ export default {
   decorators: [
     Story => {
       return (
-        <Provider store={store}>
+        <TestContext>
           <Story />
-        </Provider>
+        </TestContext>
       );
     },
   ],
@@ -34,6 +25,7 @@ export default {
 const Template: Story<PureAuthChooserProps> = args => <PureAuthChooser {...args} />;
 
 const argFixture = {
+  clusterName: 'some-cluster',
   title: 'some title',
   testingTitle: 'some testing title',
   testingAuth: false,

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -11,7 +11,7 @@ import { createRouteURL, getRoute, getRoutePath } from '../../lib/router';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import { setConfig } from '../../redux/actions/actions';
 import { ClusterDialog } from '../cluster/Chooser';
-import { Loader } from '../common';
+import { Link, Loader } from '../common';
 import { DialogTitle } from '../common/Dialog';
 import Empty from '../common/EmptyContent';
 import OauthPopup from '../oidcauth/OauthPopup';
@@ -151,6 +151,7 @@ function AuthChooser({ children }: AuthChooserProps) {
 
   return (
     <PureAuthChooser
+      clusterName={clusterName}
       testingTitle={
         numClusters > 1
           ? t('Getting auth info: {{ clusterName }}', { clusterName })
@@ -203,6 +204,7 @@ export interface PureAuthChooserProps {
   handleTryAgain: () => void;
   handleBackButtonPress: () => void;
   children?: React.ReactNode;
+  clusterName: string;
 }
 
 export function PureAuthChooser({
@@ -218,6 +220,7 @@ export function PureAuthChooser({
   handleTryAgain,
   handleBackButtonPress,
   children,
+  clusterName,
 }: PureAuthChooserProps) {
   const { t } = useTranslation('auth');
 
@@ -270,6 +273,9 @@ export function PureAuthChooser({
                         errorMessage: error!.message,
                       })}
                 </Empty>
+                <Link routeName="settingsCluster" params={{ clusterID: clusterName }}>
+                  {t('settings|Cluster settings')}
+                </Link>
               </Box>
               <ColorButton onClick={handleTryAgain}>{t('frequent|Try Again')}</ColorButton>
             </Box>

--- a/frontend/src/components/cluster/Charts.tsx
+++ b/frontend/src/components/cluster/Charts.tsx
@@ -110,7 +110,7 @@ export function PodsStatusCircleChart(props: Pick<ResourceCircularChartProps, 'i
       return '…';
     }
     const percentage = ((podsReady.length / items.length) * 100).toFixed(1);
-    return `${percentage} %`;
+    return `${items.length === 0 ? 0 : percentage} %`;
   }
 
   function getData() {

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -1,5 +1,9 @@
+import React from 'react';
 import { useTranslation } from 'react-i18next';
+import helpers from '../../helpers';
+import { useCluster } from '../../lib/k8s';
 import Namespace from '../../lib/k8s/namespace';
+import { Link, SimpleTable } from '../common';
 import { StatusLabel } from '../common/Label';
 import ResourceTable from '../common/Resource/ResourceTable';
 import { SectionBox } from '../common/SectionBox';
@@ -7,16 +11,53 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 
 export default function NamespacesList() {
   const { t } = useTranslation('glossary');
+  const cluster = useCluster();
+  const [allowedNamespaces, setAllowedNamespaces] = React.useState<{ namespace: string }[]>([]);
+  let renderResource = null;
+
+  React.useEffect(() => {
+    if (cluster) {
+      const namespaces = helpers.loadClusterSettings(cluster)?.allowedNamespaces || [];
+      setAllowedNamespaces(namespaces.map(namespace => ({ namespace })));
+    }
+  }, [cluster]);
 
   function makeStatusLabel(namespace: Namespace) {
     const status = namespace.status.phase;
     return <StatusLabel status={status === 'Active' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
-  return (
-    <SectionBox
-      title={<SectionFilterHeader title={t('Namespaces')} noNamespaceFilter headerStyle="main" />}
-    >
+  if (allowedNamespaces.length > 0) {
+    renderResource = (
+      <SimpleTable
+        columns={[
+          {
+            label: t('Name'),
+            getter: ({ namespace }) => (
+              <Link
+                routeName={'namespace'}
+                params={{
+                  name: namespace,
+                }}
+              >
+                {namespace}
+              </Link>
+            ),
+          },
+          {
+            label: t('Status'),
+            getter: () => 'Unknown',
+          },
+          {
+            label: t('Age'),
+            getter: () => 'Unknown',
+          },
+        ]}
+        data={allowedNamespaces}
+      />
+    );
+  } else {
+    renderResource = (
       <ResourceTable
         resourceClass={Namespace}
         columns={[
@@ -29,6 +70,14 @@ export default function NamespacesList() {
           'age',
         ]}
       />
+    );
+  }
+
+  return (
+    <SectionBox
+      title={<SectionFilterHeader title={t('Namespaces')} noNamespaceFilter headerStyle="main" />}
+    >
+      {renderResource}
     </SectionBox>
   );
 }

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -215,6 +215,26 @@ function loadNotifications(): Notification[] {
   return notifications.map((n: any) => Notification.fromJSON(n));
 }
 
+export interface ClusterSettings {
+  defaultNamespace?: string;
+  allowedNamespaces?: string[];
+}
+
+function storeClusterSettings(clusterName: string, settings: ClusterSettings) {
+  if (!clusterName) {
+    return;
+  }
+  localStorage.setItem(`cluster_settings.${clusterName}`, JSON.stringify(settings));
+}
+
+function loadClusterSettings(clusterName: string): ClusterSettings {
+  if (!clusterName) {
+    return {};
+  }
+  const settings = JSON.parse(localStorage.getItem(`cluster_settings.${clusterName}`) || '{}');
+  return settings;
+}
+
 const exportFunctions = {
   getBaseUrl,
   isDevMode,
@@ -232,6 +252,8 @@ const exportFunctions = {
   storeNotifications,
   loadNotifications,
   defaultMaxNotificationsStored,
+  storeClusterSettings,
+  loadClusterSettings,
 };
 
 export default exportFunctions;

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -799,7 +799,15 @@ export async function apply(body: KubeObjectInterface): Promise<JSON> {
   if (!namespace) {
     const knownResource = ResourceClasses[body.kind];
     if (knownResource?.isNamespaced) {
-      bodyToApply.metadata.namespace = 'default';
+      let defaultNamespace = 'default';
+
+      const cluster = getCluster();
+      if (!!cluster) {
+        const clusterSettings = helpers.loadClusterSettings(cluster);
+        defaultNamespace = clusterSettings?.defaultNamespace || defaultNamespace;
+      }
+
+      bodyToApply.metadata.namespace = defaultNamespace;
     }
   }
 

--- a/frontend/src/lib/k8s/priorityClasses.ts
+++ b/frontend/src/lib/k8s/priorityClasses.ts
@@ -1,4 +1,4 @@
-import { apiFactoryWithNamespace } from './apiProxy';
+import { apiFactory } from './apiProxy';
 import { KubeObjectInterface, makeKubeObject } from './cluster';
 
 export interface KubePriorityClasses extends KubeObjectInterface {
@@ -9,7 +9,7 @@ export interface KubePriorityClasses extends KubeObjectInterface {
 }
 
 class PriorityClasses extends makeKubeObject<KubePriorityClasses>('priorityClass') {
-  static apiEndpoint = apiFactoryWithNamespace('scheduling.k8s.io', 'v1', 'priorityclasses');
+  static apiEndpoint = apiFactory('scheduling.k8s.io', 'v1', 'priorityclasses');
 
   static get pluralName(): string {
     return 'priorityclasses';

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -3,6 +3,7 @@ import NotFoundComponent from '../components/404';
 import AuthToken from '../components/account/Auth';
 import NotificationList from '../components/App/Notifications/List';
 import AppSettings, { SettingsButton } from '../components/App/settings';
+import { ClusterSettings, ClustersSettings } from '../components/App/settings/clusters';
 import AuthChooser from '../components/authchooser';
 import Chooser from '../components/cluster/Chooser';
 import KubeConfigLoader from '../components/cluster/KubeConfigLoader';
@@ -532,6 +533,23 @@ const defaultRoutes: {
     useClusterURL: false,
     noAuthRequired: true,
     component: () => <AppSettings />,
+  },
+  settingsClusters: {
+    path: '/settings/clusters',
+    exact: true,
+    name: 'Clusters',
+    sidebar: 'settingsClusters',
+    useClusterURL: false,
+    noAuthRequired: true,
+    component: () => <ClustersSettings />,
+  },
+  settingsCluster: {
+    path: '/settings',
+    exact: true,
+    name: 'Cluster Settings',
+    sidebar: 'settingsCluster',
+    noAuthRequired: true,
+    component: () => <ClusterSettings />,
   },
   portforwards: {
     path: '/portforwards',


### PR DESCRIPTION
How to test:
- [ ] Verify that the cluster settings button exists in the user menu (when in cluster)
- [ ] Verify that the cluster settings exists in the "failed to connect to cluster" login dialog
- [ ] Verify that the cluster settings exists in the "token requested" login dialog
- [ ] Go to the cluster settings in 2 different clusters and set different values for the default namespace and the allowed namespaces; then changes routes/refresh and go back to the cluster settings: verify that the values added are persistent
- [ ] Set the default namespace for a cluster and apply a simple resource in that cluster without specifying the namespace: verify it takes the namespace set as default
- [ ] Use a token that grants access only to a certain namespace; then set that namespace as the allowed one; then go to all list views: verify that only resources in the allowed namespace are shown
- [ ] Use a token that grants access only to a certain namespace; then set that namespace as the allowed one; then go to a list view and open the namespace filter: verify that only the allowed namespace is shown in the filter

fixes #679 