### PR TITLE
frontend: Settings button fixes

### DIFF
--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -42,7 +42,7 @@ export default function Settings() {
 
   return (
     <SectionBox
-      title={t('frequent|General')}
+      title={t('frequent|General Settings')}
       headerProps={{
         actions: [
           <ActionButton

--- a/frontend/src/components/App/Settings/SettingsButton.tsx
+++ b/frontend/src/components/App/Settings/SettingsButton.tsx
@@ -1,19 +1,25 @@
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { createRouteURL } from '../../../lib/router';
+import { getCluster } from '../../../lib/util';
 import { ActionButton } from '../../common';
 
 export default function SettingsButton(props: { onClickExtra?: () => void }) {
   const { onClickExtra } = props;
   const { t } = useTranslation(['glossary']);
   const history = useHistory();
+  const clusterName = getCluster();
+
+  if (clusterName === null) {
+    return null;
+  }
 
   return (
     <ActionButton
       icon="mdi:cog"
       description={t('frequent|Settings')}
       onClick={() => {
-        history.push(createRouteURL('settings'));
+        history.push(createRouteURL('settingsCluster', { cluster: clusterName }));
         onClickExtra && onClickExtra();
       }}
     />

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -1,5 +1,5 @@
 import { Icon, InlineIcon } from '@iconify/react';
-import { Box, Chip, IconButton, TextField } from '@material-ui/core';
+import { Box, Chip, IconButton, Link, TextField } from '@material-ui/core';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom';
 import helpers, { ClusterSettings } from '../../../helpers';
 import { useCluster, useClustersConf } from '../../../lib/k8s';
 import { deleteCluster } from '../../../lib/k8s/apiProxy';
+import { createRouteURL } from '../../../lib/router';
 import { setConfig } from '../../../redux/actions/actions';
 import { NameValueTable, SectionBox } from '../../common';
 import ConfirmButton from '../../common/ConfirmButton';
@@ -168,6 +169,17 @@ export default function SettingsCluster() {
             : t('settings|Cluster Settings')
         }
         backLink
+        headerProps={{
+          actions: [
+            <Link
+              href={createRouteURL('settings')}
+              align="right"
+              style={{ color: theme.palette.text.primary }}
+            >
+              {t('settings|General Settings')}
+            </Link>,
+          ],
+        }}
       >
         <NameValueTable
           rows={[

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.stories.storyshot
@@ -41,7 +41,7 @@ exports[`Storyshots Settings General 1`] = `
           <h1
             class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
           >
-            General
+            General Settings
           </h1>
           <div
             class="MuiBox-root MuiBox-root"

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -291,14 +291,14 @@ export function PureTopBar({
       <MenuItem
         component="a"
         onClick={() => {
-          history.push(createRouteURL('settingsCluster', { cluster: cluster! }));
+          history.push(createRouteURL('settings'));
           handleMenuClose();
         }}
       >
         <ListItemIcon>
           <Icon icon="mdi:cog-box" />
         </ListItemIcon>
-        <ListItemText>{t('settings|Cluster settings')}</ListItemText>
+        <ListItemText>{t('settings|General Settings')}</ListItemText>
       </MenuItem>
       <MenuItem
         component="a"

--- a/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
@@ -51,22 +51,6 @@ exports[`Storyshots TopBar No Token 1`] = `
           class="MuiTouchRipple-root"
         />
       </button>
-      <button
-        aria-label="Settings"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        title="Settings"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <span />
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
   </nav>
 </div>
@@ -118,22 +102,6 @@ exports[`Storyshots TopBar One Cluster 1`] = `
               fill="currentColor"
             />
           </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-      <button
-        aria-label="Settings"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        title="Settings"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <span />
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -215,22 +183,6 @@ exports[`Storyshots TopBar Processor Action 1`] = `
           class="MuiTouchRipple-root"
         />
       </button>
-      <button
-        aria-label="Settings"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        title="Settings"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <span />
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
   </nav>
 </div>
@@ -287,22 +239,6 @@ exports[`Storyshots TopBar Token 1`] = `
           class="MuiTouchRipple-root"
         />
       </button>
-      <button
-        aria-label="Settings"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        title="Settings"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <span />
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
   </nav>
 </div>
@@ -354,22 +290,6 @@ exports[`Storyshots TopBar Two Cluster 1`] = `
               fill="currentColor"
             />
           </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-      <button
-        aria-label="Settings"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        title="Settings"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <span />
         </span>
         <span
           class="MuiTouchRipple-root"


### PR DESCRIPTION
Fixes for issue #1189 

Currently working on completing the solution based on the pillars of the issue.

Changes made:
- **Top Bar Settings Button Navigation:** The Top bar settings button now navigates to the Cluster Settings page of the current cluster. This simplifies the navigation process and brings a more intuitive user experience. Note that the settings button will not be visible when no cluster is set, preventing any confusion or error when there's no active cluster.

- **User Menu "General Settings" Navigation:** I have replaced the "Cluster Settings" button under the User Menu with a "General Settings" button. This button leads to the User Settings page, making it straightforward for users to modify their general settings.

- **Added "General Settings" Link to Cluster Settings:** To ensure that users can easily switch between settings pages if desired, I have added a link to the "General Settings" on the Cluster Settings page. This allows for quick and easy access to the General Settings page from within the Cluster Settings.

![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/ea2fcc1f-f1ff-421a-894e-87b9798b8e9b)

**To do**
- [x] Make the top bar settings button go to the cluster settings; and hide this button if no cluster is set
- [x] Replace the "Cluster Settings" button under the user menu by "General Settings"
- [x] Add a link "General Settings" to the cluster's settings, so the user can easily go to the general settings if they want.


