### PR TITLE
frontend init-containers: Includes init containers to pod containers

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -739,6 +739,10 @@ export function ContainersSection(props: { resource: KubeObjectInterface | null 
     return containers;
   }
 
+  function getInitContainers() {
+    return resource?.spec?.initContainers || [];
+  }
+
   function getStatuses() {
     if (!resource || resource.kind !== 'Pod') {
       return {};
@@ -757,6 +761,7 @@ export function ContainersSection(props: { resource: KubeObjectInterface | null 
   }
 
   const containers = getContainers();
+  const initContainers = getInitContainers();
   const statuses = getStatuses();
   const numContainers = containers.length;
 
@@ -780,6 +785,21 @@ export function ContainersSection(props: { resource: KubeObjectInterface | null 
           ))
         )}
       </>
+
+      {initContainers.length > 0 && (
+        <>
+          <SectionBox title={t('resource|Init Containers')} />
+          {initContainers.map((initContainer: KubeContainer, i: number) => (
+            <SectionBox key={`init_container_${i}`} outterBoxProps={{ pt: 1 }}>
+              <ContainerInfo
+                resource={resource}
+                container={initContainer}
+                status={statuses[initContainer.name]}
+              />
+            </SectionBox>
+          ))}
+        </>
+      )}
     </>
   );
 }

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -1570,6 +1570,245 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="MuiBox-root MuiBox-root"
+        >
+          <div
+            class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiBox-root MuiBox-root"
+              >
+                <h2
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                >
+                  Init Containers
+                </h2>
+                <div
+                  class="MuiBox-root MuiBox-root"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiBox-root MuiBox-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <div
+                class="MuiBox-root MuiBox-root"
+              >
+                <div
+                  class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+                >
+                  <div
+                    class="MuiGrid-root MuiGrid-item"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root"
+                    >
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        init-myservice
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <table
+                  class="MuiTable-root makeStyles-table"
+                >
+                  <tbody
+                    class="MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                        role="cell"
+                        scope="row"
+                      >
+                        Image Pull Policy
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
+                      >
+                        <span
+                          class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
+                        >
+                          Always
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                        role="cell"
+                        scope="row"
+                      >
+                        Image
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1"
+                        >
+                          busybox
+                        </p>
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                        role="cell"
+                        scope="row"
+                      >
+                        Command
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
+                      >
+                        <span
+                          class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
+                        >
+                          sh -c until nslookup myservice; do echo waiting for myservice; sleep 2; done;
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root MuiBox-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <div
+                class="MuiBox-root MuiBox-root"
+              >
+                <div
+                  class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+                >
+                  <div
+                    class="MuiGrid-root MuiGrid-item"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root"
+                    >
+                      <h3
+                        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h3 MuiTypography-noWrap"
+                      >
+                        init-mydb
+                      </h3>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <table
+                  class="MuiTable-root makeStyles-table"
+                >
+                  <tbody
+                    class="MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                        role="cell"
+                        scope="row"
+                      >
+                        Image Pull Policy
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
+                      >
+                        <span
+                          class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
+                        >
+                          Always
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                        role="cell"
+                        scope="row"
+                      >
+                        Image
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1"
+                        >
+                          busybox
+                        </p>
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                        role="cell"
+                        scope="row"
+                      >
+                        Command
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
+                      >
+                        <span
+                          class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
+                        >
+                          sh -c until nslookup mydb; do echo waiting for mydb; sleep 2; done;
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
For issue #983 

Creates an additional field for Init containers under the regular containers when in the pod view.

<img width="695" alt="image" src="https://user-images.githubusercontent.com/78232183/224773810-dcc3e24a-fc63-4589-b533-e0a006664ded.png">
