### PR TITLE
frontend: Go back using the "back" function from load-kube-config

### DIFF
--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -253,7 +253,7 @@ function KubeConfigLoader() {
               </FormControl>
             </Box>
             <Box style={{ display: 'flex', justifyContent: 'center' }}>
-              <Button onClick={() => history.push('/')} className={classes.wideButton}>
+              <Button onClick={() => history.goBack()} className={classes.wideButton}>
                 {t('frequent|Back')}
               </Button>
             </Box>


### PR DESCRIPTION
Instead of always going back to the root location, the
load-kube-config dialog should go back to whatever location that
originated it, so this patch adds that behavior.
