### PR TITLE
charts: Update to Headlamp 0.18.0

### DIFF
--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -15,5 +15,5 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.12.0
-appVersion: 0.17.1
+version: 0.13.0
+appVersion: 0.18.0


### PR DESCRIPTION
Hello there,
just quick PR to move the charts to 0.18.0 provided this is the current released version.
Hope this helps!
Francesco