### PR TITLE
Helm endpoints bug fixes.

### DIFF
--- a/backend/pkg/cache/cache.go
+++ b/backend/pkg/cache/cache.go
@@ -102,7 +102,7 @@ func (c *cache) cleanUp() {
 		<-ticker.C
 
 		for key, value := range c.store {
-			if !value.expiresAt.IsZero() && value.expiresAt.After(time.Now()) {
+			if !value.expiresAt.IsZero() && value.expiresAt.Before(time.Now()) {
 				c.lock.Lock()
 				delete(c.store, key)
 				c.lock.Unlock()

--- a/backend/pkg/helm/handler.go
+++ b/backend/pkg/helm/handler.go
@@ -114,7 +114,7 @@ func (r *restConfigGetter) ToRESTMapper() (meta.RESTMapper, error) {
 
 type stat struct {
 	Status string
-	Err    error
+	Err    *string
 }
 
 // getReleaseStatus returns the status of the release.
@@ -150,7 +150,11 @@ func (h *Handler) setReleaseStatus(actionName, releaseName, status string, err e
 
 	stat := stat{
 		Status: status,
-		Err:    err,
+	}
+
+	if err != nil {
+		errString := err.Error()
+		stat.Err = &errString
 	}
 
 	cacheErr := h.Cache.SetWithTTL(context.Background(), key, stat, statusCacheTimeout)

--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -464,6 +464,8 @@ func (h *Handler) InstallRelease(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		zlog.Error().Err(err).Str("action", "install").Msg("validating request body")
 		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
 	}
 
 	err = h.setReleaseStatus("install", req.Name, processing, nil)

--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -789,7 +789,7 @@ func (h *Handler) GetActionStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if stat.Status == failed {
-		response["message"] = "action failed with error: " + stat.Err.Error()
+		response["message"] = "action failed with error: " + *stat.Err
 	}
 
 	w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
This PR fixes the following:
- The get status function fails when an error occurs in the async task. This was due to unmarshalling error with the type error.
- In install release function the request validation error was missing a return statement that is fixed.
- Due to an issue in the cache clean up logic the cached values were dropped before the validity expiry.  