### PR TITLE
frontend Sidebar: Add a different color to selected sub-entries

### DIFF
--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -52,7 +52,7 @@ const commonRules = {
         color: '#fff',
       },
       selected: {
-        color: '#fff',
+        color: '#fff099',
         backgroundColor: 'unset',
       },
       hover: {


### PR DESCRIPTION
This is in order for the currently selected entry to be more actively distinguishable.

Old/current:

![old screenshot](https://github.com/headlamp-k8s/headlamp/assets/1029635/b4327c33-74d3-4070-8dd3-9618fff507e4)


New:
![new screenshot](https://github.com/headlamp-k8s/headlamp/assets/1029635/9889cf39-9e49-4e1c-85d2-566dca409538)
