### PR TITLE
docs: Fix anchors in functionality.md and in plugin example READMEs

### DIFF
--- a/docs/development/plugins/functionality.md
+++ b/docs/development/plugins/functionality.md
@@ -57,12 +57,12 @@ what we have so far:
 ### App Bar Action
 
 Show a component in the app bar (in the top right) with
-[registerAppBarAction](../api/modules/plugin_registry.md#registerAppBarAction).
+[registerAppBarAction](../api/modules/plugin_registry.md#registerappbaraction).
 
 ![screenshot of the header showing two actions](./images/podcounter_screenshot.png)
 
 - Example plugin shows [How To Register an App Bar Action](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/pod-counter)
-- API reference for [registerAppBarAction](../api/modules/plugin_registry.md#registerAppBarAction)
+- API reference for [registerAppBarAction](../api/modules/plugin_registry.md#registerappbaraction)
 
 ### App Logo
 
@@ -77,79 +77,79 @@ Change the logo (at the top left) with
 ### App Menus
 
 Add menus when Headlamp is running as an app.
-[Headlamp.setAppMenu](../api/classes/plugin_lib.Headlamp/#setAppMenu)
+[Headlamp.setAppMenu](../api/classes/plugin_lib.Headlamp/#setappmenu)
 
 ![screenshot of the logo being changed](./images/app-menus.png)
 
 - Example plugin shows [How To Add App Menus](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/app-menus)
-- API reference for [Headlamp.setAppMenu](../api/classes/plugin_lib.Headlamp/#setAppMenu)
+- API reference for [Headlamp.setAppMenu](../api/classes/plugin_lib.Headlamp/#setappmenu)
 
 ### Cluster Chooser
 
 Change the Cluster Chooser button (in the middle top of the Headlamp app bar) with
-[registerClusterChooser](../api/modules/plugin_registry.md#registerClusterChooser).
+[registerClusterChooser](../api/modules/plugin_registry.md#registerclusterchooser).
 
 ![screenshot of the cluster chooser button](./images/cluster-chooser.png)
 
 - Example plugin shows [How To Register Cluster Chooser button](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/clusterchooser)
-- API reference for [registerClusterChooser](../api/modules/plugin_registry.md#registerClusterChooser)
+- API reference for [registerClusterChooser](../api/modules/plugin_registry.md#registerclusterchooser)
 
 ### Details View Header Action
 
 Show a component to the top right area of a detail view
 (in the area of the screenshot below that's highlighted as yellow)
-[registerDetailsViewHeaderAction](../api/modules/plugin_registry.md#registerDetailsViewHeaderAction).
+[registerDetailsViewHeaderAction](../api/modules/plugin_registry.md#registerdetailsviewheaderaction).
 
 ![screenshot of the header showing two actions](./images/header_actions_screenshot.png)
 
 - Example plugin shows [How To set a Details View Header Action](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/details-view)
-- API reference for [registerDetailsViewHeaderAction](../api/modules/plugin_registry.md#registerDetailsViewHeaderAction)
+- API reference for [registerDetailsViewHeaderAction](../api/modules/plugin_registry.md#registerdetailsviewheaderaction)
 
 ### Details View Section
 
 Show a component at the bottom of different details views.
-[registerDetailsViewSection](../api/modules/plugin_registry.md#registerDetailsViewSection).
+[registerDetailsViewSection](../api/modules/plugin_registry.md#registerdetailsviewsection).
 
 ![screenshot of the appended Details View Section](./images/details-view.png)
 
 - Example plugin shows [How To set a Details View Section](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/details-view)
-- API reference for [registerDetailsViewSection](../api/modules/plugin_registry.md#registerDetailsViewSection)
+- API reference for [registerDetailsViewSection](../api/modules/plugin_registry.md#registerdetailsviewsection)
 
 ### Dynamic Clusters
 
 Set a cluster dynamically, rather than have the backend read it from configuration files.
-[Headlamp.setCluster](../api/classes/plugin_lib.headlamp/#setCluster).
+[Headlamp.setCluster](../api/classes/plugin_lib.Headlamp/#setcluster).
 
 - Example plugin shows [How To Dynamically Set a Cluster](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/dynamic-clusters)
-- API reference for [Headlamp.setCluster](../api/classes/plugin_lib.headlamp/#setCluster)
+- API reference for [Headlamp.setCluster](../api/classes/plugin_lib.Headlamp/#setcluster)
 
 ### Route
 
 Show a component (in Headlamps main area) at a given URL with
-[registerRoute](../api/modules/plugin_registry.md#registerRoute).
+[registerRoute](../api/modules/plugin_registry.md#registerroute).
 
 - Example plugin shows [How To Register a Route](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/sidebar), and how to remove a route.
-- API reference for [registerRoute](../api/modules/plugin_registry.md#registerRoute)
-- API reference for [registerRouteFilter](../api/modules/plugin_registry.md#registerRouteFilter)
+- API reference for [registerRoute](../api/modules/plugin_registry.md#registerroute)
+- API reference for [registerRouteFilter](../api/modules/plugin_registry.md#registerroutefilter)
 
 
 ### Sidebar Item
 
 Add sidebar items (menu on the left) with
-[registerSidebarEntry](../api/modules/plugin_registry.md#registerSidebarEntry).
-Remove sidebar items with [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registerSidebarEntryFilter).
+[registerSidebarEntry](../api/modules/plugin_registry.md#registersidebarentry).
+Remove sidebar items with [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registersidebarentryfilter).
 
 ![screenshot of the sidebar being changed](./images/sidebar.png)
 
 - Example plugin shows [How To add items to the sidebar](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/sidebar), and also how to remove sidebar items.
-- API reference for [registerSidebarEntry](../api/modules/plugin_registry.md#registerSidebarEntry)
-- API reference for [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registerSidebarEntryFilter)
+- API reference for [registerSidebarEntry](../api/modules/plugin_registry.md#registersidebarentry)
+- API reference for [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registersidebarentryfilter)
 
 ### Tables
 
-Change what tables across Headlamp show with [registerResourceTableColumnsProcessor](../api/modules/plugin_registry.md#registerSidebarEntry). This allows to remove, add, update, or shuffle table columns.
+Change what tables across Headlamp show with [registerResourceTableColumnsProcessor](../api/modules/plugin_registry.md#registersidebarentry). This allows to remove, add, update, or shuffle table columns.
 
 ![screenshot of the pods list with a context menu added by a plugin](./images/table-context-menu.png)
 
 - Example plugin shows [How to add a context menu to each row in the pods list table](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/tables).
-- API reference for [registerResourceTableColumnsProcessor](../api/modules/plugin_registry.md#registerResourceTableColumnsProcessor)
+- API reference for [registerResourceTableColumnsProcessor](../api/modules/plugin_registry.md#registerresourcetablecolumnsprocessor)

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -439,6 +439,7 @@ export function registerDetailsViewSection(viewSection: DetailsViewSectionType) 
  * which is a string with two values 'light' and 'dark' base on which theme is selected.
  *
  * @example
+ *
  * ```tsx
  * import { registerAppLogo } from '@kinvolk/headlamp-plugin/lib';
  *
@@ -460,6 +461,7 @@ export function registerAppLogo(logo: AppLogoType) {
  * action handler that happens when the custom chooser button component click event occurs
  *
  * @example
+ *
  * ```tsx
  * import { ClusterChooserProps, registerClusterChooser } from '@kinvolk/headlamp-plugin/lib';
  *
@@ -480,10 +482,12 @@ export function registerClusterChooser(chooser: ClusterChooserType) {
  * @param override - The setToken override method to use.
  *
  * @example
+ *
  * ```ts
  * registerSetTokenFunction((cluster: string, token: string | null) => {
  * // set token logic here
  * });
+ * ```
  */
 export function registerSetTokenFunction(
   override: (cluster: string, token: string | null) => void
@@ -496,10 +500,12 @@ export function registerSetTokenFunction(
  * @param override - The getToken override method to use.
  *
  * @example
+ *
  * ```ts
  * registerGetTokenFunction(() => {
  * // set token logic here
  * });
+ * ```
  */
 export function registerGetTokenFunction(override: (cluster: string) => string | undefined) {
   store.dispatch(setFunctionsToOverride({ getToken: override }));

--- a/plugins/examples/app-menus/README.md
+++ b/plugins/examples/app-menus/README.md
@@ -17,4 +17,4 @@ The main code for the example plugin is in [src/index.tsx](src/index.tsx).
 
 See the API documentation for:
 
-- [Headlamp.setAppMenu](https://headlamp.dev/docs/latest/development/api/classes/plugin_lib.Headlamp/#setAppMenu)
+- [Headlamp.setAppMenu](https://headlamp.dev/docs/latest/development/api/classes/plugin_lib.headlamp/#setappmenu)

--- a/plugins/examples/cluster-chooser/README.md
+++ b/plugins/examples/cluster-chooser/README.md
@@ -20,5 +20,5 @@ The main code for the plugin is in [src/index.tsx](src/index.tsx).
 
 See:
 
-- API documentation for [registerClusterChooser](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registercluster-chooser)
+- API documentation for [registerClusterChooser](https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registerclusterchooser)
 - The [getting started documentation for Headlamp plugin development](https://headlamp.dev/docs/latest/development/plugins/building/)

--- a/plugins/examples/details-view/README.md
+++ b/plugins/examples/details-view/README.md
@@ -18,5 +18,5 @@ The main code for the example plugin is in [src/index.tsx](src/index.tsx).
 
 See the API documentation for:
 
-- [registerDetailsViewSection](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerDetailsViewSection)
-- [registerDetailsViewHeaderAction](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerDetailsViewHeaderAction)
+- [registerDetailsViewSection](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerdetailsviewsection)
+- [registerDetailsViewHeaderAction](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerdetailsviewheaderaction)

--- a/plugins/examples/dynamic-clusters/README.md
+++ b/plugins/examples/dynamic-clusters/README.md
@@ -22,5 +22,5 @@ The main code for the plugin is in [src/index.tsx](src/index.tsx).
 
 See:
 
-- API documentation for [Headlamp.setCluster](https://headlamp.dev/docs/latest/development/api/classes/plugin_lib.headlamp/#setCluster)
+- API documentation for [Headlamp.setCluster](https://headlamp.dev/docs/latest/development/api/classes/plugin_lib.headlamp/#setcluster)
 - The [getting started documentation for Headlamp plugin development](https://headlamp.dev/docs/latest/development/plugins/building/)

--- a/plugins/examples/pod-counter/README.md
+++ b/plugins/examples/pod-counter/README.md
@@ -18,4 +18,4 @@ The main code for the plugin is in [src/index.tsx](src/index.tsx).
 
 See the API documentation for:
 
-- [registerAppBarAction](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerappbaraction)
+- [registerAppBarAction](https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registerappbaraction)

--- a/plugins/examples/sidebar/README.md
+++ b/plugins/examples/sidebar/README.md
@@ -19,7 +19,7 @@ The main code for the plugin is in [src/index.tsx](src/index.tsx).
 
 See the API documentation for:
 
-- [registerSidebarEntry](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registersidebarentry)
-- [registerSidebarEntryFilter](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registersidebarentryfilter)
-- [registerRoute](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerroute)
-- [registerRouteFilter](https://headlamp.dev/docs/latest/development/api/classes/plugin_registry.registry/#registerroutefilter)
+- [registerSidebarEntry](https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registersidebarentry)
+- [registerSidebarEntryFilter](https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registersidebarentryfilter)
+- [registerRoute](https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registerroute)
+- [registerRouteFilter](https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registerroutefilter)


### PR DESCRIPTION
They are not mixed case anchors on the website.

How to test:
- does not work (stays at top of page): https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registerRouteFilter
- does work (jumps to registerRouteFilter): https://headlamp.dev/docs/latest/development/api/modules/plugin_registry/#registerroutefilter

