### PR TITLE
frontend: Add attach to pod option

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -288,6 +288,7 @@ export default function PodDetails(props: PodDetailsProps) {
   const [showLogs, setShowLogs] = React.useState(!!showLogsDefault);
   const [showTerminal, setShowTerminal] = React.useState(false);
   const { t } = useTranslation('glossary');
+  const [isAttached, setIsAttached] = React.useState(false);
 
   return (
     <DetailsGrid
@@ -311,6 +312,13 @@ export default function PodDetails(props: PodDetailsProps) {
                 onClick={() => setShowTerminal(true)}
               >
                 <Icon icon="mdi:console" />
+              </IconButton>
+            </Tooltip>
+          </AuthVisible>,
+          <AuthVisible item={item} authVerb="get" subresource="attach">
+            <Tooltip title={t('Attach') as string}>
+              <IconButton aria-label={t('attach') as string} onClick={() => setIsAttached(true)}>
+                <Icon icon="mdi:connection" />
               </IconButton>
             </Tooltip>
           </AuthVisible>,
@@ -356,9 +364,13 @@ export default function PodDetails(props: PodDetailsProps) {
             />
             <Terminal
               key="terminal"
-              open={showTerminal}
+              open={showTerminal || isAttached}
               item={item}
-              onClose={() => setShowTerminal(false)}
+              onClose={() => {
+                setShowTerminal(false);
+                setIsAttached(false);
+              }}
+              isAttach={isAttached}
             />
           </>
         )

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -81,6 +81,9 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
               </div>
             </div>
           </div>
@@ -931,6 +934,9 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
               >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -2040,6 +2046,9 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
               </div>
             </div>
           </div>
@@ -3006,6 +3015,9 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
               </div>
             </div>
           </div>
@@ -3823,6 +3835,9 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
               >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -4695,6 +4710,9 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
               >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -96,6 +96,9 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                 />
                 <div
                   class="MuiGrid-root MuiGrid-item"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item"
                 >
                   <button
                     aria-label="View YAML"

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -130,6 +130,18 @@ class Pod extends makeKubeObject<KubePod>('Pod') {
     return cancel;
   }
 
+  attach(container: string, onAttach: StreamResultsCb, options: StreamArgs = {}) {
+    const url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/attach?container=${container}&stdin=true&stderr=true&stdout=true&tty=true`;
+    const additionalProtocols = [
+      'v4.channel.k8s.io',
+      'v3.channel.k8s.io',
+      'v2.channel.k8s.io',
+      'channel.k8s.io',
+    ];
+
+    return stream(url, onAttach, { additionalProtocols, isJson: false, ...options });
+  }
+
   exec(container: string, onExec: StreamResultsCb, options: ExecOptions = {}) {
     const { command = ['sh'], ...streamOpts } = options;
     const commandStr = command.map(item => '&command=' + encodeURIComponent(item)).join('');


### PR DESCRIPTION
Acceptance Criteria:

- [x] Go to pods detail view and there is a attach header action
- [x] Click on the attach header action and you are able to connect to the container stdin, stdout, stderr whichever is available
- [x] Change the container and you get attached to the new container i/o/err stream now