### PR TITLE
frontend: Add node version and services selector into list

### DIFF
--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -58,6 +58,10 @@ export default function NodeList() {
               />
             ),
           },
+          {
+            label: t('Version'),
+            getter: node => node.status.nodeInfo.kubeProxyVersion,
+          },
           'age',
         ]}
       />

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -60,7 +60,7 @@ export default function NodeList() {
           },
           {
             label: t('Version'),
-            getter: node => node.status.nodeInfo.kubeProxyVersion,
+            getter: node => node.status.nodeInfo.kubeletVersion,
           },
           'age',
         ]}

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import Service from '../../lib/k8s/service';
+import { StatusLabel } from '../common';
 import ResourceTable from '../common/Resource/ResourceTable';
 import { SectionBox } from '../common/SectionBox';
 import SectionFilterHeader from '../common/SectionFilterHeader';
@@ -28,6 +29,20 @@ export default function ServiceList() {
             label: t('External IP'),
             getter: service => service.getExternalAddresses(),
             sort: true,
+          },
+          {
+            label: 'Selector',
+            getter: service => {
+              const selectors: JSX.Element[] = [];
+              Object.keys(service.spec.selector).forEach((key: string) => {
+                selectors.push(
+                  <StatusLabel key={key} status="">
+                    {key}={service.spec.selector[key]}
+                  </StatusLabel>
+                );
+              });
+              return <>{selectors}</>;
+            },
           },
           'age',
         ]}

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import Service from '../../lib/k8s/service';
-import { StatusLabel } from '../common';
 import ResourceTable from '../common/Resource/ResourceTable';
 import { SectionBox } from '../common/SectionBox';
 import SectionFilterHeader from '../common/SectionFilterHeader';
@@ -29,20 +28,6 @@ export default function ServiceList() {
             label: t('External IP'),
             getter: service => service.getExternalAddresses(),
             sort: true,
-          },
-          {
-            label: 'Selector',
-            getter: service => {
-              const selectors: JSX.Element[] = [];
-              Object.keys(service.spec.selector).forEach((key: string) => {
-                selectors.push(
-                  <StatusLabel key={key} status="">
-                    {key}={service.spec.selector[key]}
-                  </StatusLabel>
-                );
-              });
-              return <>{selectors}</>;
-            },
           },
           'age',
         ]}


### PR DESCRIPTION
To keep the same output with kubectl, I made following changes:
* Add selector for services list
![image](https://user-images.githubusercontent.com/13809749/234524043-9ae75132-4cbe-46ba-8a5f-88d59344f57e.png)

* Add node version to node list
![image](https://user-images.githubusercontent.com/13809749/234523962-c078cfc8-5785-4b97-8556-1bd7435cbaeb.png)
