### PR TITLE
Improve sidebar

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -64,7 +64,15 @@ function RouteComponent({ route }: { route: RouteType }) {
   }, [route.hideAppBar]);
 
   return (
-    <PageTitle title={t(route.name ? route.name : route.sidebar ? route.sidebar : '')}>
+    <PageTitle
+      title={t(
+        route.name
+          ? route.name
+          : typeof route.sidebar === 'string'
+          ? route.sidebar
+          : route.sidebar?.item || ''
+      )}
+    >
       <route.component />
     </PageTitle>
   );
@@ -86,7 +94,7 @@ function PageTitle({
 
 interface AuthRouteProps {
   children: React.ReactNode | JSX.Element;
-  sidebar: string | null;
+  sidebar: RouteType['sidebar'];
   requiresAuth: boolean;
   requiresCluster: boolean;
   requiresToken: () => boolean;

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -61,10 +61,10 @@ export default function NavigationTabs() {
   }
 
   let defaultIndex = null;
-  const listItems = prepareRoutes(t);
-  let navigationItem = listItems.find(item => item.name === sidebar.selected);
+  const listItems = prepareRoutes(t, sidebar.selected.sidebar || '');
+  let navigationItem = listItems.find(item => item.name === sidebar.selected.item);
   if (!navigationItem) {
-    const parent = findParentOfSubList(listItems, sidebar.selected);
+    const parent = findParentOfSubList(listItems, sidebar.selected.item);
     if (!parent) {
       return null;
     }
@@ -101,7 +101,7 @@ export default function NavigationTabs() {
       return { label: item.label, component: <></> };
     });
 
-  defaultIndex = subList.findIndex(item => item.name === sidebar.selected);
+  defaultIndex = subList.findIndex(item => item.name === sidebar.selected.item);
   return (
     <Box mb={2} component="nav" aria-label={t('frequent|Main Navigation')}>
       <Tabs

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -8,6 +8,7 @@ import { generatePath } from 'react-router';
 import { createRouteURL, getRoute } from '../../lib/router';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import ListItemLink from './ListItemLink';
+import { DefaultSidebars } from './Sidebar';
 
 const useItemStyle = makeStyles(theme => ({
   nested: {
@@ -101,6 +102,9 @@ export interface SidebarEntryProps {
    * @see https://icon-sets.iconify.design/mdi/ for icons.
    */
   icon?: IconProps['icon'];
+  /** The sidebar to display this item in. If not specified, it will be displayed in the default sidebar.
+   */
+  sidebar?: DefaultSidebars | string;
 }
 
 /**
@@ -116,7 +120,7 @@ export interface SidebarItemProps extends ListItemProps, SidebarEntryProps {
   /** Search part of the URL. */
   search?: string;
   /** If a menu item has sub menu items, they will be in here. */
-  subList?: this[];
+  subList?: Omit<this, 'sidebar'>[];
   /** Whether to hide the sidebar item. */
   hide?: boolean;
 }

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -172,8 +172,7 @@ function prepareRoutes(t: (arg: string) => string) {
 
   const items = store.getState().ui.sidebar.entries;
   const filters = store.getState().ui.sidebar.filters;
-  // @todo: Find a better way to avoid modifying the objects in LIST_ITEMS.
-  const routes: SidebarItemProps[] = JSON.parse(JSON.stringify(LIST_ITEMS));
+  const routes: SidebarItemProps[] = _.cloneDeep(LIST_ITEMS);
 
   for (const i of Object.values(items)) {
     const item = _.cloneDeep(i);

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -1,10 +1,33 @@
 import _ from 'lodash';
 import helpers from '../../helpers';
 import store from '../../redux/stores/store';
-import { SidebarItemProps } from '../Sidebar';
+import { DefaultSidebars, SidebarItemProps } from '../Sidebar';
 
-function prepareRoutes(t: (arg: string) => string) {
-  const LIST_ITEMS: SidebarItemProps[] = [
+function prepareRoutes(
+  t: (arg: string) => string,
+  sidebarToReturn: string = DefaultSidebars.IN_CLUSTER
+) {
+  const homeItems: SidebarItemProps[] = [
+    {
+      name: 'clusters',
+      icon: 'mdi:hexagon-multiple',
+      label: t('glossary|Cluster'),
+      url: '/',
+    },
+    {
+      name: 'notifications',
+      icon: 'mdi:bell',
+      label: t('frequent|Notifications'),
+      url: '/notifications',
+    },
+    {
+      name: 'settings',
+      icon: 'mdi:cog',
+      label: t('frequent|Settings'),
+      url: '/settings',
+    },
+  ];
+  const inClusterItems: SidebarItemProps[] = [
     {
       name: 'cluster',
       label: t('glossary|Cluster'),
@@ -170,14 +193,26 @@ function prepareRoutes(t: (arg: string) => string) {
     },
   ];
 
+  const sidebars: { [key: string]: SidebarItemProps[] } = {
+    [DefaultSidebars.IN_CLUSTER]: _.cloneDeep(inClusterItems),
+    [DefaultSidebars.HOME]: _.cloneDeep(homeItems),
+  };
+
   const items = store.getState().ui.sidebar.entries;
   const filters = store.getState().ui.sidebar.filters;
-  const routes: SidebarItemProps[] = _.cloneDeep(LIST_ITEMS);
 
   for (const i of Object.values(items)) {
     const item = _.cloneDeep(i);
-    const parent = item.parent ? routes.find(({ name }) => name === item.parent) : null;
-    let placement = routes;
+    // For back-compatibility reasons, the default sidebar is the in-cluster one.
+    const desiredSidebar = item.sidebar || DefaultSidebars.IN_CLUSTER;
+    let itemsSidebar = sidebars[desiredSidebar];
+    if (!itemsSidebar) {
+      itemsSidebar = [];
+      sidebars[desiredSidebar] = itemsSidebar;
+    }
+
+    const parent = item.parent ? itemsSidebar.find(({ name }) => name === item.parent) : null;
+    let placement = itemsSidebar;
     if (parent) {
       if (!parent['subList']) {
         parent['subList'] = [];
@@ -188,9 +223,12 @@ function prepareRoutes(t: (arg: string) => string) {
 
     placement.push(item);
   }
+
   // Filter the routes, if we have any filters.
+  // @todo: We need to deprecate this and implement a list processor.
   const filteredRoutes = [];
-  for (const route of routes) {
+  const defaultRoutes: SidebarItemProps[] = sidebars[DefaultSidebars.IN_CLUSTER];
+  for (const route of defaultRoutes) {
     const routeFiltered =
       filters.length > 0 && filters.filter(f => f(route)).length !== filters.length;
     if (routeFiltered) {
@@ -205,7 +243,12 @@ function prepareRoutes(t: (arg: string) => string) {
 
     filteredRoutes.push(route);
   }
-  return filteredRoutes;
+
+  if (!sidebarToReturn || sidebarToReturn === DefaultSidebars.IN_CLUSTER) {
+    return filteredRoutes;
+  }
+
+  return sidebars[sidebarToReturn];
 }
 
 export default prepareRoutes;

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -61,6 +61,7 @@ import ServiceDetails from '../components/service/Details';
 import ServiceList from '../components/service/List';
 import ServiceAccountDetails from '../components/serviceaccount/Details';
 import ServiceAccountList from '../components/serviceaccount/List';
+import { DefaultSidebars } from '../components/Sidebar';
 import StatefulSetDetails from '../components/statefulset/Details';
 import StatefulSetList from '../components/statefulset/List';
 import PersistentVolumeClaimDetails from '../components/storage/ClaimDetails';
@@ -97,8 +98,8 @@ export interface Route {
   useClusterURL?: boolean;
   /** This route does not require Authentication. */
   noAuthRequired?: boolean;
-  /** The sidebar group this Route should be in, or null if it is in no group. */
-  sidebar: string | null;
+  /** The sidebar entry this Route should enable, or null if it shouldn't enable any. If an object is passed with item and sidebar, it will try to enable the given sidebar and the given item. */
+  sidebar: string | null | { item: string | null; sidebar: string | DefaultSidebars };
   /** Shown component for this route. */
   component: () => JSX.Element;
   /** Hide the appbar at the top. */
@@ -586,7 +587,10 @@ const defaultRoutes: {
     exact: true,
     useClusterURL: false,
     name: 'Notifications',
-    sidebar: 'notifications',
+    sidebar: {
+      item: 'notifications',
+      sidebar: DefaultSidebars.HOME,
+    },
     noAuthRequired: true,
     component: () => (
       <PageGrid>
@@ -598,7 +602,10 @@ const defaultRoutes: {
     path: '/settings',
     exact: true,
     name: 'Settings',
-    sidebar: 'settings',
+    sidebar: {
+      item: 'settings',
+      sidebar: DefaultSidebars.HOME,
+    },
     useClusterURL: false,
     noAuthRequired: true,
     component: () => (

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ClusterChooserProps, ClusterChooserType } from '../components/cluster/ClusterChooser';
 import { SectionBox } from '../components/common/SectionBox';
 import { DetailsViewSectionProps, DetailsViewSectionType } from '../components/DetailsViewSection';
-import { SidebarEntryProps } from '../components/Sidebar';
+import { DefaultSidebars, SidebarEntryProps } from '../components/Sidebar';
 import { AppLogoProps, AppLogoType } from '../components/Sidebar/AppLogo';
 import { KubeObject } from '../lib/k8s/cluster';
 import { Route } from '../lib/router';
@@ -31,7 +31,7 @@ export interface SectionFuncProps {
 
 export type { AppLogoProps, AppLogoType };
 export type { ClusterChooserProps, ClusterChooserType };
-export type { SidebarEntryProps };
+export type { SidebarEntryProps, DefaultSidebars };
 export type { DetailsViewSectionProps, DetailsViewSectionType };
 export const DetailsViewDefaultHeaderActions = DefaultHeaderAction;
 
@@ -59,7 +59,7 @@ export default class Registry {
     itemName: string,
     itemLabel: string,
     url: string,
-    opts: Pick<SidebarEntryProps, 'useClusterURL' | 'icon'> = { useClusterURL: true }
+    opts: Pick<SidebarEntryProps, 'sidebar' | 'useClusterURL' | 'icon'> = { useClusterURL: true }
   ) {
     console.warn('Registry.registerSidebarItem is deprecated. Please use registerSidebarItem.');
     const { useClusterURL = true, ...options } = opts;
@@ -181,6 +181,7 @@ export function registerSidebarEntry({
   url,
   useClusterURL = true,
   icon,
+  sidebar,
 }: SidebarEntryProps) {
   store.dispatch(
     setSidebarItem({
@@ -190,6 +191,7 @@ export function registerSidebarEntry({
       parent,
       useClusterURL,
       icon,
+      sidebar,
     })
   );
 }

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -135,8 +135,8 @@ export function updateClusterAction(actionOptions: ClusterAction) {
   return { type: CLUSTER_ACTION_UPDATE, ...actionOptions };
 }
 
-export function setSidebarSelected(selected: SidebarType['selected']) {
-  return { type: UI_SIDEBAR_SET_SELECTED, selected };
+export function setSidebarSelected(selected: string | null, sidebar = '') {
+  return { type: UI_SIDEBAR_SET_SELECTED, selected: { item: selected, sidebar } };
 }
 
 export function setWhetherSidebarOpen(isSidebarOpen: boolean) {

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { SidebarEntryProps } from '../../components/Sidebar';
+import { DefaultSidebars, SidebarEntryProps } from '../../components/Sidebar';
 import helpers from '../../helpers';
 import { KubeObject } from '../../lib/k8s/cluster';
 import { Notification } from '../../lib/notification';
@@ -43,7 +43,10 @@ type HeaderActionsProcessor = {
 
 export interface UIState {
   sidebar: {
-    selected: string | null;
+    selected: {
+      item: string | null;
+      sidebar: string | DefaultSidebars | null;
+    };
     isVisible: boolean;
     isSidebarOpen?: boolean;
     /** This is only set to true/false based on a user interaction. */
@@ -106,7 +109,10 @@ function setInitialSidebarOpen() {
 export const INITIAL_STATE: UIState = {
   sidebar: {
     ...setInitialSidebarOpen(),
-    selected: null,
+    selected: {
+      item: null,
+      sidebar: null,
+    },
     isVisible: false,
     entries: {},
     filters: [],
@@ -143,7 +149,7 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
     case UI_SIDEBAR_SET_SELECTED: {
       newFilters.sidebar = {
         ...newFilters.sidebar,
-        selected: action.selected,
+        selected: { ...action.selected },
         isVisible: !!action.selected,
       };
       break;

--- a/plugins/examples/sidebar/src/index.tsx
+++ b/plugins/examples/sidebar/src/index.tsx
@@ -33,6 +33,48 @@ registerRoute({
   ),
 });
 
+// Add an entry to the home sidebar (not in cluster).
+registerSidebarEntry({
+  name: 'mypluginsidebar',
+  label: 'Special Plugin Area',
+  url: '/mypluginarea',
+  icon: 'mdi:comment-quote',
+  sidebar: 'HOME',
+});
+
+registerRoute({
+  path: '/mypluginarea',
+  sidebar: {
+    item: 'mypluginarea',
+    sidebar: 'myplugin',
+  },
+  useClusterURL: false,
+  noAuthRequired: true, // No authentication is required to see the view
+  name: 'mypluginarea',
+  exact: true,
+  component: () => (
+    <SectionBox title="Special Plugin Area" textAlign="center" paddingTop={2}>
+      <Typography>See how the home sidebar is completely new?</Typography>
+    </SectionBox>
+  ),
+});
+// Adds a completely new sidebar + entry because the sidebar "myplugin" does not exist.
+registerSidebarEntry({
+  name: 'backtoclusters',
+  label: 'Back to Clusters',
+  url: '/',
+  icon: 'mdi:hexagon',
+  sidebar: 'myplugin',
+});
+// Adds a entry to the recently created sidebar "myplugin".
+registerSidebarEntry({
+  name: 'mypluginarea',
+  label: 'Special Area',
+  url: '/mypluginarea',
+  icon: 'mdi:comment-quote',
+  sidebar: 'myplugin',
+});
+
 // Another top level sidebar menu item.
 // The sidebar link URL is: /c/mycluster/feedback2
 registerSidebarEntry({

--- a/plugins/headlamp-plugin/lib/index.ts
+++ b/plugins/headlamp-plugin/lib/index.ts
@@ -7,6 +7,7 @@ import { Headlamp, Plugin } from '../types/plugin/lib';
 import Registry, {
   AppLogoProps,
   ClusterChooserProps,
+  DefaultSidebars,
   DetailsViewDefaultHeaderActions,
   DetailsViewSectionProps,
   registerAppBarAction,
@@ -38,6 +39,7 @@ export {
   ClusterChooserProps,
   DetailsViewSectionProps,
   DetailsViewDefaultHeaderActions,
+  DefaultSidebars,
   registerAppLogo,
   registerAppBarAction,
   registerClusterChooser,


### PR DESCRIPTION
This PR improves the sidebar, more particularly, it stops special casing the "home" sidebar and now supports having several sidebars, creating new ones, and controlling them from plugins.
It also fixes smaller issues like the special casing of the sidebar matching routes by name or cloning default routes by stringifying/unstringifying them...

This was part of the multi-cluster improvements but it's important enough that we can treat it separately.

Unfortunately, due to not easily being able to import types from plugins, I couldn't use the `DefaultSidebars.HOME` constant to refer to the home sidebar. Maybe @illume has a solution for this.

How to test:
- [ ] Verify there are no regressions to the default sidebars' behavior
- [ ] Verify there are no regressions to how the sidebar plugins behave (except for the new functionality)
