### PR TITLE
backend: Fix --html-static-dir cmd line option on windows

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -72,6 +72,8 @@ const (
 	STOPPED = "Stopped"
 )
 
+const isWindows = runtime.GOOS == "windows"
+
 type PortForward struct {
 	ID               string `json:"id"`
 	closeChan        chan struct{}
@@ -192,22 +194,15 @@ func getPortForwardByID(cluster string, id string) PortForward {
 }
 
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// get the absolute path to prevent directory traversal
-	path, err := filepath.Abs(r.URL.Path)
-	if err != nil {
-		// if we failed to get the absolute path respond with a 400 bad request
-		// and stop
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
+	// Clean the path to prevent directory traversal
+	path := filepath.Clean(r.URL.Path)
 	path = strings.TrimPrefix(path, h.baseURL)
 
 	// prepend the path with the path to the static directory
 	path = filepath.Join(h.staticPath, path)
 
 	// check whether a file exists at the given path
-	_, err = os.Stat(path)
+	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		// file does not exist, serve index.html
 		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
@@ -364,7 +359,7 @@ func defaultKubeConfigPersistenceDir() (string, error) {
 	userConfigDir, err := os.UserConfigDir()
 	if err == nil {
 		kubeConfigDir := filepath.Join(userConfigDir, "Headlamp", "kubeconfigs")
-		if runtime.GOOS == "windows" {
+		if isWindows {
 			// golang is wrong for config folder on windows.
 			// This matches env-paths and headlamp-plugin.
 			kubeConfigDir = filepath.Join(userConfigDir, "Headlamp", "Config", "kubeconfigs")
@@ -823,7 +818,16 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 
 	// Serve the frontend if needed
 	if config.staticDir != "" {
-		spa := spaHandler{staticPath: config.staticDir, indexPath: "index.html", baseURL: config.baseURL}
+		staticPath := config.staticDir
+
+		if isWindows {
+			// We support unix paths on windows. So "frontend/static" works.
+			if strings.Contains(config.staticDir, "/") {
+				staticPath = filepath.FromSlash(config.staticDir)
+			}
+		}
+
+		spa := spaHandler{staticPath: staticPath, indexPath: "index.html", baseURL: config.baseURL}
 		r.PathPrefix("/").Handler(spa)
 
 		http.Handle("/", r)


### PR DESCRIPTION
The path cleaning didn't work on windows.

Additionally, support unix paths for html-static-dir like 'frontend/build'.

Fixes #1094


## How to test?

- build on windows
- use cmd (not bash) and run `backend\headlamp-server.exe --dev=true --proxy-urls=* --html-static-dir=frontend/build`
- http://localhost:4466/static/ should work
- directory traversal should not work. Eg. `http://localhost:4466/../../../etc/passwd`