### PR TITLE
frontend backend app: Prevent unauthorized access to helm endpoints

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1025,9 +1025,28 @@ func getHelmHandler(c *HeadlampConfig, w http.ResponseWriter, r *http.Request) (
 	return helmHandler, nil
 }
 
+// Check request for header "X-HEADLAMP_BACKEND-TOKEN" matches HEADLAMP_BACKEND_TOKEN env
+// This check is to prevent access except for from the app.
+// The app sets HEADLAMP_BACKEND_TOKEN, and gives the token to the frontend.
+func checkHeadlampBackendToken(w http.ResponseWriter, r *http.Request) error {
+	backendToken := r.Header.Get("X-HEADLAMP_BACKEND-TOKEN")
+	backendTokenEnv := os.Getenv("HEADLAMP_BACKEND_TOKEN")
+
+	if backendToken != backendTokenEnv || backendTokenEnv == "" {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return errors.New("X-HEADLAMP_BACKEND-TOKEN does not match HEADLAMP_BACKEND_TOKEN")
+	}
+
+	return nil
+}
+
 //nolint:gocognit,funlen
 func handleClusterHelm(c *HeadlampConfig, router *mux.Router) {
 	router.PathPrefix("/clusters/{clusterName}/helm/{.*}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := checkHeadlampBackendToken(w, r); err != nil {
+			return
+		}
+
 		helmHandler, err := getHelmHandler(c, w, r)
 		if err != nil {
 			return
@@ -1204,6 +1223,10 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 
 //nolint:funlen,nestif
 func (c *HeadlampConfig) addCluster(w http.ResponseWriter, r *http.Request) {
+	if err := checkHeadlampBackendToken(w, r); err != nil {
+		return
+	}
+
 	clusterReq := ClusterReq{}
 	if err := json.NewDecoder(r.Body).Decode(&clusterReq); err != nil {
 		http.Error(w, "Error decoding cluster info", http.StatusBadRequest)
@@ -1296,6 +1319,10 @@ func (c *HeadlampConfig) addCluster(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *HeadlampConfig) deleteCluster(w http.ResponseWriter, r *http.Request) {
+	if err := checkHeadlampBackendToken(w, r); err != nil {
+		return
+	}
+
 	name := mux.Vars(r)["name"]
 	if _, ok := c.contextProxies[name]; !ok {
 		http.Error(w, "Cluster not found", http.StatusNotFound)

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -235,6 +235,28 @@ function loadClusterSettings(clusterName: string): ClusterSettings {
   return settings;
 }
 
+/**
+ * The backend token to use when making API calls from Headlamp when running as an app.
+ * The app opens the index.html?backendToken=... and passes the token to the frontend
+ * in this way. The token is then used in the getHeadlampAPIHeaders function below.
+ *
+ * The app also passes the token to the headlamp-server via HEADLAMP_BACKEND_TOKEN env var.
+ */
+const backendToken = new URLSearchParams(window.location.search).get('backendToken');
+
+/**
+ * Returns headers for making API calls to the headlamp-server backend.
+ */
+export function getHeadlampAPIHeaders(): { [key: string]: string } {
+  if (backendToken === null) {
+    return {};
+  }
+
+  return {
+    'X-HEADLAMP_BACKEND-TOKEN': backendToken,
+  };
+}
+
 const exportFunctions = {
   getBaseUrl,
   isDevMode,
@@ -254,6 +276,7 @@ const exportFunctions = {
   defaultMaxNotificationsStored,
   storeClusterSettings,
   loadClusterSettings,
+  getHeadlampAPIHeaders,
 };
 
 export default exportFunctions;

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -11,6 +11,7 @@ import { OpPatch } from 'json-patch';
 import _ from 'lodash';
 import { decodeToken } from 'react-jwt';
 import helpers from '../../helpers';
+import { getHeadlampAPIHeaders } from '../../helpers';
 import store from '../../redux/stores/store';
 import { getToken, logout, setToken } from '../auth';
 import { getCluster } from '../util';
@@ -872,14 +873,23 @@ export async function testAuth() {
 export async function setCluster(clusterReq: ClusterRequest) {
   return request(
     '/cluster',
-    { method: 'POST', body: JSON.stringify(clusterReq), headers: JSON_HEADERS },
+    {
+      method: 'POST',
+      body: JSON.stringify(clusterReq),
+      headers: { ...JSON_HEADERS, ...getHeadlampAPIHeaders() },
+    },
     false,
     false
   );
 }
 
 export async function deleteCluster(cluster: string) {
-  return request(`/cluster/${cluster}`, { method: 'DELETE' }, false, false);
+  return request(
+    `/cluster/${cluster}`,
+    { method: 'DELETE', headers: { ...getHeadlampAPIHeaders() } },
+    false,
+    false
+  );
 }
 
 export function startPortForward(

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -9,6 +9,7 @@ import { Headlamp, Plugin } from './lib';
 import { PluginInfo } from './pluginsSlice';
 import Registry, {
   DetailsViewDefaultHeaderActions,
+  getHeadlampAPIHeaders,
   registerAppBarAction,
   registerAppLogo,
   registerClusterChooser,
@@ -60,6 +61,7 @@ window.pluginLib = {
   registerGetTokenFunction,
   registerDetailsViewHeaderActionsProcessor,
   DetailsViewDefaultHeaderActions,
+  getHeadlampAPIHeaders,
 };
 
 // @todo: should window.plugins be private?

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -4,6 +4,7 @@ import { SectionBox } from '../components/common/SectionBox';
 import { DetailsViewSectionProps, DetailsViewSectionType } from '../components/DetailsViewSection';
 import { DefaultSidebars, SidebarEntryProps } from '../components/Sidebar';
 import { AppLogoProps, AppLogoType } from '../components/Sidebar/AppLogo';
+import { getHeadlampAPIHeaders } from '../helpers';
 import { KubeObject } from '../lib/k8s/cluster';
 import { Route } from '../lib/router';
 import {
@@ -447,3 +448,5 @@ export function registerSetTokenFunction(
 export function registerGetTokenFunction(override: (cluster: string) => string | undefined) {
   store.dispatch(setFunctionsToOverride({ getToken: override }));
 }
+
+export { getHeadlampAPIHeaders };


### PR DESCRIPTION
This prevents some backend endpoints from being called unless there is a token passed in via the X-HEADLAMP_BACKEND-TOKEN header. The app generates the token and then sets HEADLAMP_BACKEND_TOKEN environment variable which the backend uses. This also makes available a getHeadlampAPIHeaders() function which can be used by the frontend and plugins to add headers to API endpoints that the backend serves. App creates token and sends it to the backend and frontend. This prevents unauthorized connections to the helm chart endpoints. The threat was that any connection from a Browser or localhost process could call helm and dynamic cluster creation endpoints.

Here's the steps of how the token gets generated, passed around and checked:

- [x] app/ generates a token (`backendToken`)
- [x] app starts backend with `backendToken` (via HEADLAMP_BACKEND_TOKEN env var)
- [x] backend opens frontend URL with ?backendToken=XXX
- [x] frontend takes `?backendToken=XXX` in app mode
  - [x] `getHeadlampAPIHeaders()` API function made available to frontend
  - [x] plugins have `getHeadlampAPIHeaders()` API function made available to frontend
- [x] backend checks API calls have backendtoken `X-HEADLAMP_BACKEND-TOKEN header == HEADLAMP_BACKEND_TOKEN env var`
  - [x] helm chart api calls
  - [x] dynamic cluster endpoint creation
- [x] use `getHeadlampAPIHeaders` for setCluster and deleteCluster in the frontend/.

# how to use

Here's how you use the headers for `fetch()` in a plugin:
```ts
import { getHeadlampAPIHeaders } from '@kinvolk/headlamp-plugin/lib';
fetch(url, {headers: getHeadlampAPIHeaders()})
```
