### PR TITLE
Wide UI

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.stories.storyshot
@@ -193,7 +193,7 @@ exports[`Storyshots Home/Home Base 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -184,9 +184,9 @@ export default function Layout({}: LayoutProps) {
             ''
           )}
           <AlertNotification />
-          <Box p={[0, 3, 3]}>
+          <Box>
             <div className={classes.toolbar} />
-            <Container maxWidth="lg">
+            <Container maxWidth="xl">
               <NavigationTabs />
               {arePluginsLoaded && (
                 <RouteSwitcher

--- a/frontend/src/components/App/Notifications/__snapshots__/List.stories.storyshot
+++ b/frontend/src/components/App/Notifications/__snapshots__/List.stories.storyshot
@@ -113,7 +113,7 @@ exports[`Storyshots Notifications List 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <tbody
             class="MuiTableBody-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.stories.storyshot
@@ -32,7 +32,7 @@ exports[`Storyshots Settings/PluginSettings Default Save Enable 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"
@@ -436,7 +436,7 @@ exports[`Storyshots Settings/PluginSettings Empty Homepage Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"
@@ -776,7 +776,7 @@ exports[`Storyshots Settings/PluginSettings Few Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"
@@ -1116,7 +1116,7 @@ exports[`Storyshots Settings/PluginSettings Many Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"
@@ -1981,7 +1981,7 @@ exports[`Storyshots Settings/PluginSettings More Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -96,7 +96,7 @@ export function useSidebarInfo() {
   const isSidebarOpenUserSelected = useTypedSelector(
     state => state.ui.sidebar.isSidebarOpenUserSelected
   );
-  const isTemporary = useMediaQuery('(max-width:600px)');
+  const isTemporary = useMediaQuery('(max-width:599px)');
   const isNarrowOnly = useMediaQuery('(max-width:960px) and (min-width:600px)');
   const temporarySideBarOpen =
     isSidebarOpen === true && isTemporary && isSidebarOpenUserSelected === true;

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -13,6 +13,7 @@ import SimpleTable, {
   SimpleTableGetterColumn,
   SimpleTableProps,
 } from '../SimpleTable';
+import { LightTooltip } from '../Tooltip';
 import TableColumnChooserPopup from './ResourceTableColumnChooser';
 
 interface ToggableColumn {
@@ -156,7 +157,15 @@ function Table(props: ResourceTableProps) {
             return {
               id: 'name',
               label: t('frequent|Name'),
-              getter: (resource: KubeObject) => <Link kubeObject={resource} />,
+              gridTemplate: 1.5,
+              // We add the span element because somehow the tooltip doesn't work without it.
+              getter: (resource: KubeObject) => (
+                <LightTooltip title={resource.getName()} interactive>
+                  <span>
+                    <Link kubeObject={resource} />
+                  </span>
+                </LightTooltip>
+              ),
               sort: (n1: KubeObject, n2: KubeObject) => {
                 if (n1.metadata.name < n2.metadata.name) {
                   return -1;
@@ -174,6 +183,7 @@ function Table(props: ResourceTableProps) {
               id: 'age',
               label: t('frequent|Age'),
               cellProps: { style: { textAlign: 'right' } },
+              gridTemplate: 0.5,
               getter: (resource: KubeObject) => (
                 <DateLabel
                   date={resource.metadata.creationTimestamp}

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots Resource/ListView One Hidden Column 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.stories.storyshot
@@ -174,12 +174,17 @@ exports[`Storyshots Resource/ListView One Hidden Column 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="imagepullbackoff"
                 >
-                  imagepullbackoff
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    imagepullbackoff
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -210,12 +215,17 @@ exports[`Storyshots Resource/ListView One Hidden Column 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="imagepullbackoff"
                 >
-                  imagepullbackoff
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    imagepullbackoff
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -246,12 +256,17 @@ exports[`Storyshots Resource/ListView One Hidden Column 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="imagepullbackoff"
                 >
-                  imagepullbackoff
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    imagepullbackoff
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -282,12 +297,17 @@ exports[`Storyshots Resource/ListView One Hidden Column 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="imagepullbackoff"
                 >
-                  imagepullbackoff
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    imagepullbackoff
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -318,12 +338,17 @@ exports[`Storyshots Resource/ListView One Hidden Column 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="imagepullbackoff"
                 >
-                  imagepullbackoff
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    imagepullbackoff
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
@@ -89,12 +89,17 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
           >
-            <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-              href="/"
+            <span
+              class=""
+              title="mypod3"
             >
-              mypod3
-            </a>
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                href="/"
+              >
+                mypod3
+              </a>
+            </span>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -214,12 +219,17 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
           >
-            <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-              href="/"
+            <span
+              class=""
+              title="mypod0"
             >
-              mypod0
-            </a>
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                href="/"
+              >
+                mypod0
+              </a>
+            </span>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -250,12 +260,17 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
           >
-            <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-              href="/"
+            <span
+              class=""
+              title="mypod1"
             >
-              mypod1
-            </a>
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                href="/"
+              >
+                mypod1
+              </a>
+            </span>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -286,12 +301,17 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
           >
-            <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-              href="/"
+            <span
+              class=""
+              title="mypod2"
             >
-              mypod2
-            </a>
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                href="/"
+              >
+                mypod2
+              </a>
+            </span>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -322,12 +342,17 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
           >
-            <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-              href="/"
+            <span
+              class=""
+              title="mypod3"
             >
-              mypod3
-            </a>
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                href="/"
+              >
+                mypod3
+              </a>
+            </span>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -131,7 +131,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -25,13 +25,23 @@ const useTableStyle = makeStyles(theme => ({
   sortCell: {
     whiteSpace: 'nowrap',
   },
-  table: {
+  table: ({ gridTemplateColumns }: { gridTemplateColumns: string }) => ({
+    minWidth: '100%',
+    width: 'auto',
+    display: 'grid',
+    gridTemplateColumns: gridTemplateColumns || '1fr',
     [theme.breakpoints.down('sm')]: {
-      display: 'block',
       overflowX: 'auto', // make it responsive
     },
     '& .MuiTableCell-root': {
-      padding: '8px 24px 7px 16px',
+      padding: '8px 16px 7px 16px',
+      [theme.breakpoints.down('sm')]: {
+        padding: '8px 24px 7px 16px',
+      },
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      width: '100%',
     },
     '& .MuiTableBody-root': {
       background: theme.palette.tables.body.background,
@@ -43,10 +53,18 @@ const useTableStyle = makeStyles(theme => ({
       },
     },
     '& .MuiTableCell-head': {
+      overflow: 'hidden',
+      textOverflow: 'unset',
+      whiteSpace: 'nowrap',
       color: theme.palette.tables.head.text,
       background: theme.palette.tables.head.background,
+      width: '100%',
+      minWidth: 'fit-content',
     },
-  },
+    '& .MuiTableHead-root, & .MuiTableRow-root, & .MuiTableBody-root': {
+      display: 'contents',
+    },
+  }),
   tableContainer: {
     overflowY: 'hidden',
   },
@@ -58,6 +76,7 @@ type getterFunction = (arg: any) => any;
 interface SimpleTableColumn {
   label: string;
   header?: React.ReactNode;
+  gridTemplate?: number | string;
   cellProps?: {
     [propName: string]: any;
   };
@@ -184,7 +203,20 @@ export default function SimpleTable(props: SimpleTableProps) {
     defaultValue: defaultRowsPerPage,
     prefix,
   });
-  const classes = useTableStyle();
+  const gridTemplateColumns = React.useMemo(() => {
+    const columnsTemplates = columns.map(column => column.gridTemplate || 1);
+    const templates: string[] = [];
+    columnsTemplates.forEach(template => {
+      if (typeof template === 'number') {
+        templates.push(`${template}fr`);
+      } else if (typeof template === 'string') {
+        templates.push(template);
+      }
+    });
+
+    return templates.join(' ');
+  }, [columns]);
+  const classes = useTableStyle({ gridTemplateColumns });
   const [isIncreasingOrder, setIsIncreasingOrder] = React.useState(
     !defaultSortingColumn || defaultSortingColumn > 0
   );

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots SimpleTable Datum 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -127,7 +127,7 @@ exports[`Storyshots SimpleTable Getter 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -455,7 +455,7 @@ exports[`Storyshots SimpleTable Label Search 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -738,7 +738,7 @@ exports[`Storyshots SimpleTable Name Search 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -997,7 +997,7 @@ exports[`Storyshots SimpleTable Namespace Search 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -1268,7 +1268,7 @@ exports[`Storyshots SimpleTable Namespace Select 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -1549,7 +1549,7 @@ exports[`Storyshots SimpleTable Number Search 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"
@@ -1628,7 +1628,7 @@ exports[`Storyshots SimpleTable Reflect In URL 1`] = `
       class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
     >
       <table
-        class="MuiTable-root makeStyles-table"
+        class="MuiTable-root makeStyles-table makeStyles-table"
       >
         <thead
           class="MuiTableHead-root"
@@ -1784,7 +1784,7 @@ exports[`Storyshots SimpleTable Reflect In URL With Prefix 1`] = `
       class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
     >
       <table
-        class="MuiTable-root makeStyles-table"
+        class="MuiTable-root makeStyles-table makeStyles-table"
       >
         <thead
           class="MuiTableHead-root"
@@ -2099,7 +2099,7 @@ exports[`Storyshots SimpleTable UID Search 1`] = `
     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-table"
+      class="MuiTable-root makeStyles-table makeStyles-table"
     >
       <thead
         class="MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
@@ -201,7 +201,7 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -305,7 +305,7 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -447,7 +447,7 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -606,7 +606,7 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -801,7 +801,7 @@ exports[`Storyshots crd/CustomResourceDefinition List 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -288,7 +288,7 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
@@ -312,7 +312,7 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Ast 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"
@@ -725,7 +725,7 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Minute 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -180,7 +180,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -282,7 +282,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -427,7 +427,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
@@ -181,54 +181,17 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="endpoints-0"
                 >
-                  endpoints-0
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  my-namespace
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                style="width: 40%; max-width: 40%;"
-              >
-                127.0.01:8080
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                style="text-align: right;"
-              >
-                <p
-                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
-                  title="2020-01-01T00:00:00.000Z"
-                >
-                  3mo
-                  <span />
-                </p>
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  endpoints-1
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    endpoints-0
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -265,54 +228,17 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="endpoints-1"
                 >
-                  endpoints-2
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  my-namespace
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                style="width: 40%; max-width: 40%;"
-              >
-                127.0.01:8080
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                style="text-align: right;"
-              >
-                <p
-                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
-                  title="2020-01-01T00:00:00.000Z"
-                >
-                  3mo
-                  <span />
-                </p>
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  endpoints-3
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    endpoints-1
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -349,12 +275,111 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
+                <span
+                  class=""
+                  title="endpoints-2"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    endpoints-2
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                   href="/"
                 >
-                  endpoints-4
+                  my-namespace
                 </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="width: 40%; max-width: 40%;"
+              >
+                127.0.01:8080
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="text-align: right;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
+                  title="2020-01-01T00:00:00.000Z"
+                >
+                  3mo
+                  <span />
+                </p>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <span
+                  class=""
+                  title="endpoints-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    endpoints-3
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="/"
+                >
+                  my-namespace
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="width: 40%; max-width: 40%;"
+              >
+                127.0.01:8080
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="text-align: right;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
+                  title="2020-01-01T00:00:00.000Z"
+                >
+                  3mo
+                  <span />
+                </p>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <span
+                  class=""
+                  title="endpoints-4"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    endpoints-4
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -189,7 +189,7 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
                     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
                   >
                     <table
-                      class="MuiTable-root makeStyles-table"
+                      class="MuiTable-root makeStyles-table makeStyles-table"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -322,7 +322,7 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
@@ -249,12 +249,17 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="php-apache"
                 >
-                  php-apache
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    php-apache
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -338,12 +343,17 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="php-apache"
                 >
-                  php-apache
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    php-apache
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -427,12 +437,17 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="php-apache"
                 >
-                  php-apache
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    php-apache
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -516,12 +531,17 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="php-apache"
                 >
-                  php-apache
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    php-apache
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -605,12 +625,17 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="php-apache"
                 >
-                  php-apache
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    php-apache
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/lease/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.stories.storyshot
@@ -227,7 +227,7 @@ exports[`Storyshots Lease/LeaseDetailsView Lease Detail 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/limitRange/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.stories.storyshot
@@ -340,7 +340,7 @@ exports[`Storyshots LimitRange/DetailsView Limit Range Detail 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/limitRange/__snapshots__/List.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots LimitRange/ListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/limitRange/__snapshots__/List.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.stories.storyshot
@@ -174,12 +174,17 @@ exports[`Storyshots LimitRange/ListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="limit-range"
                 >
-                  limit-range
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    limit-range
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
@@ -385,12 +385,17 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                        href="/"
+                      <span
+                        class=""
+                        title="imagepullbackoff"
                       >
-                        imagepullbackoff
-                      </a>
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="/"
+                        >
+                          imagepullbackoff
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -446,12 +451,17 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                        href="/"
+                      <span
+                        class=""
+                        title="successful"
                       >
-                        successful
-                      </a>
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="/"
+                        >
+                          successful
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -507,12 +517,17 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                        href="/"
+                      <span
+                        class=""
+                        title="initializing"
                       >
-                        initializing
-                      </a>
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="/"
+                        >
+                          initializing
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -568,12 +583,17 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                        href="/"
+                      <span
+                        class=""
+                        title="liveness-http"
                       >
-                        liveness-http
-                      </a>
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="/"
+                        >
+                          liveness-http
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -636,12 +656,17 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                        href="/"
+                      <span
+                        class=""
+                        title="terminated"
                       >
-                        terminated
-                      </a>
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="/"
+                        >
+                          terminated
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -704,12 +729,17 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                        href="/"
+                      <span
+                        class=""
+                        title="running"
                       >
-                        running
-                      </a>
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="/"
+                        >
+                          running
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
@@ -233,7 +233,7 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -809,7 +809,7 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots Namespace/ListView Regular 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.stories.storyshot
@@ -174,12 +174,17 @@ exports[`Storyshots Namespace/ListView Regular 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="namespace-0"
                 >
-                  namespace-0
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    namespace-0
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -210,12 +215,17 @@ exports[`Storyshots Namespace/ListView Regular 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="namespace-1"
                 >
-                  namespace-1
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    namespace-1
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -246,12 +256,17 @@ exports[`Storyshots Namespace/ListView Regular 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="namespace-2"
                 >
-                  namespace-2
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    namespace-2
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -282,12 +297,17 @@ exports[`Storyshots Namespace/ListView Regular 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="namespace-3"
                 >
-                  namespace-3
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    namespace-3
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -318,12 +338,17 @@ exports[`Storyshots Namespace/ListView Regular 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="namespace-4"
                 >
-                  namespace-4
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    namespace-4
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -252,7 +252,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -650,7 +650,7 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -1000,7 +1000,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -1527,7 +1527,7 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -1884,7 +1884,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -2374,7 +2374,7 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -2724,7 +2724,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -3102,7 +3102,7 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -3452,7 +3452,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -3861,7 +3861,7 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -4211,7 +4211,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -4614,7 +4614,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
@@ -264,12 +264,17 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="imagepullbackoff"
                 >
-                  imagepullbackoff
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    imagepullbackoff
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -335,12 +340,17 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="successful"
                 >
-                  successful
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    successful
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -406,12 +416,17 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="initializing"
                 >
-                  initializing
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    initializing
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -477,12 +492,17 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="liveness-http"
                 >
-                  liveness-http
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    liveness-http
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -555,12 +575,17 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="terminated"
                 >
-                  terminated
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    terminated
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -633,12 +658,17 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="running"
                 >
-                  running
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    running
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -281,7 +281,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"
@@ -690,7 +690,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
@@ -32,7 +32,7 @@ exports[`Storyshots pods/VolumeDetails Volume Details 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
@@ -207,63 +207,17 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="coredns-pdb"
                 >
-                  coredns-pdb
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  kube-system
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                1
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                N/A
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                1
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                style="text-align: right;"
-              >
-                <p
-                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
-                  title="2020-01-01T00:00:00.000Z"
-                >
-                  3mo
-                  <span />
-                </p>
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  coredns-pdb
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    coredns-pdb
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -309,63 +263,17 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="coredns-pdb"
                 >
-                  coredns-pdb
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  kube-system
-                </a>
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                1
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                N/A
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                1
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                style="text-align: right;"
-              >
-                <p
-                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
-                  title="2020-01-01T00:00:00.000Z"
-                >
-                  3mo
-                  <span />
-                </p>
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
-                >
-                  coredns-pdb
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    coredns-pdb
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -411,12 +319,129 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
+                <span
+                  class=""
+                  title="coredns-pdb"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    coredns-pdb
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                   href="/"
                 >
-                  coredns-pdb
+                  kube-system
                 </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                N/A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="text-align: right;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
+                  title="2020-01-01T00:00:00.000Z"
+                >
+                  3mo
+                  <span />
+                </p>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <span
+                  class=""
+                  title="coredns-pdb"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    coredns-pdb
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="/"
+                >
+                  kube-system
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                N/A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="text-align: right;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
+                  title="2020-01-01T00:00:00.000Z"
+                >
+                  3mo
+                  <span />
+                </p>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <span
+                  class=""
+                  title="coredns-pdb"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    coredns-pdb
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
@@ -165,12 +165,17 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="high-priority-apps"
                 >
-                  high-priority-apps
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    high-priority-apps
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -201,12 +206,17 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="high-priority-apps"
                 >
-                  high-priority-apps
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    high-priority-apps
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -237,12 +247,17 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="high-priority-apps"
                 >
-                  high-priority-apps
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    high-priority-apps
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -273,12 +288,17 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="high-priority-apps"
                 >
-                  high-priority-apps
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    high-priority-apps
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -309,12 +329,17 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="high-priority-apps"
                 >
-                  high-priority-apps
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    high-priority-apps
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -172,7 +172,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
                     class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
                   >
                     <table
-                      class="MuiTable-root makeStyles-table"
+                      class="MuiTable-root makeStyles-table makeStyles-table"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -301,7 +301,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
               class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
             >
               <table
-                class="MuiTable-root makeStyles-table"
+                class="MuiTable-root makeStyles-table makeStyles-table"
               >
                 <thead
                   class="MuiTableHead-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
@@ -91,7 +91,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
         class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
       >
         <table
-          class="MuiTable-root makeStyles-table"
+          class="MuiTable-root makeStyles-table makeStyles-table"
         >
           <thead
             class="MuiTableHead-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
@@ -186,12 +186,17 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="test-cpu-quota"
                 >
-                  test-cpu-quota
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    test-cpu-quota
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -256,12 +261,17 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="test-cpu-quota"
                 >
-                  test-cpu-quota
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    test-cpu-quota
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -326,12 +336,17 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="test-cpu-quota"
                 >
-                  test-cpu-quota
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    test-cpu-quota
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -396,12 +411,17 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="test-cpu-quota"
                 >
-                  test-cpu-quota
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    test-cpu-quota
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -466,12 +486,17 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                <a
-                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="/"
+                <span
+                  class=""
+                  title="test-cpu-quota"
                 >
-                  test-cpu-quota
-                </a>
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    test-cpu-quota
+                  </a>
+                </span>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"


### PR DESCRIPTION
This PR increases the width of the inner container so we can pack the information given by the `-o wide` option for `kubectl`.
It also changes how the table is displayed to be a grid instead.

Known problems:
- [ ] The bar charts on the Node list view show the popup as being clipped by the cell's contents: hover on the chart to reproduce