### PR TITLE
backend: Remove not required helm annotations

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -687,10 +687,7 @@ func (h *Handler) upgradeRelease(req UpgradeReleaseRequest) {
 		logActionState(zlog.Error(), err, "upgrade", req.Chart, req.Name, "failed", "values un-marshalling failed")
 		return
 	}
-	// add headlamp chart metadata
-	values["dev.headlamp.metadata"] = map[string]string{
-		"chartName": req.Chart,
-	}
+
 	// Upgrade chart
 	_, err = upgradeClient.Run(req.Name, chart, values)
 	if err != nil {


### PR DESCRIPTION
We don't need helm annotations now that we get the chart version.