### PR TITLE
headlamp-plugin: Fix npm start to also copy package.json

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -246,6 +246,10 @@ function start() {
                 source: './dist/*',
                 destination: path.join(configDir, 'plugins', packageName),
               },
+              {
+                source: './package.json',
+                destination: path.join(configDir, 'plugins', packageName, 'package.json'),
+              },
             ],
           },
         },


### PR DESCRIPTION
Before, only the extract command copied it. But this meant that during development using npm start, the package.json file was not copied.