### PR TITLE
frontend: Create nav link for ingress

### DIFF
--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -1,11 +1,156 @@
+import { Box, Link, Typography } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import Ingress, { IngressRule } from '../../lib/k8s/ingress';
+import { IngressBackend } from '../../lib/k8s/ingress';
 import { useSettings } from '../App/Settings/hook';
 import LabelListItem from '../common/LabelListItem';
 import { DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
+
+/**
+ * Is https used in the ingress item
+ */
+function isHttpsUsed(item: Ingress, url: String) {
+  const hostList: string[] = item.jsonData.spec?.tls?.map(({ ...hosts }) => `${hosts.hosts}`);
+  const isHttps = hostList.includes(`${url}`);
+
+  return isHttps;
+}
+
+export interface LinkStringFormatProps {
+  url: string;
+  item: Ingress;
+  urlPath?: string;
+}
+
+/**
+ * Format the url to be used in the Link component
+ */
+export function LinkStringFormat({ url, item, urlPath }: LinkStringFormatProps) {
+  let urlProtocol;
+  let formatURL;
+
+  /**
+   * Renders the "host" field as we intentionally do not supply a path.
+   * If the url is set to * or undefined/empty, and the optional path is not used, print url
+   */
+  if ((url === '*' || !url) && !urlPath) {
+    return <Typography>{url || ''}</Typography>;
+  }
+
+  /**
+   * Renders the "path" field as we intentionally supply both a path and url.
+   */
+  if ((url === '*' || !url) && urlPath) {
+    return <Typography>{urlPath}</Typography>;
+  } else {
+    /*
+     * If the ingress does not use tls, then the url should be http
+     */
+    if (!item.jsonData.spec?.tls) {
+      urlProtocol = 'http://';
+    } else {
+      /*
+       * If the url is in the tls array, then the url should be https
+       */
+      isHttpsUsed(item, url) ? (urlProtocol = 'https://') : (urlProtocol = 'http://');
+    }
+
+    /*
+     * Since we cannot access the prefix from the ingress object, we have to access it from the rules array
+     */
+    const rules: any[] = item.spec.rules;
+    let currentPathType;
+    if (rules) {
+      for (let i = 0; i < rules.length; i++) {
+        for (let j = 0; j < rules[i].http.paths.length; j++) {
+          if (rules[i].http.paths[j].path === urlPath) {
+            currentPathType = rules[i].http.paths[j].pathType;
+          }
+        }
+      }
+    }
+
+    function isValidURL(url: string): boolean {
+      try {
+        new URL(url);
+      } catch (e) {
+        return false;
+      }
+      return true;
+    }
+
+    /**
+     * Adding the protocol to the url string is required for the URL constructor to work because data.host is only the host name
+     */
+    if (!isValidURL(urlProtocol + url)) {
+      console.debug(`Ingress' host ${url} is not a valid URL; displaying it without a link.`);
+      return <Typography>{url}</Typography>;
+    }
+
+    formatURL = new URL(urlProtocol + url);
+
+    if (formatURL && urlPath) {
+      return (
+        <Box style={{ display: 'flex', marginBottom: '5px' }}>
+          <Link
+            href={`${formatURL.protocol}//${formatURL.hostname}${urlPath}`}
+            style={{ marginRight: '5px' }}
+          >
+            {urlPath}
+          </Link>
+          {`(${currentPathType})`}
+        </Box>
+      );
+    }
+
+    return <Link href={formatURL.toString()}>{`${formatURL.toString()}`}</Link>;
+  }
+}
+
+export interface BackendFormatProps {
+  backend: IngressBackend[];
+}
+
+/**
+ * Used to format the backend to be used in the backends field
+ */
+
+export function BackendFormat({ backend }: BackendFormatProps) {
+  const backendList: string[] = [];
+  for (const backendItem of backend) {
+    let currentBackend: string = '';
+
+    if (!!backendItem.resource) {
+      currentBackend = backendItem.resource.kind + ':' + backendItem.resource.name;
+    }
+    if (!!backendItem.service) {
+      currentBackend =
+        backendItem.service.name +
+        ':' +
+        (backendItem.service.port.number ?? backendItem.service.port.name ?? '').toString();
+    }
+
+    backendList.push(currentBackend);
+  }
+
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flexWrap: 'nowrap',
+        marginBottom: '5px',
+      }}
+    >
+      {backendList.map(backendItem => (
+        <Typography>{backendItem}</Typography>
+      ))}
+    </Box>
+  );
+}
 
 export default function IngressDetails() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
