### PR TITLE
charts: Fix 404 home page link, add new source link, fix maintainers URL, screenshots, keywords

### DIFF
--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: headlamp
 description: Headlamp is an easy-to-use and extensible Kubernetes web UI.
 icon: https://raw.githubusercontent.com/headlamp-k8s/headlamp/main/docs/headlamp_light.svg
-home: https://github.com/headlamp-k8s/headlamp/tree/main/deploy/helm
+home: https://headlamp.dev/
 type: application
 keywords:
   - kubernetes
@@ -10,8 +10,8 @@ keywords:
   - kinvolk
   - headlamp
 sources:
+  - https://github.com/headlamp-k8s/headlamp/tree/main/charts/headlamp
   - https://github.com/headlamp-k8s/headlamp
-  - https://headlamp.dev/
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/

--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -9,6 +9,11 @@ keywords:
   - plugins
   - kinvolk
   - headlamp
+  - dashboard
+  - ui
+  - web
+  - monitoring
+  - logging
 sources:
   - https://github.com/headlamp-k8s/headlamp/tree/main/charts/headlamp
   - https://github.com/headlamp-k8s/headlamp

--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -17,3 +17,19 @@ maintainers:
     url: https://kinvolk.io/
 version: 0.13.0
 appVersion: 0.18.0
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/screenshots: |
+    - title: Cluster Overview
+      url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_overview.png
+    - title: Cluster Chooser
+      url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_chooser.png
+    - title: Nodes
+      url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/nodes.png
+    - title: Resource edition
+      url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/resource_edition.png
+    - title: Editor Documentation
+      url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/editor_documentation.png
+    - title: Terminal
+      url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/terminal.png

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -14,9 +14,7 @@ $ helm install my-headlamp headlamp/headlamp --namespace kube-system
 
 ## Maintainers
 
-| Name | Url |
-| ---- | --- |
-| kinvolk | https://kinvolk.io/ |
+See [MAINTAINERS.md](https://github.com/headlamp-k8s/headlamp/blob/main/MAINTAINERS.md) in the headlamp github repo.
 
 ## Source Code
 


### PR DESCRIPTION
- Fix 404 home page link, add new source link (This link https://github.com/headlamp-k8s/headlamp/tree/main/deploy/helm is a 404)
- Fix maintainers URL from kinvolk to MAINTAINERS.md
- Add screenshots, category, and license for artifacthub (See https://artifacthub.io/docs/topics/annotations/helm/)
- Add some keywords

See artifact page here: https://artifacthub.io/packages/helm/headlamp/headlamp
