### PR TITLE
Fix docker ext release

### DIFF
--- a/.github/workflows/docker-extension-release.yml
+++ b/.github/workflows/docker-extension-release.yml
@@ -36,7 +36,9 @@ jobs:
           if [ -z $user ]; then
             user=yolossn
           fi
-          if [[${{github.event_name}} != "workflow_dispatch"]]; then  
+          if [ "${{github.event_name}}" == "workflow_dispatch" ]; then  
+              echo "Manual trigger so skipping git push"
+          else
             git config --global user.name "$user"
             git config --global user.email "$user@users.noreply.github.com"
             git diff
@@ -48,8 +50,6 @@ jobs:
             git commit --signoff -m "docker-ext: Bump Headlamp version from $lastTag to $latestTag"
             git log -1
             git push origin main
-          else
-            echo "Manual trigger so skipping git push"
           fi
       - name: Build and Publish extension to DockerHub
         run: | 

--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -5,6 +5,7 @@ FROM scratch
 LABEL org.opencontainers.image.title="Headlamp" \
     org.opencontainers.image.description="An easy-to-use and extensible web UI for Kubernetes." \
     org.opencontainers.image.vendor="kinvolk" \
+    com.docker.extension.categories="Kubernetes,utility-tools" \
     com.docker.desktop.extension.api.version=">= 0.2.0" \
     com.docker.extension.screenshots='[{"alt":"Cluster overview","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_overview.png"},{"alt":"Cluster Chooser","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_chooser.png"},{"alt":"Nodes list","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/nodes.png"},{"alt":"Resource Editor","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/resource_edition.png"},{"alt":"Editor Documentation","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/editor_documentation.png"},{"alt":"Terminal","url":"https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/terminal.png"}]' \
     com.docker.extension.detailed-description="Headlamp is an easy-to-use and extensible Kubernetes web UI. Headlamp was created to be a Kubernetes web UI that has the traditional functionality of other web UIs/dashboards available (i.e. to list and view resources) as well as other features." \

--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/headlamp-k8s/headlamp:v0.15.1 as headlamp
+FROM ghcr.io/headlamp-k8s/headlamp:v0.16.0 as headlamp
 
 FROM scratch
 

--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   headlamp:
-    image: ghcr.io/headlamp-k8s/headlamp:v0.15.1
+    image: ghcr.io/headlamp-k8s/headlamp:v0.16.0
     command: ["--kubeconfig","/headlamp/config/config", "--port","64446"]
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
The docker extension release action is also responsible for updating the base image used by the docker extension, due to a bug that was introduced when manual trigger was added to this github action the automatic updating part didn't work. This patch fixes it