### PR TITLE
charts: OIDC config via secrets

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -67,11 +67,11 @@ $ helm install my-headlamp headlamp/headlamp --namespace kube-system
 
 ### Headlamp Configuration
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| config.baseURL | string | `""` | base url path at which headlamp should run |
-| config.oidc.clientID | string | `""` | OIDC client ID |
-| config.oidc.clientSecret | string | `""` | OIDC client secret |
-| config.oidc.issuerURL | string | `""` | OIDC issuer URL |
-| config.oidc.scopes | string | `""` | OIDC scopes to be used |
-| config.pluginsDir | string | `"/headlamp/plugins"` | directory to look for plugins |
+| Key                      | Type   | Default               | Description                                |
+|--------------------------|--------|-----------------------|--------------------------------------------|
+| config.baseURL           | string | `""`                  | base url path at which headlamp should run |
+| config.oidc.clientID     | string | `""`                  | OIDC client ID                             |
+| config.oidc.clientSecret | string | `""`                  | OIDC client secret                         |
+| config.oidc.issuerURL    | string | `""`                  | OIDC issuer URL                            |
+| config.oidc.scopes       | string | `""`                  | OIDC scopes to be used                     |
+| config.pluginsDir        | string | `"/headlamp/plugins"` | directory to look for plugins              |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -35,22 +35,51 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- with .Values.config.oidc.clientID }}
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: clientID
+            {{- end }}
+            {{- with .Values.config.oidc.clientSecret }}
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: clientSecret
+            {{- end }}
+            {{- with .Values.config.oidc.issuerURL }}
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: issuerURL
+            {{- end }}
+            {{- with .Values.config.oidc.scopes }}
+            - name: OIDC_SCOPES
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: scopes
+            {{- end }}
           args:
             - "-in-cluster"
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}
             {{- with .Values.config.oidc.clientID }}
-            - "-oidc-client-id={{ . }}"
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             {{- end }}
             {{- with .Values.config.oidc.clientSecret }}
-            - "-oidc-client-secret={{ . }}"
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             {{- end }}
             {{- with .Values.config.oidc.issuerURL }}
-            - "-oidc-idp-issuer-url={{ . }}"
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             {{- end }}
             {{- with .Values.config.oidc.scopes }}
-            - "-oidc-scopes={{ . }}"
+            - "-oidc-scopes=$(OIDC_SCOPES)"
             {{- end }}
             {{- with .Values.config.baseURL }}
             - "-base-url={{ . }}"

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+type: Opaque
+data:
+{{- with .Values.config.oidc.clientID }}
+  clientID: {{ . | b64enc | quote }}
+{{- end }}
+{{- with .Values.config.oidc.clientSecret }}
+  clientSecret: {{ . | b64enc | quote }}
+{{- end }}
+{{- with .Values.config.oidc.issuerURL }}
+  issuerURL: {{ . | b64enc | quote }}
+{{- end }}
+{{- with .Values.config.oidc.scopes }}
+  scopes: {{ . | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
When installing charts, oidc was being provided as config and since this contains sensitive information it should have been provided as secret.

Fixes: #1160