### PR TITLE
Misc improvements for loading a cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ frontend-build-storybook:
 	cd frontend && npm run build-storybook
 
 run-backend:
-	./backend/headlamp-server -dev
+	@echo "**** Warning: Running with Helm and dynamic-clusters endpoints enabled. ****"
+	@echo
+	HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev
 
 run-frontend:
 	cd frontend && npm start

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -405,6 +405,8 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 
 	log.Printf("static plugin dir: %s\n", config.staticPluginDir)
 	log.Printf("plugins-dir: %s\n", config.pluginDir)
+	log.Printf("dynamic clusters support: %v\n", config.enableDynamicClusters)
+	log.Printf("Helm support: %v\n", config.enableHelm)
 
 	if !config.useInCluster {
 		// in-cluster mode is unlikely to want reloading plugins.

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -175,8 +175,10 @@ function KubeConfigLoader() {
               setState(Step.Success);
             }
           })
-          .catch(() => {
+          .catch(e => {
+            console.debug('Error setting up clusters from kubeconfig:', e);
             setError(t('cluster|Error setting up clusters, please load a valid kubeconfig file'));
+            setState(Step.SelectClusters);
           });
       }
       loadClusters();

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -317,7 +317,10 @@ function KubeConfigLoader() {
                     </Grid>
                     <Grid item>
                       <Button
-                        onClick={() => setState(Step.LoadKubeConfig)}
+                        onClick={() => {
+                          setError('');
+                          setState(Step.LoadKubeConfig);
+                        }}
                         className={classes.wideButton}
                       >
                         {t('frequent|Back')}


### PR DESCRIPTION
How to test:
- [ ] Run `make run-backend`: verify that the backend prints info that the Helm + dynamic-clusters are enabled
- [ ] Run the backend without enabling the dynamic-clusters; in the desktop app, start adding a cluster and select a value kube config and then a value cluster: it should show an error and go back to the cluster selection with the error banner (because the backend will not have the dynamic-cluster)
  - [ ] Click `back`: It should go back to the kube config loader view and no longer show the error dialog