### PR TITLE
frontend: Do not show namespace filter in resources' namespace

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -758,13 +758,14 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   };
 
   const [pods, error] = Pod.useList(queryData);
+  const onlyOneNamespace = !!resource.metadata.namespace || resource.kind === 'Namespace';
 
   return (
     <PodListRenderer
-      hideColumns={hideColumns}
+      hideColumns={hideColumns || onlyOneNamespace ? ['namespace'] : undefined}
       pods={pods}
       error={error}
-      noNamespaceFilter={resource.kind === 'Namespace'}
+      noNamespaceFilter={onlyOneNamespace}
     />
   );
 }


### PR DESCRIPTION
How to test:
- [ ] Go to the pods list in a namespace or node view: there should be a namespace table and namespace filter available for the pod table
- [ ] Go to the general pods list view + pod list view of a resource like deployment, replicaset, etc.: verify that no namespace column and no namespace filter is available for the pod table