### PR TITLE
frontend: Fix plugins settings sidebar entry

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -20,7 +20,7 @@ import CreateButton from '../common/Resource/CreateButton';
 import HeadlampButton from './HeadlampButton';
 import NavigationTabs from './NavigationTabs';
 import prepareRoutes from './prepareRoutes';
-import SidebarItem, { SidebarEntryProps, SidebarItemProps } from './SidebarItem';
+import SidebarItem, { SidebarEntryProps } from './SidebarItem';
 import VersionButton from './VersionButton';
 
 export const drawerWidth = 330;
@@ -83,37 +83,6 @@ const useButtonStyle = makeStyles({
 
 export default function Sidebar() {
   const { t, i18n } = useTranslation(['glossary', 'frequent']);
-
-  const settingsMenu: SidebarItemProps = {
-    name: 'settings',
-    icon: 'mdi:cog',
-    label: t('frequent|Settings'),
-    url: '/settings',
-  };
-
-  const specialSidebarOptions: SidebarItemProps[] = [
-    {
-      name: 'clusters',
-      icon: 'mdi:hexagon-multiple',
-      label: t('glossary|Cluster'),
-      url: '/',
-    },
-    {
-      name: 'notifications',
-      icon: 'mdi:bell',
-      label: t('frequent|Notifications'),
-      url: '/notifications',
-    },
-  ];
-
-  specialSidebarOptions.push(settingsMenu);
-
-  /** Only adds settings menu when running as an App*/
-  if (helpers.isElectron() === true) {
-    settingsMenu.subList = [
-      { name: 'plugins', label: t('settings|Plugins'), url: '/settings/plugins' },
-    ];
-  }
 
   const sidebar = useTypedSelector(state => state.ui.sidebar);
   const isSidebarOpen = useTypedSelector(state => state.ui.sidebar.isSidebarOpen);

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -25,6 +25,14 @@ function prepareRoutes(
       icon: 'mdi:cog',
       label: t('frequent|Settings'),
       url: '/settings',
+      subList: [
+        {
+          name: 'plugins',
+          label: t('settings|Plugins'),
+          url: '/settings/plugins',
+          hide: !helpers.isElectron(),
+        },
+      ],
     },
   ];
   const inClusterItems: SidebarItemProps[] = [

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -645,7 +645,10 @@ const defaultRoutes: {
     path: '/settings/plugins',
     exact: true,
     name: 'Plugins',
-    sidebar: 'plugins',
+    sidebar: {
+      item: 'plugins',
+      sidebar: DefaultSidebars.HOME,
+    },
     useClusterURL: false,
     noAuthRequired: true,
     disabled: !helpers.isElectron(),


### PR DESCRIPTION
It was not migrated to the new way sidebars are defined, so it was
no longer visible. This patch removes the legacy code and sets up
the sidebar properly.
