### PR TITLE
frontend: Clone the clusters conf to prevent direct state changes

### DIFF
--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { ConfigState } from '../../redux/reducers/config';
@@ -80,7 +81,7 @@ export const ResourceClasses = resourceClassesDict;
 
 // Hook for getting or fetching the clusters configuration.
 export function useClustersConf(): ConfigState['clusters'] {
-  const clusters = useTypedSelector(state => state.config.clusters);
+  const clusters = _.cloneDeep(useTypedSelector(state => state.config.clusters));
   return clusters;
 }
 

--- a/frontend/src/redux/reducers/clusterAction.tsx
+++ b/frontend/src/redux/reducers/clusterAction.tsx
@@ -11,7 +11,7 @@ export const INITIAL_STATE: ClusterState = {
 
 function cluster(clusterActions = _.cloneDeep(INITIAL_STATE), action: ClusterAction & Action) {
   const { type, id, ...actionOptions } = action;
-  const newState = { ...clusterActions };
+  const newState = { ..._.cloneDeep(clusterActions) };
   switch (type) {
     case CLUSTER_ACTION_UPDATE:
       if (_.isEmpty(actionOptions)) {

--- a/frontend/src/redux/reducers/config.tsx
+++ b/frontend/src/redux/reducers/config.tsx
@@ -37,7 +37,7 @@ export interface ConfigAction extends Action {
 }
 
 function reducer(state = _.cloneDeep(INITIAL_STATE), action: ConfigAction) {
-  const newState = { ...state };
+  const newState = { ..._.cloneDeep(state) };
   switch (action.type) {
     case CONFIG_NEW: {
       newState.clusters = { ...action.config.clusters };

--- a/frontend/src/redux/reducers/filter.tsx
+++ b/frontend/src/redux/reducers/filter.tsx
@@ -8,7 +8,7 @@ export const INITIAL_STATE: FilterState = {
 };
 
 function filter(filters = _.cloneDeep(INITIAL_STATE), action: Action) {
-  let newFilters = { ...filters };
+  let newFilters = { ..._.cloneDeep(filters) };
   switch (action.type) {
     case FILTER_SET_NAMESPACE:
       newFilters.namespaces = new Set(action.namespaces);

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -144,7 +144,8 @@ export const INITIAL_STATE: UIState = {
 };
 
 function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
-  const newFilters = { ...state };
+  const newFilters = { ..._.cloneDeep(state) };
+
   switch (action.type) {
     case UI_SIDEBAR_SET_SELECTED: {
       newFilters.sidebar = {


### PR DESCRIPTION
The auth chooser was getting an error when checking for a cluster's
auth because of how the cluster's state is set. It sets the state
directly and then calls dispatch, but since the object being modified
is the same that redux holds, redux detected this and it threw an
exception.

To prevent this case, the useClustersConf hook now returns a copy of
the state instead.
