### PR TITLE
app: Notarize with ascProvider set

### DIFF
--- a/app/mac/scripts/notarize.js
+++ b/app/mac/scripts/notarize.js
@@ -14,5 +14,6 @@ exports.default = async function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,
     appleIdPassword: process.env.APPLEIDPASS,
+    ascProvider: process.env.ASCPROVIDER,
   });
 };


### PR DESCRIPTION
This is required if there are multiple keys set up on the machine doing the notarization.