### PR TITLE
WIP: frontend registerAppBarAction: fixes state mutation error

### DIFF
--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -144,7 +144,8 @@ export const INITIAL_STATE: UIState = {
 };
 
 function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
-  const newFilters = { ...state };
+  // const newFilters = { ...state };
+  const newFilters = _.cloneDeep(state);
   switch (action.type) {
     case UI_SIDEBAR_SET_SELECTED: {
       newFilters.sidebar = {


### PR DESCRIPTION
Fixes for issue #1088 

Currently:

![image](https://user-images.githubusercontent.com/78232183/233128476-bf7f2395-1dde-40a9-a566-b4f70bda2663.png)

Similar to the screenshot in the original issue, I am able to replicate the error in the browser console by parsing through the error messages at the root dir of my local dev env. The original screenshot delivers the error for plugins\cop, but I am using the headlamp-pod-counter plugin (the only plugin I ran) and the same error is delivered.

I implemented the suggested change Rene had mentioned when overviewing the issue, changing the newFilters const variable to be a clone. 

By changing  `const newFilters = { ...state }` to `const newFilters = _.cloneDeep(state)` within the reducer function in headlamp/frontend/src/redux/reducers/ui.tsx, and reloading the home dir in the dev env, I no longer see the error message.

I will continue to look for alternative solutions if this is not a whole fix, including implementation of a redux slice.