### PR TITLE
ci: add multi-platform (arm64) Docker images

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -74,5 +74,10 @@ jobs:
       with:
         context: .
         push: true
+        pull: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ env.CONTAINER_TAGS }}
         labels: ${{ steps.meta.outputs.labels }}
+        provenance: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_REPO ?= ghcr.io/headlamp-k8s
 DOCKER_EXT_REPO ?= docker.io/headlamp
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)
-DOCKER_IMAGE_BASE ?= alpine:3.17.0
+DOCKER_PLATFORM ?= local
 
 ifeq ($(OS), Windows_NT)
 	SERVER_EXE_EXT = .exe
@@ -83,8 +83,9 @@ plugins-test:
 	cd plugins/headlamp-plugin && ./test-plugins-examples.sh
 
 image:
-	$(DOCKER_CMD) build \
-	--build-arg IMAGE_BASE=$(DOCKER_IMAGE_BASE) \
+	$(DOCKER_CMD) buildx build \
+	--pull \
+	--platform=$(DOCKER_PLATFORM) \
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile \
 	.


### PR DESCRIPTION
Refactor the Docker image to support cross-compiling and update the CI pipeline to publish arm64 images in addition to the amd64 images already being published.

There's also some general improvements here, e.g. the Go builds copy `go.{mod,sum}` and run `go mod download`, cache volumes, use of `COPY --link`, removal of unnecessary base images.

This removes the symlink for `/headlamp/server`, which has been around for almost a year for compatibility. (Keeping it will add a dependency on QEMU to run the `cd` / `ln` commands, as it's the only command run in the final image, which is for the _target_ arch, not the _build_ arch.)

CI also uses GitHub Actions cache now - free speed-up!

The builds are also done with `pull: true` to ensure that the latest Go / Node / Alpine patch versions get used.

Additionally, the images publish provenance metadata.

Fixes #369.