### PR TITLE
charts: Fix liveness and readiness probes

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -90,11 +90,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: "{{ .Values.config.baseURL }}/"
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: "{{ .Values.config.baseURL }}/"
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Previously when user changed baseURL for the application it was not reflecting with liveness and readiness probes. Due to which the application was crashing.

Fixes: #1266