### PR TITLE
frontend: Load Monaco from node_module and export Monaco to plugin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -175,7 +175,7 @@
       "text"
     ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!d3|internmap|react-markdown|xterm|github-markdown-css|vfile|unist-.+|unified|bail|is-plain-obj|trough|remark-.+|mdast-util-.+|micromark|parse-entities|character-entities|property-information|comma-separated-tokens|hast-util-whitespace|remark-.+|space-separated-tokens|decode-named-character-reference|spacetime)"
+      "/node_modules/(?!d3|internmap|react-markdown|xterm|github-markdown-css|vfile|unist-.+|unified|bail|is-plain-obj|trough|remark-.+|mdast-util-.+|micromark|parse-entities|character-entities|property-information|comma-separated-tokens|hast-util-whitespace|remark-.+|space-separated-tokens|decode-named-character-reference|spacetime|monaco-editor.+|react-monaco-editor|@monaco-editor/react)"
     ],
     "resetMocks": false
   },

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -10,7 +10,6 @@ import Switch from '@material-ui/core/Switch';
 import Typography from '@material-ui/core/Typography';
 import Editor, { loader } from '@monaco-editor/react';
 import * as yaml from 'js-yaml';
-import * as monaco from 'monaco-editor';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { KubeObjectInterface } from '../../../lib/k8s/cluster';
@@ -21,6 +20,16 @@ import Loader from '../Loader';
 import Tabs from '../Tabs';
 import DocsViewer from './DocsViewer';
 import SimpleEditor from './SimpleEditor';
+
+// Jest does not work with esm modules and 'monaco-editor' properly
+// It says it can't find the module when running the tests.
+let monaco: any;
+if (process.env.NODE_ENV === 'test') {
+  monaco = require('monaco-editor/esm/vs/editor/editor.api.js');
+} else {
+  // const monaco = monacoEditor;
+  monaco = require('monaco-editor');
+}
 
 const useStyle = makeStyles(theme => ({
   dialogContent: {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -10,6 +10,7 @@ import Switch from '@material-ui/core/Switch';
 import Typography from '@material-ui/core/Typography';
 import Editor, { loader } from '@monaco-editor/react';
 import * as yaml from 'js-yaml';
+import * as monaco from 'monaco-editor';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { KubeObjectInterface } from '../../../lib/k8s/cluster';
@@ -256,7 +257,9 @@ export default function EditorDialog(props: EditorDialogProps) {
   function makeEditor() {
     // @todo: monaco editor does not support pt, ta, hi amongst various other langs.
     if (['de', 'es', 'fr', 'it', 'ja', 'ko', 'ru', 'zh-cn', 'zh-tw'].includes(lang)) {
-      loader.config({ 'vs/nls': { availableLanguages: { '*': lang } } });
+      loader.config({ 'vs/nls': { availableLanguages: { '*': lang } }, monaco });
+    } else {
+      loader.config({ monaco });
     }
 
     return useSimpleEditor ? (

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -12,7 +12,6 @@ import Editor from '@monaco-editor/react';
 import { Location } from 'history';
 import { Base64 } from 'js-base64';
 import _ from 'lodash';
-import * as monaco from 'monaco-editor';
 import React, { isValidElement, PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, NavLinkProps, useLocation } from 'react-router-dom';
@@ -290,7 +289,7 @@ export function DataField(props: TextFieldProps) {
   useTheme();
   const themeName = getThemeName();
 
-  function handleEditorDidMount(editor: monaco.editor.IStandaloneCodeEditor) {
+  function handleEditorDidMount(editor: any) {
     const editorElement: HTMLElement | null = editor.getDomNode();
     if (!editorElement) {
       return;

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -20,6 +20,8 @@ import Registry, {
 window.pluginLib = {
   ApiProxy: require('../lib/k8s/apiProxy'),
   Crd: require('../lib/k8s/crd'),
+  ReactMonacoEditor: require('@monaco-editor/react'),
+  MonacoEditor: require('monaco-editor'),
   K8s: require('../lib/k8s'),
   CommonComponents: require('../components/common'),
   MuiCore: require('@material-ui/core'),

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -21,7 +21,9 @@ window.pluginLib = {
   ApiProxy: require('../lib/k8s/apiProxy'),
   Crd: require('../lib/k8s/crd'),
   ReactMonacoEditor: require('@monaco-editor/react'),
-  MonacoEditor: require('monaco-editor'),
+  MonacoEditor: require(process.env.NODE_ENV === 'test'
+    ? 'monaco-editor/esm/vs/editor/editor.api.js'
+    : 'monaco-editor'),
   K8s: require('../lib/k8s'),
   CommonComponents: require('../components/common'),
   MuiCore: require('@material-ui/core'),

--- a/plugins/headlamp-plugin/config/webpack.config.js
+++ b/plugins/headlamp-plugin/config/webpack.config.js
@@ -1,5 +1,7 @@
 const externalModules = {
   '@material-ui/core': 'pluginLib.MuiCore',
+  '@monaco-editor/react': 'pluginLib.ReactMonacoEditor',
+  'monaco-editor': 'pluginLib.MonacoEditor',
   '@material-ui/lab': 'pluginLib.MuiLab',
   '@material-ui/styles': 'pluginLib.MuiStyles',
   react: 'pluginLib.React',


### PR DESCRIPTION
This PR covers two scenarios:

- Load Monaco Editor from node_module instead of cdn for airgaped environment.
![image](https://user-images.githubusercontent.com/13809749/225914753-c2daa242-3a81-4e4e-8e3a-59099d95137d.png)
![image](https://user-images.githubusercontent.com/13809749/225914895-d32e7deb-5cad-43fe-a277-68ff5862a02c.png)

- For those of who want to create monaco editor in plugin, they can leverage monaco editor exported from frontend. It can reduce the size of plugin. In our case, we create editor for manage data stored in annotation. 