### PR TITLE
frontend: Only get non-normal events for notifications

### DIFF
--- a/frontend/src/components/App/Notifications/index.tsx
+++ b/frontend/src/components/App/Notifications/index.tsx
@@ -173,7 +173,7 @@ export default function Notifications() {
   const [anchorEl, setAnchorEl] = useState(null);
   const notifications = useTypedSelector(state => state.ui.notifications);
   const dispatch = useDispatch();
-  const [events] = Event.useList();
+  const [events] = Event.useList({ fieldSelector: 'type!=Normal' });
   const { t } = useTranslation();
   const history = useHistory();
 


### PR DESCRIPTION
This will make the number of events to process much smaller and thus
be more optimal.
