### PR TITLE
frontend: Rename port forwarding

### DIFF
--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -97,7 +97,7 @@ function prepareRoutes(t: (arg: string) => string) {
         },
         {
           name: 'portforwards',
-          label: t('glossary|Port Forwards'),
+          label: t('glossary|Port Forwarding'),
           hide: !helpers.isElectron(),
         },
       ],

--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -57,7 +57,7 @@ export default function PortForwardingList() {
     const cluster = getCluster();
     if (!cluster) return;
 
-    // fetch port forwards
+    // fetch port forwarding list
     listPortForward(cluster).then(portforwards => {
       const massagedPortForwards = portforwards === null ? [] : portforwards;
       massagedPortForwards.forEach((portforward: any) => {
@@ -169,7 +169,7 @@ export default function PortForwardingList() {
 
   function prepareStatusLabel(portforward: any) {
     if (portForwardInAction?.id === portforward.id && portForwardInAction.loading) {
-      return <Loader noContainer title={t('resource|Loading port forwards')} size={30} />;
+      return <Loader noContainer title={t('resource|Loading port forwarding')} size={30} />;
     }
     const error = portforward.error;
     if (error) {
@@ -183,7 +183,7 @@ export default function PortForwardingList() {
   }
 
   return (
-    <SectionBox title={t('glossary|Port Forwards')}>
+    <SectionBox title={t('glossary|Port Forwarding')}>
       <SimpleTable
         columns={[
           {

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -92,7 +92,7 @@
   "Restarts": "Restarts",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} ago)",
   "Pod Disruption Budget": "Pod Disruption Budget",
-  "Port Forwards": "Port Forwards",
+  "Port Forwarding": "Port Forwarding",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",
   "Generation": "Generation",

--- a/frontend/src/i18n/locales/en/resource.json
+++ b/frontend/src/i18n/locales/en/resource.json
@@ -65,7 +65,7 @@
   "Resumed CronJob {{ newItemName }}.": "Resumed CronJob {{ newItemName }}.",
   "Failed to suspend CronJob {{ newItemName }}.": "Failed to suspend CronJob {{ newItemName }}.",
   "Failed to resume CronJob {{ newItemName }}.": "Failed to resume CronJob {{ newItemName }}.",
-  "Loading port forwards": "Loading port forwards",
+  "Loading port forwarding": "Loading port forwarding",
   "Pod Port": "Pod Port",
   "Local Port": "Local Port"
 }

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -92,7 +92,7 @@
   "Restarts": "Reinicios",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (hace {{ abbrevTime }})",
   "Pod Disruption Budget": "Pod Disruption Budget",
-  "Port Forwards": "Redir. de Puertos",
+  "Port Forwarding": "Redir. de Puertos",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",
   "Generation": "Generación",

--- a/frontend/src/i18n/locales/es/resource.json
+++ b/frontend/src/i18n/locales/es/resource.json
@@ -65,7 +65,7 @@
   "Resumed CronJob {{ newItemName }}.": "",
   "Failed to suspend CronJob {{ newItemName }}.": "",
   "Failed to resume CronJob {{ newItemName }}.": "",
-  "Loading port forwards": "Cargango redireccionamientos de puerto",
+  "Loading port forwarding": "Cargango redireccionamientos de puerto",
   "Pod Port": "Puerto del Pod",
   "Local Port": "Perto Local"
 }

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -92,7 +92,7 @@
   "Restarts": "Reinícios",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (há {{ abbrevTime }})",
   "Pod Disruption Budget": "Pod Disruption Budget",
-  "Port Forwards": "Redir. Portas",
+  "Port Forwarding": "Redir. de Portas",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",
   "Generation": "Geração",

--- a/frontend/src/i18n/locales/pt/resource.json
+++ b/frontend/src/i18n/locales/pt/resource.json
@@ -65,7 +65,7 @@
   "Resumed CronJob {{ newItemName }}.": "",
   "Failed to suspend CronJob {{ newItemName }}.": "",
   "Failed to resume CronJob {{ newItemName }}.": "",
-  "Loading port forwards": "A carregar redir. de portas",
+  "Loading port forwarding": "A carregar redir. de portas",
   "Pod Port": "Porta do \"Pod\"",
   "Local Port": "Porta Local"
 }


### PR DESCRIPTION
It was "port forwards" but @blixtra brought to my attention this was not correct.