### PR TITLE
frontend ClearPodLogs: Creates button to clear pod logs

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -192,6 +192,13 @@ export function LogViewer(props: LogViewerProps) {
           </Grid>
           <Grid item xs>
             <ActionButton
+              description={t('frequent|Clear')}
+              onClick={() => clearPodLogs(xtermRef)}
+              icon="mdi:broom"
+            />
+          </Grid>
+          <Grid item xs>
+            <ActionButton
               description={t('Download')}
               onClick={downloadLog}
               icon="mdi:file-download-outline"
@@ -213,6 +220,13 @@ export function LogViewer(props: LogViewerProps) {
       </DialogContent>
     </Dialog>
   );
+}
+
+// clears logs for pod
+function clearPodLogs(xtermRef: React.MutableRefObject<XTerminal | null>) {
+  xtermRef.current?.clear();
+  // keeping this comment if logs dont print after clear
+  // xtermRef.current?.write(getJointLogs());
 }
 
 function enableCopyPasteInXterm(xterm: XTerminal) {


### PR DESCRIPTION
For issue #1061 

**Description:**
As part of the pod logs component improvement, a suggestion has been made to implement a "Clear Logs" button. This functionality will enable users to effortlessly clear the current log contents displayed in the text view, enhancing the troubleshooting experience by allowing focused analysis of specific service calls while maintaining continuous access to the log output.

**In progress:**
**Implementing Ongoing Log Printing:** I am currently working on implementing the necessary logic to ensure that the pod logs continue to be printed to the component even after the logs have been cleared. This will enable users to view the ongoing log output without interruption.


**Work Implemented:**
- [x] **Added Functional Clear Button:** I have implemented a clear button within the component for pod logs. This button provides the ability to clear all currently displayed logs in the text view.
- [x] **Clear Button Functionality:** The clear button is now fully functional, removing all the current logs from the view upon being clicked. This allows users to easily clear the logs and focus on the specific service call they are troubleshooting.

![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/6b6bdf35-de3e-44a9-8e3b-c1e4282adfad)
