### PR TITLE
frontend: Always show overridden cluster chooser button

### DIFF
--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -57,11 +57,11 @@ export function ClusterTitle(props: ClusterTitleProps) {
     return null;
   }
 
-  if (Object.keys(clusters || {}).length <= 1) {
+  if (!arePluginsLoaded || _.isNull(ChooserButton)) {
     return null;
   }
 
-  if (!arePluginsLoaded || _.isNull(ChooserButton)) {
+  if (!ChooserButton && Object.keys(clusters || {}).length <= 1) {
     return null;
   }
 


### PR DESCRIPTION
We don't show the default cluster chooser button if only one cluster
is available, but if the button is overridden by a plugin, we
shouldn't make that change.
