### PR TITLE
Fix namespace pods

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -759,7 +759,14 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
 
   const [pods, error] = Pod.useList(queryData);
 
-  return <PodListRenderer hideColumns={hideColumns} pods={pods} error={error} />;
+  return (
+    <PodListRenderer
+      hideColumns={hideColumns}
+      pods={pods}
+      error={error}
+      noNamespaceFilter={resource.kind === 'Namespace'}
+    />
+  );
 }
 
 export function ContainersSection(props: { resource: KubeObjectInterface | null }) {

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -53,10 +53,11 @@ export interface PodListProps {
   error: ApiError | null;
   hideColumns?: ('namespace' | 'restarts')[];
   reflectTableInURL?: SimpleTableProps['reflectInURL'];
+  noNamespaceFilter?: boolean;
 }
 
 export function PodListRenderer(props: PodListProps) {
-  const { pods, error, hideColumns = [], reflectTableInURL = 'pods' } = props;
+  const { pods, error, hideColumns = [], reflectTableInURL = 'pods', noNamespaceFilter } = props;
   const { t } = useTranslation('glossary');
 
   function getDataCols() {
@@ -116,7 +117,9 @@ export function PodListRenderer(props: PodListProps) {
   }
 
   return (
-    <SectionBox title={<SectionFilterHeader title={t('Pods')} />}>
+    <SectionBox
+      title={<SectionFilterHeader title={t('Pods')} noNamespaceFilter={noNamespaceFilter} />}
+    >
       <ResourceTable
         errorMessage={Pod.getErrorMessage(error)}
         columns={getDataCols()}

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -1,5 +1,5 @@
 import { OpPatch } from 'json-patch';
-import { unset } from 'lodash';
+import { cloneDeep, unset } from 'lodash';
 import React from 'react';
 import helpers from '../../helpers';
 import { createRouteURL } from '../router';
@@ -264,7 +264,7 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       }
 
       const listCalls = [];
-      const queryParams = opts;
+      const queryParams = cloneDeep(opts);
       let namespaces: string[] = [];
       unset(queryParams, 'namespace');
 


### PR DESCRIPTION
fixes #1128 

Acceptance criteria

- [ ] Go to the namespace detail view of a namespace
- [ ] Check if all the pods listed are only of the namespace you are in
- [ ] Open the table filter of pods list in namespace detail view and you will see we don't have the redundant namespace filter now