### PR TITLE
chocolatey: Bump Headlamp version to 0.17.0

### DIFF
--- a/app/windows/chocolatey/headlamp.nuspec
+++ b/app/windows/chocolatey/headlamp.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>headlamp</id>
-    <version>0.16.0</version>
+    <version>0.17.0</version>
     <packageSourceUrl>https://github.com/headlamp-k8s/headlamp/tree/main/app/windows/chocolatey</packageSourceUrl>
     <title>Headlamp</title>
     <authors>Kinvolk</authors>

--- a/app/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/app/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$headlampVersion = '0.16.0'
+$headlampVersion = '0.17.0'
 $url = "https://github.com/headlamp-k8s/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
-$checksum = '4adafcfc43132c1cb2113cf884b66ed3841252ea0d0f035dbe0d826d011db01e'
+$checksum = '6d5b418444b69847e2d23ba61ea610326367555be71bd70f1246cb4391a24df1'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
Choco bump. Version already tested locally and pushed to Chocolatey's registry.