### PR TITLE
frontend lib/k8s: Fix useConnectApi to depend on cluster not location

### DIFF
--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -111,8 +111,7 @@ export type CancellablePromise = Promise<() => void>;
 export function useConnectApi(...apiCalls: (() => CancellablePromise)[]) {
   // Use the location to make sure the API calls are changed, as they may depend on the cluster
   // (defined in the URL ATM).
-  // @todo: Update this if the active cluster management is changed.
-  const location = useLocation();
+  const cluster = useCluster();
 
   React.useEffect(
     () => {
@@ -127,7 +126,7 @@ export function useConnectApi(...apiCalls: (() => CancellablePromise)[]) {
     // If we add the apiCalls to the dependency list, then it actually
     // results in undesired reloads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [location]
+    [cluster]
   );
 }
 


### PR DESCRIPTION
Before every time the location changed this was being recalled. This lead to some pretty big unneeded network calls and recalculations every time a URL was changed... even when the cluster had not changed.

It should help performance on large clusters because there are less network calls that aren't needed, and also less recalculations.

### How to test?

- [ ] Check the network tab for 'event' calls. When changing location it should not do a network call each page you visit.
- [ ] When changing the cluster it should do extra 'event' calls.
- [ ] Everything else should also work as before.


cc / @lijianzhi01 
related to https://github.com/headlamp-k8s/headlamp/issues/1161