### PR TITLE
frontend: Fixes mobile spacing

### DIFF
--- a/frontend/src/components/Sidebar/HeadlampButton.tsx
+++ b/frontend/src/components/Sidebar/HeadlampButton.tsx
@@ -21,7 +21,7 @@ const useStyle = makeStyles(theme => ({
   },
   button: {
     padding: (props: { isSidebarOpen: boolean; isSmall: boolean }) =>
-      props.isSmall && !props.isSidebarOpen ? 0 : '6px 8px',
+      props.isSmall && !props.isSidebarOpen ? `10px 10px` : '6px 8px',
     // Useful for when the button has text.
     color: theme.palette.text.primary,
   },

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -36,7 +36,7 @@ const useTableStyle = makeStyles(theme => ({
     '& .MuiTableCell-root': {
       padding: '8px 16px 7px 16px',
       [theme.breakpoints.down('sm')]: {
-        padding: '8px 24px 7px 16px',
+        padding: '15px 24px 15px 16px',
       },
       overflow: 'hidden',
       width: '100%',


### PR DESCRIPTION
For issue #1233

## Description

This PR aims to improve the touch interface of our application, focusing specifically on button sizes and spacing, as per the touch interface guidelines. The changes target both general links/buttons and the sidebar navigation, enhancing usability on touch devices. Improving the touch interface should significantly enhance user experience on mobile devices by reducing misclicks and easing navigation.

## Changes

1. Increase the size of buttons/links to a minimum of 44px to ensure a comfortable touch area on mobile devices.

2. Add ample space between buttons to avoid accidental touches. 

3. Apply the same design principles to the sidebar navigation, increasing touch areas and ensuring accurate navigation.

## To-Do

- [x] Increase size of buttons
- [x] Add additional vertical padding between buttons/links.
- [ ] Apply similar touch guidelines to the sidebar navigation.



## Current
Working on a fix for the topbar new size taking up space for main content

Example
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/2282275d-ff85-4dc1-bdbb-70da4c62d610)

## Notes

WIP: currently added space around the topbar icon for mobile

Before and after for the topbar mobile button
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/f6c5131b-508e-4cc3-aa8d-5837a1cfef6f)

WIP: also added space between tables 

Before and after spacing
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/c35626e3-94e5-4525-ade0-930c192ecbd6)


