### PR TITLE
frontend statefulset/List: Use replicas instead of currentReplicas

### DIFF
--- a/frontend/src/components/statefulset/List.tsx
+++ b/frontend/src/components/statefulset/List.tsx
@@ -8,9 +8,9 @@ export default function StatefulSetList() {
   const { t } = useTranslation('glossary');
 
   function renderPods(statefulSet: StatefulSet) {
-    const { readyReplicas, currentReplicas } = statefulSet.status;
+    const { readyReplicas, replicas } = statefulSet.status;
 
-    return `${readyReplicas || 0}/${currentReplicas || 0}`;
+    return `${readyReplicas || 0}/${replicas || 0}`;
   }
 
   return (


### PR DESCRIPTION
As the latter may be 0 when there are readyReplicas, as a user reported.

fixes #1308