### PR TITLE
frontend: SidebarItem: Fix focus background color

### DIFF
--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -37,6 +37,9 @@ const useItemStyle = makeStyles(theme => ({
         color: theme.palette.sidebarLink.hover.color,
       },
     },
+    '& a.Mui-focusVisible': {
+      backgroundColor: theme.palette.sidebarLink.hover.backgroundColor,
+    },
     '& svg': {
       color: theme.palette.sidebarLink.color,
     },
@@ -105,6 +108,9 @@ const useItemStyle = makeStyles(theme => ({
     backgroundColor: `${theme.palette.sidebarLink.main.selected.backgroundColor}!important`,
     '& .MuiListItemText-secondary': {
       color: theme.palette.sidebarLink.main.selected.color,
+    },
+    '& a.Mui-focusVisible': {
+      backgroundColor: theme.palette.sidebarLink.selected.backgroundColor,
     },
   },
   linkSelected: {


### PR DESCRIPTION
When tabbing with the keyboard through the links, it was not
obvious with color which link was focused in light mode theme.

Fixes https://github.com/headlamp-k8s/headlamp/issues/1234