### PR TITLE
frontend: TopBar: Fix icon centering in mobile

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -326,11 +326,19 @@ export function PureTopBar({
     ...appBarActions,
     {
       id: DefaultAppBarAction.NOTIFICATION,
-      action: <Notifications />,
+      action: (
+        <MenuItem>
+          <Notifications />
+        </MenuItem>
+      ),
     },
     {
       id: DefaultAppBarAction.SETTINGS,
-      action: <SettingsButton onClickExtra={handleMenuClose} />,
+      action: (
+        <MenuItem>
+          <SettingsButton onClickExtra={handleMenuClose} />
+        </MenuItem>
+      ),
     },
     {
       id: DefaultAppBarAction.USER,


### PR DESCRIPTION

before:
![image](https://github.com/headlamp-k8s/headlamp/assets/9541/d8e56648-0845-4301-9ddf-2c3d990f7d70)


after:

![Screenshot 2023-07-14 125330](https://github.com/headlamp-k8s/headlamp/assets/9541/2f69505e-0238-4e9e-9fd7-36865730fb48)
