### PR TITLE
make: Use semantic version for docker ext tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ image:
 	.
 
 docker-ext:
-	$(eval LATEST_TAG=$(shell git tag --list --sort=version:refname 'v*' | tail -1))
+	$(eval LATEST_TAG=$(shell git tag --list --sort=version:refname 'v*' | tail -1 | sed 's/^.//'))
 	$(DOCKER_CMD) buildx build \
 	--platform=linux/amd64,linux/arm64 \
 	--push \


### PR DESCRIPTION
This patch removes the 'v' that was used in the
docker image tag to follow semantic versioning