### PR TITLE
Use cluster health in alert notification

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -76,7 +76,7 @@ const useStyle = makeStyles(theme => ({
   },
 }));
 
-function useSidebarInfo() {
+export function useSidebarInfo() {
   const isSidebarOpen = useTypedSelector(state => state.ui.sidebar.isSidebarOpen);
   const isSidebarOpenUserSelected = useTypedSelector(
     state => state.ui.sidebar.isSidebarOpenUserSelected
@@ -97,8 +97,10 @@ function useSidebarInfo() {
     canExpand: !isNarrowOnly,
     isTemporary,
     isUserOpened: isSidebarOpenUserSelected,
+    width: isOpen ? `${drawerWidth}px` : isTemporary ? '0px' : `${drawerWidthClosed}px`,
   };
 }
+
 const useButtonStyle = makeStyles({
   button: {
     color: '#adadad',

--- a/frontend/src/components/common/AlertNotification.stories.tsx
+++ b/frontend/src/components/common/AlertNotification.stories.tsx
@@ -25,7 +25,7 @@ const Template: Story<PureAlertNotificationProps> = args => <PureAlertNotificati
 
 export const Error = Template.bind({});
 Error.args = {
-  testAuth: () => {
+  checkerFunction: () => {
     return new Promise(function (resolve, reject) {
       reject('Offline');
     });
@@ -36,7 +36,7 @@ Error.args = {
 
 export const NoError = Template.bind({});
 NoError.args = {
-  testAuth: () => {
+  checkerFunction: () => {
     return new Promise(function (resolve) {
       resolve('fine');
     });

--- a/frontend/src/components/common/AlertNotification.stories.tsx
+++ b/frontend/src/components/common/AlertNotification.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { SnackbarProvider } from 'notistack';
-import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { TestContext } from '../../test';
 import { PureAlertNotification, PureAlertNotificationProps } from './AlertNotification';
 
 export default {
@@ -12,11 +11,11 @@ export default {
   },
   decorators: [
     Story => (
-      <MemoryRouter>
+      <TestContext>
         <SnackbarProvider>
           <Story />
         </SnackbarProvider>
-      </MemoryRouter>
+      </TestContext>
     ),
   ],
 } as Meta;
@@ -30,17 +29,13 @@ Error.args = {
       reject('Offline');
     });
   },
-  moreRoutes: {},
-  routes: {},
 };
 
 export const NoError = Template.bind({});
 NoError.args = {
   checkerFunction: () => {
     return new Promise(function (resolve) {
-      resolve('fine');
+      resolve({ statusText: 'OK' });
     });
   },
-  moreRoutes: {},
-  routes: {},
 };

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -2,23 +2,22 @@ import { Box, useTheme } from '@material-ui/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation } from 'react-router-dom';
-import { testAuth } from '../../lib/k8s/apiProxy';
+import { testClusterHealth } from '../../lib/k8s/apiProxy';
 import { getDefaultRoutes, getRoutePath, Route } from '../../lib/router';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 
-const NOT_FOUND_ERROR_MESSAGES = ['Error: Api request error: Bad Gateway', 'Offline'];
 // in ms
 const NETWORK_STATUS_CHECK_TIME = 5000;
 
 export interface PureAlertNotificationProps {
   routes: { [path: string]: any };
   moreRoutes: { [routeName: string]: Route };
-  testAuth(): Promise<any>;
+  checkerFunction(): Promise<any>;
 }
 
 export function PureAlertNotification({
   routes,
-  testAuth,
+  checkerFunction,
   moreRoutes,
 }: PureAlertNotificationProps) {
   const [networkStatusCheckTimeFactor, setNetworkStatusCheckTimeFactor] = React.useState(0);
@@ -35,7 +34,7 @@ export function PureAlertNotification({
         return;
       }
       setError(null);
-      testAuth()
+      checkerFunction()
         .then(() => {
           setError(false);
         })
@@ -99,9 +98,6 @@ export function PureAlertNotification({
     return null;
   }
 
-  if (NOT_FOUND_ERROR_MESSAGES.filter(err => err === error).length === 0) {
-    return null;
-  }
   return (
     <Box
       bgcolor="error.main"
@@ -138,6 +134,10 @@ export default function AlertNotification() {
   const routes = useTypedSelector(state => state.ui.routes);
 
   return (
-    <PureAlertNotification routes={routes} testAuth={testAuth} moreRoutes={getDefaultRoutes()} />
+    <PureAlertNotification
+      routes={routes}
+      checkerFunction={testClusterHealth}
+      moreRoutes={getDefaultRoutes()}
+    />
   );
 }

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -33,7 +33,7 @@ export function PureAlertNotification({
         setError(t('frequent|Offline') as string);
         return;
       }
-      setError(null);
+
       checkerFunction()
         .then(() => {
           setError(false);

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation } from 'react-router-dom';
 import { testClusterHealth } from '../../lib/k8s/apiProxy';
 import { getRoute, getRoutePath } from '../../lib/router';
+import { getCluster } from '../../lib/util';
 import { useSidebarInfo } from '../Sidebar';
 
 // in ms
@@ -62,6 +63,12 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
         return;
       }
 
+      // Don't check for the cluster health if we are not on a cluster route.
+      if (!getCluster()) {
+        setError(null);
+        return;
+      }
+
       checkerFunction()
         .then(() => {
           setError(false);
@@ -85,6 +92,13 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     // eslint-disable-next-line
     []
   );
+
+  // Make sure we do not show the alert notification if we are not on a cluster route.
+  React.useEffect(() => {
+    if (!getCluster()) {
+      setError(null);
+    }
+  }, [pathname]);
 
   React.useEffect(
     () => {

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -1,31 +1,59 @@
-import { Box, useTheme } from '@material-ui/core';
+import { Box, Button, makeStyles } from '@material-ui/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation } from 'react-router-dom';
 import { testClusterHealth } from '../../lib/k8s/apiProxy';
-import { getDefaultRoutes, getRoutePath, Route } from '../../lib/router';
-import { useTypedSelector } from '../../redux/reducers/reducers';
+import { getRoute, getRoutePath } from '../../lib/router';
+import { useSidebarInfo } from '../Sidebar';
 
 // in ms
 const NETWORK_STATUS_CHECK_TIME = 5000;
 
 export interface PureAlertNotificationProps {
-  routes: { [path: string]: any };
-  moreRoutes: { [routeName: string]: Route };
   checkerFunction(): Promise<any>;
 }
 
-export function PureAlertNotification({
-  routes,
-  checkerFunction,
-  moreRoutes,
-}: PureAlertNotificationProps) {
+const useStyle = makeStyles(theme => ({
+  box: {
+    color: theme.palette.common.white,
+    textAlign: 'center',
+    display: 'flex',
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(0.5),
+    justifyContent: 'center',
+    position: 'fixed',
+    zIndex: theme.zIndex.snackbar + 1,
+    width: '100%',
+    top: '0',
+    height: '3.8vh',
+  },
+  button: {
+    color: theme.palette.error.main,
+    borderColor: theme.palette.error.main,
+    background: theme.palette.common.white,
+    lineHeight: '1',
+    marginLeft: theme.spacing(1),
+    '&:hover': {
+      color: theme.palette.common.white,
+      borderColor: theme.palette.common.white,
+      background: theme.palette.error.dark,
+    },
+  },
+}));
+
+// Routes where we don't show the alert notification.
+// Because maybe they already offer context about the cluster health or
+// some other reason.
+const ROUTES_WITHOUT_ALERT = ['login', 'token', 'settingsCluster'];
+
+export function PureAlertNotification({ checkerFunction }: PureAlertNotificationProps) {
+  const { width: sidebarWidth } = useSidebarInfo();
   const [networkStatusCheckTimeFactor, setNetworkStatusCheckTimeFactor] = React.useState(0);
   const [error, setError] = React.useState<null | string | boolean>(null);
   const [intervalID, setIntervalID] = React.useState<NodeJS.Timeout | null>(null);
   const { t } = useTranslation('resource');
-  const theme = useTheme();
   const { pathname } = useLocation();
+  const classes = useStyle();
 
   function registerSetInterval(): NodeJS.Timeout {
     return setInterval(() => {
@@ -71,73 +99,36 @@ export function PureAlertNotification({
     [networkStatusCheckTimeFactor]
   );
 
-  function checkWhetherInNoAuthRequireRoute(): boolean {
-    const noAuthRequiringRoutes = Object.values(moreRoutes)
-      .concat(Object.values(routes))
-      .filter(route => route.noAuthRequired);
-
-    for (const route of noAuthRequiringRoutes) {
-      const routeMatch = matchPath(pathname, {
-        path: getRoutePath(route),
-        strict: true,
-      });
-
-      if (routeMatch && routeMatch.isExact) {
-        return true;
+  const showOnRoute = React.useMemo(() => {
+    for (const route of ROUTES_WITHOUT_ALERT) {
+      const routePath = getRoutePath(getRoute(route));
+      if (matchPath(pathname, routePath)?.isExact) {
+        return false;
       }
     }
-    return false;
-  }
+    return true;
+  }, [pathname]);
 
-  const whetherInNoAuthRoute = checkWhetherInNoAuthRequireRoute();
-  let isErrorInNoAuthRequiredRoute = false;
-  if (whetherInNoAuthRoute) {
-    isErrorInNoAuthRequiredRoute = true;
-  }
-  if (!error) {
+  if (!error || !showOnRoute) {
     return null;
   }
 
   return (
-    <Box
-      bgcolor="error.main"
-      color={theme.palette.common.white}
-      textAlign="center"
-      display="flex"
-      p={1}
-      justifyContent="center"
-      position="fixed"
-      zIndex={1400}
-      width="100%"
-      top={'0'}
-      height={'3.8vh'}
-    >
-      <Box marginLeft={isErrorInNoAuthRequiredRoute ? '0%' : '-15%'}>
-        {t('Something Went Wrong.')}
-      </Box>
-      <Box
-        bgcolor={theme.palette.common.white}
-        color="error.main"
-        ml={1}
-        px={1}
-        py={0.1}
-        style={{ cursor: 'pointer' }}
-        onClick={() => setNetworkStatusCheckTimeFactor(0)}
-      >
-        {t('frequent|Try Again')}
+    <Box className={classes.box} bgcolor="error.main" paddingRight={sidebarWidth}>
+      <Box>
+        {t('Something went wrong.')}
+        <Button
+          className={classes.button}
+          onClick={() => setNetworkStatusCheckTimeFactor(0)}
+          size="small"
+        >
+          {t('frequent|Try Again')}
+        </Button>
       </Box>
     </Box>
   );
 }
 
 export default function AlertNotification() {
-  const routes = useTypedSelector(state => state.ui.routes);
-
-  return (
-    <PureAlertNotification
-      routes={routes}
-      checkerFunction={testClusterHealth}
-      moreRoutes={getDefaultRoutes()}
-    />
-  );
+  return <PureAlertNotification checkerFunction={testClusterHealth} />;
 }


### PR DESCRIPTION
- frontend: Add testClusterHealth function
- frontend: Use testClusterHealth in the AlertNotification

How to test:
- [ ] Try accessing a the pods list view when the cluster is down
- [ ] The banner no longer shows up in the login, token, and settingsCluster routes (because the first 2 routes already inform the user about the issue, and the 3rd one doesn't need the banner's context)