### PR TITLE
frontend ResourceTable: Throttle data updates to 1Hz

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '@material-ui/core/styles';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KubeObject } from '../../../lib/k8s/cluster';
 import { useFilterFunc } from '../../../lib/util';
@@ -39,16 +40,57 @@ export default function ResourceTable(
   return <Table {...(props as ResourceTableProps)} />;
 }
 
+/**
+ * Returns a throttled version of the input value.
+ *
+ * @param value - The value to be throttled.
+ * @param interval - The interval in milliseconds to throttle the value.
+ * @returns The throttled value.
+ */
+export function useThrottle(value: any, interval = 1000): any {
+  const [throttledValue, setThrottledValue] = useState(value);
+  const lastEffected = useRef(Date.now() + interval);
+
+  // Ensure we don't throttle holding the loading null or undefined value before
+  // real data comes in. Otherwise we could wait up to interval milliseconds
+  // before we update the throttled value.
+  //
+  //   numEffected == 0,  null, or undefined whilst loading.
+  //   numEffected == 1,  real data.
+  const numEffected = useRef(0);
+
+  useEffect(() => {
+    const now = Date.now();
+
+    if (now >= lastEffected.current + interval || numEffected.current < 2) {
+      numEffected.current = numEffected.current + 1;
+      lastEffected.current = now;
+      setThrottledValue(value);
+    } else {
+      const id = window.setTimeout(() => {
+        lastEffected.current = now;
+        setThrottledValue(value);
+      }, interval);
+
+      return () => window.clearTimeout(id);
+    }
+  }, [value, interval]);
+
+  return throttledValue;
+}
+
 function TableFromResourceClass(props: ResourceTableFromResourceClassProps) {
   const { resourceClass, id, ...otherProps } = props;
   const [items, error] = resourceClass.useList();
+  // throttle the update of the table to once per second
+  const throttledItems = useThrottle(items, 1000);
 
   return (
     <Table
       errorMessage={resourceClass.getErrorMessage(error)}
       id={id || `headlamp-${resourceClass.pluralName}`}
       {...otherProps}
-      data={items}
+      data={throttledItems}
     />
   );
 }


### PR DESCRIPTION
Throttles the data updates on tables to once per second. When new data comes in it is shown right away, but if more comes in within the next second it is not shown until 1 second has past. So there should be new data right away in most cases, and it should be limited to how fast it updates otherwise.

### How to test

- [ ]  create many events per second on a cluster and view the cluster overview page
- [ ] filtering still works ok

