### PR TITLE
frontend: Fixes ingress render

### DIFF
--- a/frontend/src/components/common/LabelListItem.tsx
+++ b/frontend/src/components/common/LabelListItem.tsx
@@ -6,7 +6,7 @@ export interface LabelListItemProps {
 }
 
 export default function LabelListItem(props: LabelListItemProps) {
-  const { labels } = props;
+  const { labels = [] } = props;
   const [text, tooltip] = React.useMemo(() => {
     const text = labels.join(', ');
     const tooltip = labels.join('\n');

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -84,7 +84,7 @@ class Ingress extends makeKubeObject<KubeIngress>('ingress') {
 
     const rules: IngressRule[] = [];
 
-    this.spec!.rules.forEach(({ http, host }) => {
+    this.spec!.rules?.forEach(({ http, host }) => {
       const paths = http.paths.map(({ backend, path }) => {
         if (!!(backend as IngressBackend).service) {
           return {


### PR DESCRIPTION
This PR resolves an issue that was causing the Ingress tab to fail to load, resulting in a blank screen for users. The problem stemmed from a bug in the rendering logic for the Ingress resources. 