### PR TITLE
frontend: Remove the usage of jest in the storybook

### DIFF
--- a/frontend/src/test/index.tsx
+++ b/frontend/src/test/index.tsx
@@ -30,19 +30,20 @@ export function TestContext(props: TestContextProps) {
   }
 
   // override Event.objectEvents to return phony events array
-  Event.objectEvents = jest.fn().mockResolvedValue([
-    {
-      type: 'Normal',
-      reason: 'Created',
-      message: 'Created',
-      source: {
-        component: 'kubelet',
+  Event.objectEvents = () =>
+    Promise.resolve([
+      {
+        type: 'Normal',
+        reason: 'Created',
+        message: 'Created',
+        source: {
+          component: 'kubelet',
+        },
+        firstTimestamp: '2021-03-01T00:00:00Z',
+        lastTimestamp: '2021-03-01T00:00:00Z',
+        count: 1,
       },
-      firstTimestamp: '2021-03-01T00:00:00Z',
-      lastTimestamp: '2021-03-01T00:00:00Z',
-      count: 1,
-    },
-  ]);
+    ]);
 
   return (
     <Provider store={store || defaultStore}>


### PR DESCRIPTION
Jest is not made available to storybook, except in the test runner.

Fixes https://github.com/headlamp-k8s/headlamp/issues/1029

How to test?

```bash
cd frontend
npm run storybook
# go to the SimpleTable component and it should work
```

