### PR TITLE
frontend NavigationTabs: Plugin Settings Nav Links Fix

### DIFF
--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -76,19 +76,27 @@ export default function NavigationTabs() {
     return null;
   }
 
+  /**
+   * This function is used to handle the tab change event.
+   *
+   * @param index The index of the tab that was clicked.
+   * @returns void
+   */
   function tabChangeHandler(index: number) {
     if (!subList) {
       return;
     }
-    let pathname;
 
     const url = subList[index].url;
-    if (url) {
-      pathname = generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! });
+    if (url && getCluster()) {
+      history.push({
+        pathname: generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! }),
+      });
+    } else if (url) {
+      history.push(url);
     } else {
-      pathname = createRouteURL(subList[index].name);
+      history.push({ pathname: createRouteURL(subList[index].name) });
     }
-    history.push({ pathname });
   }
 
   if (createRouteURL(navigationItem.name)) {


### PR DESCRIPTION
Fixes for issue #1115

Essentially, this an issue on the desktop app when the user is within a small screen view and on the settings page, if you click the navigation tab while in settings or plugins they do not work.

![image](https://user-images.githubusercontent.com/78232183/235674021-c70f813c-750f-4eac-91a2-1b890b3262d7.png)

I was able to track the issue down while trouble shooting it in web environment and it seems to do a few things.

The first lead with this issue occurs within the console
<img width="539" alt="image" src="https://user-images.githubusercontent.com/78232183/235673136-6a685165-edd6-46f7-8af5-8dfbab416381.png">

Currently:
PLEASE NOTE: Currently debugging this issue from the web client, the router.tsx file has been edited to work with web client, under the plugins route field, disabled is temporarily set as `disabled: helpers.isElectron()` and will be reset to `disabled: !helpers.isElectron()`

- I have tried turning on and off useCluster field as well as trying to use noCluster (although its deprecated) within the router.tsx file although neither of which seems to impact the issue.
- I am currently debugger walking through the NavigationTabs.tsx file attempting to locate any console logs to further pin point the error, the console logs currently do not print.
- It seems the error may be related to a null field being used within the paths being created by either the function getClusterPrefixedPath() or the getCluster() function being used within the NavigationTabs.tsx file 
<img width="428" alt="image" src="https://user-images.githubusercontent.com/78232183/235675990-6412dce2-88a8-40e1-bc20-6035e7f4e608.png">
