### PR TITLE
ingress-examle/headlamp: Fix ingress example file

### DIFF
--- a/kubernetes-headlamp-ingress-sample.yaml
+++ b/kubernetes-headlamp-ingress-sample.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: headlamp
   namespace: kube-system
@@ -17,6 +17,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: headlamp
-          servicePort: 80
+          service:
+            name: headlamp
+            port:
+              number: 80


### PR DESCRIPTION
* Adapt apiVersion to latest supported version for kubernetes
* Add missing properties
* Use new service declaration


closes #1237 