### PR TITLE
Allow plugins to process the list of header actions

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -151,7 +151,7 @@ function AppBarActionsMenu({ appBarActions }: { appBarActions: HeaderActionType[
           );
         } else if (Action === null) {
           return null;
-        } else {
+        } else if (typeof Action === 'function') {
           return (
             <ErrorBoundary>
               <MenuItem>
@@ -174,7 +174,7 @@ function AppBarActions({ appBarActions }: { appBarActions: HeaderActionType[] })
           return <ErrorBoundary>{Action}</ErrorBoundary>;
         } else if (Action === null) {
           return null;
-        } else {
+        } else if (typeof Action === 'function') {
           return (
             <ErrorBoundary>
               <Action />

--- a/frontend/src/components/common/Resource/DeleteButton.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.tsx
@@ -48,6 +48,10 @@ export default function DeleteButton(props: DeleteButtonProps) {
     [item]
   );
 
+  if (!item) {
+    return null;
+  }
+
   return (
     <AuthVisible
       item={item}

--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -64,6 +64,10 @@ export default function EditButton(props: EditButtonProps) {
     );
   }
 
+  if (!item) {
+    return null;
+  }
+
   if (isReadOnly) {
     return <ViewButton item={item} />;
   }

--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -64,7 +64,7 @@ export function RestartButton(props: RestartButtonProps) {
     );
   }
 
-  if (!['Deployment', 'StatefulSet', 'DaemonSet'].includes(item.kind)) {
+  if (!item || !['Deployment', 'StatefulSet', 'DaemonSet'].includes(item.kind)) {
     return null;
   }
 

--- a/frontend/src/components/common/Resource/ScaleButton.tsx
+++ b/frontend/src/components/common/Resource/ScaleButton.tsx
@@ -66,7 +66,7 @@ export default function ScaleButton(props: ScaleButtonProps) {
     setOpenDialog(false);
   }
 
-  if (!['Deployment', 'StatefulSet', 'ReplicaSet'].includes(item.kind)) {
+  if (!item || !['Deployment', 'StatefulSet', 'ReplicaSet'].includes(item.kind)) {
     return null;
   }
 

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -588,6 +588,26 @@ exports[`Storyshots endpoints/EndpointsDetailsView Error 1`] = `
                 />
               </div>
             </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -683,6 +703,26 @@ exports[`Storyshots endpoints/EndpointsDetailsView No Item Yet 1`] = `
                 </h1>
                 <div
                   class="MuiBox-root MuiBox-root"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
                 />
               </div>
             </div>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -433,6 +433,26 @@ exports[`Storyshots hpa/HpaDetailsView Error 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -516,6 +536,26 @@ exports[`Storyshots hpa/HpaDetailsView No Item Yet 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -15,6 +15,7 @@ import { useParams } from 'react-router-dom';
 import { Terminal as XTerminal } from 'xterm';
 import { KubeContainerStatus } from '../../lib/k8s/cluster';
 import Pod from '../../lib/k8s/pod';
+import { DefaultHeaderAction } from '../../redux/actions/actions';
 import { LightTooltip, SectionBox, SimpleTable } from '../common';
 import Link from '../common/Link';
 import { LogViewer, LogViewerProps } from '../common/LogViewer';
@@ -298,30 +299,48 @@ export default function PodDetails(props: PodDetailsProps) {
       withEvents
       actions={item =>
         item && [
-          <AuthVisible item={item} authVerb="get" subresource="log">
-            <Tooltip title={t('Show Logs') as string}>
-              <IconButton aria-label={t('logs')} onClick={() => setShowLogs(true)}>
-                <Icon icon="mdi:file-document-box-outline" />
-              </IconButton>
-            </Tooltip>
-          </AuthVisible>,
-          <AuthVisible item={item} authVerb="get" subresource="exec">
-            <Tooltip title={t('Terminal / Exec') as string}>
-              <IconButton
-                aria-label={t('terminal') as string}
-                onClick={() => setShowTerminal(true)}
-              >
-                <Icon icon="mdi:console" />
-              </IconButton>
-            </Tooltip>
-          </AuthVisible>,
-          <AuthVisible item={item} authVerb="get" subresource="attach">
-            <Tooltip title={t('Attach') as string}>
-              <IconButton aria-label={t('attach') as string} onClick={() => setIsAttached(true)}>
-                <Icon icon="mdi:connection" />
-              </IconButton>
-            </Tooltip>
-          </AuthVisible>,
+          {
+            id: DefaultHeaderAction.POD_LOGS,
+            action: (
+              <AuthVisible item={item} authVerb="get" subresource="log">
+                <Tooltip title={t('Show Logs') as string}>
+                  <IconButton aria-label={t('logs')} onClick={() => setShowLogs(true)}>
+                    <Icon icon="mdi:file-document-box-outline" />
+                  </IconButton>
+                </Tooltip>
+              </AuthVisible>
+            ),
+          },
+          {
+            id: DefaultHeaderAction.POD_TERMINAL,
+            action: (
+              <AuthVisible item={item} authVerb="get" subresource="exec">
+                <Tooltip title={t('Terminal / Exec') as string}>
+                  <IconButton
+                    aria-label={t('terminal') as string}
+                    onClick={() => setShowTerminal(true)}
+                  >
+                    <Icon icon="mdi:console" />
+                  </IconButton>
+                </Tooltip>
+              </AuthVisible>
+            ),
+          },
+          {
+            id: DefaultHeaderAction.POD_ATTACH,
+            action: (
+              <AuthVisible item={item} authVerb="get" subresource="attach">
+                <Tooltip title={t('Attach') as string}>
+                  <IconButton
+                    aria-label={t('attach') as string}
+                    onClick={() => setIsAttached(true)}
+                  >
+                    <Icon icon="mdi:connection" />
+                  </IconButton>
+                </Tooltip>
+              </AuthVisible>
+            ),
+          },
         ]
       }
       extraInfo={item =>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
@@ -355,6 +355,26 @@ exports[`Storyshots pdb/PDBDetailsView Error 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -438,6 +458,26 @@ exports[`Storyshots pdb/PDBDetailsView No Item Yet 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
@@ -306,6 +306,26 @@ exports[`Storyshots PriorityClasses/PriorityClassesDetailsView Error 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -389,6 +409,26 @@ exports[`Storyshots PriorityClasses/PriorityClassesDetailsView No Item Yet 1`] =
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -443,6 +443,26 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Error 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -526,6 +546,26 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView No Item Yet 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"

--- a/frontend/src/components/runtimeClass/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/Details.stories.storyshot
@@ -42,6 +42,26 @@ exports[`Storyshots RuntimeClass/DetailsView Runtime Class Detail 1`] = `
             class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
           >
             
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
+              </div>
+            </div>
           </div>
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -6,10 +6,12 @@
 
 import { Headlamp, Plugin } from './lib';
 import Registry, {
+  DetailsViewDefaultHeaderActions,
   registerAppBarAction,
   registerAppLogo,
   registerClusterChooser,
   registerDetailsViewHeaderAction,
+  registerDetailsViewHeaderActionsProcessor,
   registerDetailsViewSection,
   registerGetTokenFunction,
   registerRoute,
@@ -54,6 +56,8 @@ window.pluginLib = {
   registerSidebarEntry,
   registerSidebarEntryFilter,
   registerGetTokenFunction,
+  registerDetailsViewHeaderActionsProcessor,
+  DetailsViewDefaultHeaderActions,
 };
 
 // @todo: should window.plugins be private?

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -305,7 +305,7 @@ export function registerDetailsViewHeaderAction(headerAction: DetailsViewHeaderA
  *
  */
 export function registerDetailsViewHeaderActionsProcessor(
-  processor: DetailsViewHeaderActionsProcessor
+  processor: DetailsViewHeaderActionsProcessor | DetailsViewHeaderActionsProcessor['processor']
 ) {
   store.dispatch(addDetailsViewHeaderActionsProcessor(processor));
 }

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -7,6 +7,9 @@ import { AppLogoProps, AppLogoType } from '../components/Sidebar/AppLogo';
 import { KubeObject } from '../lib/k8s/cluster';
 import { Route } from '../lib/router';
 import {
+  addDetailsViewHeaderActionsProcessor,
+  DefaultHeaderAction,
+  HeaderActionsProcessor,
   HeaderActionType,
   setAppBarAction,
   setBrandingAppLogoComponent,
@@ -30,6 +33,7 @@ export type { AppLogoProps, AppLogoType };
 export type { ClusterChooserProps, ClusterChooserType };
 export type { SidebarEntryProps };
 export type { DetailsViewSectionProps, DetailsViewSectionType };
+export const DetailsViewDefaultHeaderActions = DefaultHeaderAction;
 
 /**
  * @deprecated please used DetailsViewSectionType and registerDetailViewSection
@@ -43,6 +47,7 @@ export type sectionFunc = (resource: KubeObject) => SectionFuncProps | null | un
 // @todo: these should also have a *Props
 // @todo: HeaderActionType should be deprecated.
 export type DetailsViewHeaderActionType = HeaderActionType;
+export type DetailsViewHeaderActionsProcessor = HeaderActionsProcessor;
 export type AppBarActionType = HeaderActionType;
 
 export default class Registry {
@@ -278,6 +283,27 @@ export function registerRoute(routeSpec: Route) {
  */
 export function registerDetailsViewHeaderAction(headerAction: DetailsViewHeaderActionType) {
   store.dispatch(setDetailsViewHeaderAction(headerAction));
+}
+
+/**
+ * Add a processor for the details view header actions.
+ *
+ * @param processor - The processor to add. Receives a resource (for which we are processing the header actions) and the current header actions and returns the new header actions. Return an empty array to remove all header actions.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { registerDetailsViewHeaderActionsProcessor, DetailsViewDefaultHeaderActions } from '@kinvolk/headlamp-plugin/lib';
+ *
+ * // Processor that removes the default edit action.
+ * registerDetailsViewHeaderActionsProcessor((resource, headerActions) => {
+ *  return headerActions.filter(action => action.name !== DetailsViewDefaultHeaderActions.EDIT);
+ * });
+ */
+export function registerDetailsViewHeaderActionsProcessor(
+  processor: DetailsViewHeaderActionsProcessor
+) {
+  store.dispatch(addDetailsViewHeaderActionsProcessor(processor));
 }
 
 /**

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -286,7 +286,7 @@ export function registerDetailsViewHeaderAction(headerAction: DetailsViewHeaderA
 }
 
 /**
- * Add a processor for the details view header actions.
+ * Add a processor for the details view header actions. Allowing the modification of header actions.
  *
  * @param processor - The processor to add. Receives a resource (for which we are processing the header actions) and the current header actions and returns the new header actions. Return an empty array to remove all header actions.
  *
@@ -299,6 +299,10 @@ export function registerDetailsViewHeaderAction(headerAction: DetailsViewHeaderA
  * registerDetailsViewHeaderActionsProcessor((resource, headerActions) => {
  *  return headerActions.filter(action => action.name !== DetailsViewDefaultHeaderActions.EDIT);
  * });
+ *
+ * More complete detail view example in plugins/examples/details-view:
+ * @see {@link http://github.com/kinvolk/headlamp/plugins/examples/details-view/ Detail View Example}
+ *
  */
 export function registerDetailsViewHeaderActionsProcessor(
   processor: DetailsViewHeaderActionsProcessor

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -104,6 +104,7 @@ export enum DefaultHeaderAction {
   SCALE = 'SCALE',
   POD_LOGS = 'POD_LOGS',
   POD_TERMINAL = 'POD_TERMINAL',
+  POD_ATTACH = 'POD_ATTACH',
 }
 
 export type HeaderActionsProcessor = {

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -1,9 +1,10 @@
 import { OptionsObject as SnackbarProps } from 'notistack';
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { ClusterChooserType } from '../../components/cluster/ClusterChooser';
 import { DetailsViewSectionType } from '../../components/DetailsViewSection';
 import { SidebarEntryProps } from '../../components/Sidebar';
 import { AppLogoType } from '../../components/Sidebar/AppLogo';
+import { KubeObject } from '../../lib/k8s/cluster';
 import { Notification } from '../../lib/notification';
 import { Route } from '../../lib/router';
 import { UIState } from '../reducers/ui';
@@ -23,6 +24,8 @@ export const UI_SIDEBAR_SET_EXPANDED = 'UI_SIDEBAR_SET_EXPANDED';
 export const UI_ROUTER_SET_ROUTE = 'UI_ROUTER_SET_ROUTE';
 export const UI_ROUTER_SET_ROUTE_FILTER = 'UI_ROUTER_SET_ROUTE_FILTER';
 export const UI_DETAILS_VIEW_SET_HEADER_ACTION = 'UI_DETAILS_VIEW_SET_HEADER_ACTION';
+export const UI_DETAILS_VIEW_ADD_HEADER_ACTIONS_PROCESSOR =
+  'UI_DETAILS_VIEW_ADD_HEADER_ACTIONS_PROCESSOR';
 export const UI_SET_DETAILS_VIEW = 'UI_SET_DETAILS_VIEW';
 export const UI_APP_BAR_SET_ACTION = 'UI_APP_BAR_SET_ACTION';
 export const UI_THEME_SET = 'UI_THEME_SET';
@@ -82,8 +85,31 @@ export interface Action {
 
 type SidebarType = UIState['sidebar'];
 
-export type HeaderActionType = ((...args: any[]) => JSX.Element | null) | null | ReactElement;
+export type HeaderActionType =
+  | ((...args: any[]) => JSX.Element | null | ReactNode)
+  | null
+  | ReactElement
+  | ReactNode;
 export type DetailsViewFunc = HeaderActionType;
+
+export type HeaderAction = {
+  id: string;
+  action?: HeaderActionType;
+};
+
+export enum DefaultHeaderAction {
+  RESTART = 'RESTART',
+  DELETE = 'DELETE',
+  EDIT = 'EDIT',
+  SCALE = 'SCALE',
+  POD_LOGS = 'POD_LOGS',
+  POD_TERMINAL = 'POD_TERMINAL',
+}
+
+export type HeaderActionsProcessor = {
+  id: string;
+  processor: (resource: KubeObject | null, actions: HeaderAction[]) => HeaderAction[];
+};
 
 export function setNamespaceFilter(namespaces: string[]) {
   return { type: FILTER_SET_NAMESPACE, namespaces: namespaces };
@@ -147,8 +173,29 @@ export function setRouteFilter(filterFunc: (entry: Route) => Route | null) {
   return { type: UI_ROUTER_SET_ROUTE_FILTER, filterFunc };
 }
 
-export function setDetailsViewHeaderAction(actionFunc: HeaderActionType) {
-  return { type: UI_DETAILS_VIEW_SET_HEADER_ACTION, action: actionFunc };
+export function setDetailsViewHeaderAction(action: HeaderActionType | HeaderAction) {
+  let headerAction = action as HeaderAction;
+  if (headerAction.id === undefined) {
+    if (headerAction.action === undefined) {
+      headerAction = { id: '', action: action as HeaderActionType };
+    } else {
+      headerAction = { id: '', action: headerAction.action };
+    }
+  }
+  return { type: UI_DETAILS_VIEW_SET_HEADER_ACTION, action: headerAction };
+}
+
+export function addDetailsViewHeaderActionsProcessor(
+  actionProcessor: HeaderActionsProcessor | HeaderActionsProcessor['processor']
+) {
+  let headerActionsProcessor = actionProcessor as HeaderActionsProcessor;
+  if (headerActionsProcessor.id === undefined && typeof actionProcessor === 'function') {
+    headerActionsProcessor = {
+      id: '',
+      processor: actionProcessor,
+    };
+  }
+  return { type: UI_DETAILS_VIEW_ADD_HEADER_ACTIONS_PROCESSOR, action: headerActionsProcessor };
 }
 
 export function setDetailsView(viewSection: DetailsViewSectionType) {

--- a/plugins/examples/details-view/src/index.tsx
+++ b/plugins/examples/details-view/src/index.tsx
@@ -18,6 +18,9 @@ function IconAction() {
 }
 registerDetailsViewHeaderAction(IconAction);
 
+// We can replace the section view with our own custom one.
+// Here we are showing a custom view when it's a ConfigMap resource.
+
 registerDetailsViewSection(({ resource }: DetailsViewSectionProps) => {
   if (resource && resource.kind === 'ConfigMap') {
     return (
@@ -29,35 +32,32 @@ registerDetailsViewSection(({ resource }: DetailsViewSectionProps) => {
   return null;
 });
 
-registerDetailsViewHeaderActionsProcessor({
-  id: 'replace-default-delete-by-useless-one',
-  processor: (resource, actions) => {
-    if (!resource) {
-      return actions;
-    }
+// We can replace action buttons with our own custom ones.
 
-    let hasDeleteAction = false;
-    const noDeleteActions = actions.filter(action => {
-      if (action.id === DetailsViewDefaultHeaderActions.DELETE) {
-        hasDeleteAction = true;
-        return false;
-      }
-      return true;
-    });
+registerDetailsViewHeaderActionsProcessor(function replaceDeleteAction(resource, actions) {
+  if (!resource || !actions.find(action => action.id === DetailsViewDefaultHeaderActions.DELETE)) {
+    // There was no delete button so we do nothing.
+    return actions;
+  }
 
-    if (hasDeleteAction) {
-      noDeleteActions.push({
-        id: 'my-custom-delete-action',
-        action: (
-          <ActionButton
-            description="Useless button from a plugin example"
-            icon="mdi:delete-off"
-            onClick={() => alert(`One cannot simply delete a ${resource.kind}!`)}
-          />
-        ),
-      });
-    }
+  const actionsDeleteRemoved = actions.filter(
+    action => action.id !== DetailsViewDefaultHeaderActions.DELETE
+  );
+  // DetailsViewDefaultHeaderActions includes DELETE, EDIT, RESTART, SCALE, and more.
 
-    return noDeleteActions;
-  },
+  // We add our own button as an example to show how we can replace default buttons.
+  const actionsWithOurDelete = [
+    ...actionsDeleteRemoved,
+    {
+      id: 'my-custom-delete-action',
+      action: (
+        <ActionButton
+          description="Useless button from a plugin example from details-view example plugin"
+          icon="mdi:delete"
+          onClick={() => alert(`One cannot simply delete a ${resource.kind}!`)}
+        />
+      ),
+    },
+  ];
+  return actionsWithOurDelete;
 });

--- a/plugins/examples/details-view/src/index.tsx
+++ b/plugins/examples/details-view/src/index.tsx
@@ -1,6 +1,8 @@
 import {
+  DetailsViewDefaultHeaderActions,
   DetailsViewSectionProps,
   registerDetailsViewHeaderAction,
+  registerDetailsViewHeaderActionsProcessor,
   registerDetailsViewSection,
 } from '@kinvolk/headlamp-plugin/lib';
 import { ActionButton, SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
@@ -25,4 +27,37 @@ registerDetailsViewSection(({ resource }: DetailsViewSectionProps) => {
     );
   }
   return null;
+});
+
+registerDetailsViewHeaderActionsProcessor({
+  id: 'replace-default-delete-by-useless-one',
+  processor: (resource, actions) => {
+    if (!resource) {
+      return actions;
+    }
+
+    let hasDeleteAction = false;
+    const noDeleteActions = actions.filter(action => {
+      if (action.id === DetailsViewDefaultHeaderActions.DELETE) {
+        hasDeleteAction = true;
+        return false;
+      }
+      return true;
+    });
+
+    if (hasDeleteAction) {
+      noDeleteActions.push({
+        id: 'my-custom-delete-action',
+        action: (
+          <ActionButton
+            description="Useless button from a plugin example"
+            icon="mdi:delete-off"
+            onClick={() => alert(`One cannot simply delete a ${resource.kind}!`)}
+          />
+        ),
+      });
+    }
+
+    return noDeleteActions;
+  },
 });

--- a/plugins/headlamp-plugin/lib/index.ts
+++ b/plugins/headlamp-plugin/lib/index.ts
@@ -7,11 +7,13 @@ import { Headlamp, Plugin } from '../types/plugin/lib';
 import Registry, {
   AppLogoProps,
   ClusterChooserProps,
+  DetailsViewDefaultHeaderActions,
   DetailsViewSectionProps,
   registerAppBarAction,
   registerAppLogo,
   registerClusterChooser,
   registerDetailsViewHeaderAction,
+  registerDetailsViewHeaderActionsProcessor,
   registerDetailsViewSection,
   registerRoute,
   registerRouteFilter,
@@ -35,6 +37,7 @@ export {
   AppLogoProps,
   ClusterChooserProps,
   DetailsViewSectionProps,
+  DetailsViewDefaultHeaderActions,
   registerAppLogo,
   registerAppBarAction,
   registerClusterChooser,
@@ -44,4 +47,5 @@ export {
   registerRouteFilter,
   registerSidebarEntry,
   registerSidebarEntryFilter,
+  registerDetailsViewHeaderActionsProcessor,
 };


### PR DESCRIPTION
Instead of allowing to just add (append) header actions, we want plugins to be able to process the list of header actions in details views. The idea is that plugins supply a function that is given the current list of header actions and should return a list of header actions to display, allowing them to add/remove/update such actions.

An example is provided in the details-view example plugin.
