### PR TITLE
frontend plugin: Check plugins' compatibility with the plugin engine

### DIFF
--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -29,6 +29,15 @@ export type PluginInfo = {
 
   version?: string; // unused by PluginSettings
   author?: string; // unused by PluginSettings
+
+  /** Information about engines related to this plugin. */
+  engines?: {
+    /** The version of the headlamp plugin engine this plugin is compatible with. */
+    headlampPlugin?: string;
+    [key: string]: string | undefined;
+  };
+
+  [key: string]: any;
 };
 
 export interface PluginsState {

--- a/frontend/src/plugin/testCompatibility.test.ts
+++ b/frontend/src/plugin/testCompatibility.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from '@jest/globals';
+import { getPluginEngineVersion, isCompatiblePluginVersion } from './index';
+import { PluginInfo } from './pluginsSlice';
+
+const basePlugin: PluginInfo = {
+  name: 'our-plugin',
+  description: 'package description',
+  homepage: 'https://example.com/plugin',
+  version: '1.0.0',
+  author: 'me',
+};
+
+describe('plugin compatibility test', () => {
+  test('no filter when Headlamp has no minimum engine version', () => {
+    expect(getPluginEngineVersion(basePlugin)).toBe(undefined);
+    expect(isCompatiblePluginVersion(basePlugin, '')).toBe(true);
+
+    const myPlugin = { ...basePlugin };
+    myPlugin.engines = {
+      headlampPlugin: '2.5.0',
+    };
+    expect(getPluginEngineVersion(myPlugin)).toBe('2.5.0');
+    expect(isCompatiblePluginVersion(myPlugin, '')).toBe(true);
+  });
+
+  test('filter plugins with no version set', () => {
+    expect(getPluginEngineVersion(basePlugin)).toBe(undefined);
+    expect(isCompatiblePluginVersion(basePlugin, '>=1.0.0')).toBe(false);
+  });
+
+  test('filter plugins with version set as engine', () => {
+    const myPlugin = { ...basePlugin };
+    myPlugin.engines = {
+      headlampPlugin: '2.5.0',
+    };
+    expect(getPluginEngineVersion(myPlugin)).toBe('2.5.0');
+    expect(isCompatiblePluginVersion(myPlugin, '>=2.0.0')).toBe(true);
+
+    myPlugin.engines = {
+      headlampPlugin: '1.6.0',
+    };
+
+    expect(isCompatiblePluginVersion(myPlugin, '>=2.0.0')).toBe(false);
+  });
+
+  test('filter plugins with version set from dependency', () => {
+    const myPlugin = { ...basePlugin };
+    myPlugin.devDependencies = {
+      '@kinvolk/headlamp-plugin': '2.5.0',
+    };
+
+    expect(getPluginEngineVersion(myPlugin)).toBe('2.5.0');
+    expect(isCompatiblePluginVersion(myPlugin, '>=2.x')).toBe(true);
+  });
+});


### PR DESCRIPTION
This patch adds a way for checking for plugins' compatibility with the plugin engine the current Headlamp build uses, and uses the new functions for filtering plugins when loading them initially.

Tests for the compatibility functions are also added.

How to test:
- [ ] Verify that (without changes), plugins are loaded
- [ ] Change the `compatibleHeadlampPluginVersion` to something like `0.0.1`, then load headlamp with plugins: verify that plugins are not loaded
- [ ] Change the mentioned version for `>=0.0.1`, realize the plugins are loaded

fixes #423 