@@ -80,33 +225,21 @@ export default function IngressDetails() {
               columns={[
                 {
                   label: t('Host'),
-                  getter: (data: IngressRule) => data.host || '*',
+                  getter: (data: IngressRule) => (
+                    <LinkStringFormat url={data.host || '*'} item={item} />
+                  ),
                 },
                 {
                   label: t('Path'),
-                  getter: (data: IngressRule) => data.http.paths.map(({ path }) => path).join(', '),
+                  getter: (data: IngressRule) =>
+                    data.http.paths.map(({ path }) => (
+                      <LinkStringFormat url={data.host || '*'} item={item} urlPath={path} />
+                    )),
                 },
                 {
                   label: t('Backends'),
                   getter: (data: IngressRule) => (
-                    <LabelListItem
-                      labels={data.http.paths.map(({ backend }) => {
-                        if (!!backend.resource) {
-                          return backend.resource.kind + ':' + backend.resource.name;
-                        }
-                        if (!!backend.service) {
-                          return (
-                            backend.service.name +
-                            ':' +
-                            (
-                              backend.service.port.number ??
-                              backend.service.port.name ??
-                              ''
-                            ).toString()
-                          );
-                        }
-                      })}
-                    />
+                    <BackendFormat backend={data.http.paths.map(({ backend }) => backend)} />
                   ),
                 },
               ]}

--- a/frontend/src/components/ingress/LinkStringFormat.stories.tsx
+++ b/frontend/src/components/ingress/LinkStringFormat.stories.tsx
@@ -1,0 +1,156 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import Ingress from '../../lib/k8s/ingress';
+import { LinkStringFormat, LinkStringFormatProps } from './Details';
+
+export default {
+  title: 'ingress/LinkStringFormat',
+  component: LinkStringFormat,
+  argTypes: {},
+} as Meta;
+
+const Template: Story<LinkStringFormatProps> = args => <LinkStringFormat {...args} />;
+
+const noPath = new Ingress({
+  kind: 'Ingress',
+  metadata: {
+    name: 'test',
+    namespace: 'test',
+    uid: '',
+    creationTimestamp: '',
+  },
+  spec: {
+    rules: [
+      {
+        host: 'examplehost.com',
+        http: {
+          paths: [
+            {
+              path: '/',
+              pathType: 'Prefix',
+              backend: {
+                service: {
+                  name: 'test',
+                  port: {
+                    number: 80,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+const onePath = new Ingress({
+  kind: 'Ingress',
+  metadata: {
+    name: 'test',
+    namespace: 'test',
+    uid: '',
+    creationTimestamp: '',
+  },
+  spec: {
+    rules: [
+      {
+        host: 'examplehost.com',
+        http: {
+          paths: [
+            {
+              path: '/pathA',
+              pathType: 'Prefix',
+              backend: {
+                service: {
+                  name: 'test',
+                  port: {
+                    number: 80,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+const multiplePath = new Ingress({
+  kind: 'Ingress',
+  metadata: {
+    name: 'test',
+    namespace: 'test',
+    uid: '',
+    creationTimestamp: '',
+  },
+  spec: {
+    rules: [
+      {
+        host: 'examplehost.com',
+        http: {
+          paths: [
+            {
+              path: '/pathA',
+              pathType: 'Prefix',
+              backend: {
+                service: {
+                  name: 'test',
+                  port: {
+                    number: 80,
+                  },
+                },
+              },
+            },
+            {
+              path: '/pathB',
+              pathType: 'Prefix',
+              backend: {
+                service: {
+                  name: 'test',
+                  port: {
+                    number: 80,
+                  },
+                },
+              },
+            },
+            {
+              path: '/pathC',
+              pathType: 'Prefix',
+              backend: {
+                service: {
+                  name: 'test',
+                  port: {
+                    number: 80,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+export const Empty = Template.bind({});
+Empty.args = {
+  url: 'exampleurl.com',
+  item: noPath,
+  urlPath: '/',
+};
+
+export const soloPath = Template.bind({});
+soloPath.args = {
+  url: 'exampleurl.com',
+  item: onePath,
+  urlPath: '/pathA',
+};
+
+export const morePath = Template.bind({});
+morePath.args = {
+  url: 'exampleurl.com',
+  item: multiplePath,
+  urlPath: '/pathB',
+};

--- a/frontend/src/components/ingress/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.stories.storyshot
@@ -247,22 +247,43 @@ exports[`Storyshots Ingress/DetailsView With Resource 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      https-example.foo.com
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                    >
-                      /
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                    >
-                      <span
-                        class=""
-                        title="Service:service1"
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                        href="http://https-example.foo.com/"
                       >
-                        Service:service1
-                      </span>
+                        http://https-example.foo.com/
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                        style="display: flex; margin-bottom: 5px;"
+                      >
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="http://https-example.foo.com/"
+                          style="margin-right: 5px;"
+                        >
+                          /
+                        </a>
+                        (Prefix)
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                        style="display: flex; flex-direction: column; flex-wrap: nowrap; margin-bottom: 5px;"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1"
+                        >
+                          Service:service1
+                        </p>
+                      </div>
                     </td>
                   </tr>
                 </tbody>
@@ -682,23 +703,61 @@ exports[`Storyshots Ingress/DetailsView With TLS 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      https-example.foo.com
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                    >
-                      /, /second
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-                    >
-                      <span
-                        class=""
-                        title="service1:80
-service2:someport"
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                        href="https://https-example.foo.com/"
                       >
-                        service1:80, service2:someport
-                      </span>
+                        https://https-example.foo.com/
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                        style="display: flex; margin-bottom: 5px;"
+                      >
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="https://https-example.foo.com/"
+                          style="margin-right: 5px;"
+                        >
+                          /
+                        </a>
+                        (Prefix)
+                      </div>
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                        style="display: flex; margin-bottom: 5px;"
+                      >
+                        <a
+                          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                          href="https://https-example.foo.com/second"
+                          style="margin-right: 5px;"
+                        >
+                          /second
+                        </a>
+                        (Prefix)
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                        style="display: flex; flex-direction: column; flex-wrap: nowrap; margin-bottom: 5px;"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1"
+                        >
+                          service1:80
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1"
+                        >
+                          service2:someport
+                        </p>
+                      </div>
                     </td>
                   </tr>
                 </tbody>

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.stories.storyshot
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots ingress/LinkStringFormat Empty 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+    style="display: flex; margin-bottom: 5px;"
+  >
+    <a
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+      href="http://exampleurl.com/"
+      style="margin-right: 5px;"
+    >
+      /
+    </a>
+    (Prefix)
+  </div>
+</div>
+`;
+
+exports[`Storyshots ingress/LinkStringFormat More Path 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+    style="display: flex; margin-bottom: 5px;"
+  >
+    <a
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+      href="http://exampleurl.com/pathB"
+      style="margin-right: 5px;"
+    >
+      /pathB
+    </a>
+    (Prefix)
+  </div>
+</div>
+`;
+
+exports[`Storyshots ingress/LinkStringFormat Solo Path 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+    style="display: flex; margin-bottom: 5px;"
+  >
+    <a
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+      href="http://exampleurl.com/pathA"
+      style="margin-right: 5px;"
+    >
+      /pathA
+    </a>
+    (Prefix)
+  </div>
+</div>
+`;

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -16,6 +16,7 @@ export interface IngressRule {
   http: {
     paths: {
       path: string;
+      pathType?: string;
       backend: IngressBackend;
     }[];
   };
@@ -26,7 +27,7 @@ interface LegacyIngressBackend {
   servicePort: string;
 }
 
-interface IngressBackend {
+export interface IngressBackend {
   service?: {
     name: string;
     port: {
@@ -43,7 +44,7 @@ interface IngressBackend {
 
 export interface KubeIngress extends KubeObjectInterface {
   spec: {
-    ingressClassName: string;
+    ingressClassName?: string;
     rules: IngressRule[] | LegacyIngressRule[];
     tls?: {
       hosts: string[];


### PR DESCRIPTION
Related to issue #1268 

## Description
This PR addresses the enhancement requested in issue #1268 . The purpose was to transform the host in the ingress rules into a clickable link, thereby eliminating the need for users to manually copy and paste the URL to open the endpoint.

## Changes
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/c0850cd5-14fa-4dee-82c3-3117d9b3003a)

- [x]  Functional links within the field Host
- [x]  Additional links for path field for specific routing
- [x] Created logic for determining url protocols based on ingress tls, defaults to http when not using tls

## Notes
- To validate this change, I created example pod, service, and host with the host set to bing. The changes work for formatted URL stings only, but will print '*' if needed and will not print any links if no host is written.
- When using tls and host is within fields, protocol is set to https, if not using tls or if it is not found, defaults to http

Using tls
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/b9608a33-f21a-434c-b4e5-05048179a121)

Not using tls
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/3a8b2e48-c6f0-4684-81eb-993482a1f487)

