### PR TITLE
Fix drain, cordon icon

### DIFF
--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -85,6 +85,12 @@ export default function NodeDetails() {
           errorMessage: cordon
             ? t('Failed to uncordon node {{name}}.', { name: node.metadata.name })
             : t('Failed to cordon node {{name}}.', { name: node.metadata.name }),
+          cancelledMessage: cordon
+            ? t('Uncordon node {{name}} cancelled.', { name: node.metadata.name })
+            : t('Cordon node {{name}} cancelled.', { name: node.metadata.name }),
+          cancelCallback: () => {
+            setisUpdatingNodeScheduleProperty(false);
+          },
         }
       )
     );
@@ -135,6 +141,10 @@ export default function NodeDetails() {
           startMessage: t('Draining node {{name}}…', { name: node.metadata.name }),
           successMessage: t('Drained node {{name}}.', { name: node.metadata.name }),
           errorMessage: t('Failed to drain node {{name}}.', { name: node.metadata.name }),
+          cancelledMessage: t('Draining node {{name}} cancelled.', { name: node.metadata.name }),
+          cancelCallback: () => {
+            setisNodeDrainInProgress(false);
+          },
         }
       )
     );

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -75,6 +75,7 @@ export interface CallbackActionOptions {
   cancelledOptions?: SnackbarProps;
   successOptions?: SnackbarProps;
   errorOptions?: SnackbarProps;
+  cancelCallback?: (...args: any[]) => void;
 }
 
 export interface Action {

--- a/frontend/src/redux/sagas/sagas.tsx
+++ b/frontend/src/redux/sagas/sagas.tsx
@@ -40,6 +40,7 @@ function* doClusterAction(action: CallbackAction, actionKey: string, uniqueCance
     errorMessage,
     errorUrl,
     successMessage,
+    cancelCallback,
     startOptions = {},
     cancelledOptions = {},
     successOptions = { variant: 'success' },
@@ -78,6 +79,9 @@ function* doClusterAction(action: CallbackAction, actionKey: string, uniqueCance
           snackbarProps: cancelledOptions,
         })
       );
+      if (cancelCallback) {
+        yield call(cancelCallback);
+      }
     } else {
       // Actually perform the action. This part is no longer cancellable,
       // so it's here instead of within the try block.


### PR DESCRIPTION
Steps to reproduce 
1. Go to node detail view and press either the drain node or the cordon node icon
2. Pressing the drain or cordon node icon shows a notistack saying cancel the drain or cordon

Acceptance Criteria

- [ ] Pressing the cancel button on notistack cancels the drain or cordon process with a message 
- [ ] When the cancel button is clicked the icons return back to there enable state which were earlier staying disabled even on cancel click
