### PR TITLE
frontend: Fix warning switch always on bug.

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -75,7 +75,7 @@ function EventsSection() {
   const dispatch = useDispatch();
   const filterFunc = useFilterFunc(['.jsonData.involvedObject.kind']);
   const [isWarningEventSwitchChecked, setIsWarningEventSwitchChecked] = React.useState(
-    Boolean(localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY))
+    Boolean(JSON.parse(localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY) || 'false'))
   );
 
   const warningActionFilterFunc = (event: KubeEvent) => {


### PR DESCRIPTION
Issue:
go to cluster overview page, click on events warning switch, 
now click again to turn it off, 
switch to some other page and come back to cluster overview page, you will find the switch is always on if switched once.

This is fixed by parsing the value of event switch before making it as a default value