### PR TITLE
Fix loading kubeconfig

### DIFF
--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -65,7 +65,7 @@ function configWithSelectedClusters(config: kubeconfig, selectedClusters: string
     clusters[cluster.name] = cluster;
 
     // Optionally add the user.
-    const user = config.users.find(c => c.name === context.context.user);
+    const user = config.users?.find(c => c.name === context.context.user);
     if (!!user) {
       users[user.name] = user;
     }

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -199,6 +199,9 @@ function KubeConfigLoader() {
           ...new Uint8Array(reader.result as ArrayBuffer),
         ]);
         const doc = yaml.load(data) as kubeconfig;
+        if (!doc.clusters || !doc.contexts) {
+          throw new Error('Invalid kubeconfig file');
+        }
         setFileContent(doc);
       } catch (err) {
         setError(t('cluster|Load a valid kubeconfig'));


### PR DESCRIPTION
fixes #1107

How to test:
- [ ] Run Headlamp in desktop and click to load a kube cluster; then select a JSON or YAML file that is NOT a valid kubeconfig -> it should show the error banner in the load dialog
- [ ] Do the same with a file that's not a JSON or YAML file -> should show the same error