### PR TITLE
frontend: Fixes settings link in app mode

### DIFF
--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -1,5 +1,5 @@
 import { Icon, InlineIcon } from '@iconify/react';
-import { Box, Chip, IconButton, Link, TextField } from '@material-ui/core';
+import { Box, Chip, IconButton, TextField } from '@material-ui/core';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -8,9 +8,8 @@ import { useHistory } from 'react-router-dom';
 import helpers, { ClusterSettings } from '../../../helpers';
 import { useCluster, useClustersConf } from '../../../lib/k8s';
 import { deleteCluster } from '../../../lib/k8s/apiProxy';
-import { createRouteURL } from '../../../lib/router';
 import { setConfig } from '../../../redux/actions/actions';
-import { NameValueTable, SectionBox } from '../../common';
+import { Link, NameValueTable, SectionBox } from '../../common';
 import ConfirmButton from '../../common/ConfirmButton';
 
 const useStyles = makeStyles(theme => ({
@@ -172,7 +171,7 @@ export default function SettingsCluster() {
         headerProps={{
           actions: [
             <Link
-              href={createRouteURL('settings')}
+              routeName={'settings'}
               align="right"
               style={{ color: theme.palette.text.primary }}
             >


### PR DESCRIPTION
for issue #1294 

## Description

This PR addresses an issue where clicking on the 'General Settings' link in app mode led users to a blank page. The underlying problem was identified in the routing mechanism that didn't correctly handle this specific navigation in app mode.

## Changes

- [x] Updated the navigation routing for 'General Settings' to point to the correct destination while in app mode.
   
- [x] Using custom navigation link for routing

## Testing

After implementing the fix the 'General Settings' link now reliably redirects users to the correct page without any issues.

## Notes

It seems that the material ui Link component was the cause of the page directing to a blank view, seems to only have been an issue in app mode.

Please review and I welcome any feedback!