### PR TITLE
frontend: TopBar: Fix mobile menu to close when popup opens

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -327,7 +327,7 @@ export function PureTopBar({
     {
       id: DefaultAppBarAction.NOTIFICATION,
       action: (
-        <MenuItem>
+        <MenuItem onClick={handleMenuClose}>
           <Notifications />
         </MenuItem>
       ),
@@ -349,7 +349,10 @@ export function PureTopBar({
             aria-controls={userMenuId}
             aria-haspopup="true"
             color="inherit"
-            onClick={handleProfileMenuOpen}
+            onClick={event => {
+              handleMenuClose();
+              handleProfileMenuOpen(event);
+            }}
           >
             <Icon icon="mdi:account" />
           </IconButton>


### PR DESCRIPTION
So that people can interact with the new popup. 

To test this, touch the notification icon from the mobile menu. Note how you can not scroll the list of notifications? With this fix people can scroll the list of notifications when it pops up.