### PR TITLE
frontend: Check useClusterURL in NavigationTabs

### DIFF
--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -88,7 +88,8 @@ export default function NavigationTabs() {
     }
 
     const url = subList[index].url;
-    if (url && getCluster()) {
+    const useClusterURL = !!subList[index].useClusterURL;
+    if (url && useClusterURL && getCluster()) {
       history.push({
         pathname: generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! }),
       });


### PR DESCRIPTION
NavigationTabs were only checking if a cluster exists in getCluster()
and were ignoring whether the respective sidebar entry actually needs
a cluster for creating the URL to begin with.
This patch uses the mentioned boolean parameter of the sidebar entry
before attempting to use the cluster, thus fixing this issue.
