### PR TITLE
Add collapse to events table + fix simple table

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -15,6 +15,7 @@ import Empty from '../common/EmptyContent';
 import { PageGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { SectionBox } from '../common/SectionBox';
+import ShowHideLabel from '../common/ShowHideLabel';
 import { LightTooltip } from '../common/Tooltip';
 import { CpuCircularChart, MemoryCircularChart, PodsStatusCircleChart } from './Charts';
 
@@ -175,7 +176,9 @@ function EventsSection() {
         },
         {
           label: t('frequent|Message'),
-          getter: event => event?.message || '',
+          getter: event => (
+            <ShowHideLabel labelId={event.metadata?.uid || ''}>{event.message || ''}</ShowHideLabel>
+          ),
           sort: true,
           gridTemplate: 1.5,
         },

--- a/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
@@ -555,7 +555,16 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                       >
-                        Started container hello
+                        <div
+                          class="MuiBox-root MuiBox-root"
+                        >
+                          <label
+                            class="makeStyles-fullText"
+                            id="a12345"
+                          >
+                            Started container hello
+                          </label>
+                        </div>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -614,7 +623,16 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                       >
-                        failed to get cpu utilization: missing request for cpu
+                        <div
+                          class="MuiBox-root MuiBox-root"
+                        >
+                          <label
+                            class="makeStyles-fullText"
+                            id="b12345"
+                          >
+                            failed to get cpu utilization: missing request for cpu
+                          </label>
+                        </div>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -4,6 +4,7 @@ import { KubeObject } from '../../lib/k8s/cluster';
 import Event, { KubeEvent } from '../../lib/k8s/event';
 import { localeDate, timeAgo } from '../../lib/util';
 import { HoverInfoLabel, SectionBox, SimpleTable } from '../common';
+import ShowHideLabel from './ShowHideLabel';
 
 export interface ObjectEventListProps {
   object: KubeObject;
@@ -47,7 +48,13 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('frequent|Message'),
             getter: item => {
-              return item.message;
+              return (
+                item && (
+                  <ShowHideLabel labelId={item?.metadata?.uid || ''}>
+                    {item.message || ''}
+                  </ShowHideLabel>
+                )
+              );
             },
           },
           {

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.stories.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.stories.tsx
@@ -1,0 +1,42 @@
+import { Box } from '@material-ui/core';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import ShowHideLabel, { ShowHideLabelProps } from './ShowHideLabel';
+
+export default {
+  title: 'common/ShowHideLabel',
+  component: ShowHideLabel,
+  argTypes: {},
+} as Meta;
+
+const Template: Story<ShowHideLabelProps> = args => (
+  <Box width={300}>
+    <ShowHideLabel {...args} />
+  </Box>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  children:
+    'This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic preview of how the label will look in the final UI. You can replace this text with the actual label text once it is available. This will ensure that the UI looks complete and professional even during the development phase. Thank you for using this placeholder text!',
+  labelId: 'label-id',
+};
+
+export const Expanded = Template.bind({});
+Expanded.args = {
+  children:
+    'This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic preview of how the label will look in the final UI. You can replace this text with the actual label text once it is available. This will ensure that the UI looks complete and professional even during the development phase. Thank you for using this placeholder text!',
+  show: true,
+  labelId: 'my-label',
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  children: '',
+  labelId: 'my-label1',
+};
+
+export const ShortText = Template.bind({});
+ShortText.args = {
+  children: 'Short text',
+  labelId: 'my-label2',
+};

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
@@ -1,0 +1,78 @@
+import { Icon } from '@iconify/react';
+import { Box, IconButton } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const useStyles = makeStyles({
+  fullText: {
+    wordBreak: 'break-all',
+  },
+  button: {
+    display: 'inline',
+  },
+});
+
+export interface ShowHideLabelProps {
+  children: string;
+  show?: boolean;
+  labelId?: string;
+  maxChars?: number;
+}
+
+export default function ShowHideLabel(props: ShowHideLabelProps) {
+  const { show = false, labelId = '', maxChars = 256, children } = props;
+  const { t } = useTranslation('frequent');
+  const [expanded, setExpanded] = React.useState(show);
+  const classes = useStyles();
+
+  const labelIdOrRandom = React.useMemo(() => {
+    if (!!labelId || !!process.env.UNDER_TEST) {
+      return labelId;
+    }
+
+    return `${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 5)}`;
+  }, [labelId]);
+
+  const [actualText, needsButton] = React.useMemo(() => {
+    if (typeof children !== 'string') {
+      return ['', false];
+    }
+
+    if (expanded) {
+      return [children, true];
+    }
+
+    return [children.substr(0, maxChars), children.length > maxChars];
+  }, [children, expanded]);
+
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <Box display={expanded ? 'block' : 'flex'}>
+      <label
+        id={labelIdOrRandom}
+        className={classes.fullText}
+        aria-expanded={!needsButton ? undefined : expanded}
+      >
+        {actualText}
+        {needsButton && (
+          <>
+            {!expanded && '…'}
+            <IconButton
+              aria-controls={labelIdOrRandom}
+              className={classes.button}
+              onClick={() => setExpanded(expandedVal => !expandedVal)}
+              size="small"
+              arial-label={expanded ? t('frequent|Collapse') : t('frequent|Expand')}
+            >
+              <Icon icon={expanded ? 'mdi:menu-up' : 'mdi:menu-down'} />
+            </IconButton>
+          </>
+        )}
+      </label>
+    </Box>
+  );
+}

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.stories.storyshot
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots common/ShowHideLabel Basic 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    <div
+      class="MuiBox-root MuiBox-root"
+    >
+      <label
+        aria-expanded="false"
+        class="makeStyles-fullText"
+        id="label-id"
+      >
+        This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic pr
+        …
+        <button
+          aria-controls="label-id"
+          arial-label="Expand"
+          class="MuiButtonBase-root MuiIconButton-root makeStyles-button MuiIconButton-sizeSmall"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span />
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots common/ShowHideLabel Empty 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  />
+</div>
+`;
+
+exports[`Storyshots common/ShowHideLabel Expanded 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    <div
+      class="MuiBox-root MuiBox-root"
+    >
+      <label
+        aria-expanded="true"
+        class="makeStyles-fullText"
+        id="my-label"
+      >
+        This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic preview of how the label will look in the final UI. You can replace this text with the actual label text once it is available. This will ensure that the UI looks complete and professional even during the development phase. Thank you for using this placeholder text!
+        <button
+          aria-controls="my-label"
+          arial-label="Collapse"
+          class="MuiButtonBase-root MuiIconButton-root makeStyles-button MuiIconButton-sizeSmall"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span />
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots common/ShowHideLabel Short Text 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    <div
+      class="MuiBox-root MuiBox-root"
+    >
+      <label
+        class="makeStyles-fullText"
+        id="my-label2"
+      >
+        Short text
+      </label>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/common/ShowHideLabel/index.tsx
+++ b/frontend/src/components/common/ShowHideLabel/index.tsx
@@ -1,0 +1,3 @@
+export * from './ShowHideLabel';
+import ShowHideLabel from './ShowHideLabel';
+export default ShowHideLabel;

--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -406,6 +406,12 @@ NumberSearch.args = {
   search: '30',
 };
 
+export const NotFoundMessage = TemplateWithFilter.bind({});
+NotFoundMessage.args = {
+  simpleTableArgs: podData,
+  search: 'somethingthatsnotapossiblematch123',
+};
+
 // emptyMessage
 // defaultSortingColumn
 // rowsPerPage

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -435,7 +435,7 @@ export default function SimpleTable(props: SimpleTableProps) {
             ))
           ) : (
             <TableRow>
-              <TableCell colSpan={columns.length}>
+              <TableCell style={{ gridColumn: `span ${columns.length}` }}>
                 <Empty>{t('No data matching the filter criteria.')}</Empty>
               </TableCell>
             </TableRow>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -1357,6 +1357,259 @@ exports[`Storyshots SimpleTable Namespace Select 1`] = `
 </div>
 `;
 
+exports[`Storyshots SimpleTable Not Found Message 1`] = `
+<div>
+  <div
+    class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
+        <h1
+          class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+        >
+          Test
+        </h1>
+        <div
+          class="MuiBox-root MuiBox-root"
+        />
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-wrap-xs-nowrap MuiGrid-align-items-xs-flex-end MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                aria-expanded="false"
+                class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                role="combobox"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                    style="margin-top: 0px;"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+                      data-shrink="true"
+                      for="namespaces-filter"
+                      id="namespaces-filter-label"
+                    >
+                      Namespaces
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                    >
+                      <input
+                        aria-autocomplete="both"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                        id="namespaces-filter"
+                        placeholder="Filter"
+                        spellcheck="false"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        class="MuiAutocomplete-endAdornment"
+                      >
+                        <button
+                          aria-label="Clear"
+                          class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                          tabindex="-1"
+                          title="Clear"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                        <button
+                          aria-label="Open"
+                          class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                          tabindex="-1"
+                          title="Open"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M7 10l5 5 5-5z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled MuiFormLabel-focused MuiInputLabel-focused"
+                  data-shrink="true"
+                  for="standard-search"
+                  id="standard-search-label"
+                >
+                  Search
+                </label>
+                <div
+                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-focused MuiInput-focused MuiInputBase-formControl MuiInput-formControl"
+                  role="search"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputTypeSearch MuiInput-inputTypeSearch"
+                    id="standard-search"
+                    placeholder="Filter"
+                    type="search"
+                    value="somethingthatsnotapossiblematch123"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                aria-controls="standard-search"
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiButton-label"
+                >
+                  Clear
+                  <span
+                    class="MuiButton-endIcon MuiButton-iconSizeMedium"
+                  >
+                    <span />
+                  </span>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPaper-root MuiTableContainer-root makeStyles-tableContainer MuiPaper-outlined MuiPaper-rounded"
+  >
+    <table
+      class="MuiTable-root makeStyles-table makeStyles-table"
+    >
+      <thead
+        class="MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
+            scope="col"
+          >
+            Name
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
+            scope="col"
+          >
+            Namespace
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
+            scope="col"
+          >
+            UID
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
+            scope="col"
+          >
+            Labels
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+            style="grid-column: span 4;"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-alignCenter"
+              >
+                No data matching the filter criteria.
+              </p>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`Storyshots SimpleTable Number Search 1`] = `
 <div>
   <div

--- a/frontend/src/components/common/index.test.ts
+++ b/frontend/src/components/common/index.test.ts
@@ -33,6 +33,7 @@ const checkExports = [
   'SectionBox',
   'SectionFilterHeader',
   'SectionHeader',
+  'ShowHideLabel',
   'SimpleTable',
   'Tabs',
   'Terminal',

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -28,6 +28,8 @@ export * from './SectionFilterHeader';
 export { default as SectionFilterHeader } from './SectionFilterHeader';
 export * from './SectionHeader';
 export { default as SectionHeader } from './SectionHeader';
+export * from './ShowHideLabel';
+export { default as ShowHideLabel } from './ShowHideLabel';
 export * from './SimpleTable';
 export { default as SimpleTable } from './SimpleTable';
 export * from './Tabs';

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
@@ -685,7 +685,16 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -367,7 +367,16 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.stories.storyshot
@@ -380,7 +380,16 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Ast 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                Created
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <label
+                    class="makeStyles-fullText"
+                    id=""
+                  >
+                    Created
+                  </label>
+                </div>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -782,7 +791,16 @@ exports[`Storyshots CronJob/CronJobDetailsView Every Minute 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
-                Created
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <label
+                    class="makeStyles-fullText"
+                    id=""
+                  >
+                    Created
+                  </label>
+                </div>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -506,7 +506,16 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/lease/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.stories.storyshot
@@ -306,7 +306,16 @@ exports[`Storyshots Lease/LeaseDetailsView Lease Detail 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/limitRange/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.stories.storyshot
@@ -419,7 +419,16 @@ exports[`Storyshots LimitRange/DetailsView Limit Range Detail 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
@@ -1090,7 +1090,16 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -729,7 +729,16 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -1606,7 +1615,16 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -2453,7 +2471,16 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -3181,7 +3208,16 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -3940,7 +3976,16 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -4693,7 +4738,16 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -769,7 +769,16 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -380,7 +380,16 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      Created
+                      <div
+                        class="MuiBox-root MuiBox-root"
+                      >
+                        <label
+                          class="makeStyles-fullText"
+                          id=""
+                        >
+                          Created
+                        </label>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"


### PR DESCRIPTION
These changes fix a few issues in the simple table:

Here's the table before the fix (ignore the blueboxes):
![Empty table screenshot before the fix](https://github.com/headlamp-k8s/headlamp/assets/1029635/2d417b19-9097-4d77-8eaa-c7749c156078)

And here it is after the fix:
![Empty table screenshot after fix](https://github.com/headlamp-k8s/headlamp/assets/1029635/e8c8ddd7-3687-437b-9b4c-c6288da85fb8)

And they add an expand button to the events' message.

Storybook stories are added.