### PR TITLE
frontend: k8s: Adding docs, improving types

### DIFF
--- a/frontend/src/components/App/Home/RecentClusters.stories.tsx
+++ b/frontend/src/components/App/Home/RecentClusters.stories.tsx
@@ -7,15 +7,19 @@ import RecentClusters, { RecentClustersProps } from './RecentClusters';
 const clusters: Cluster[] = [
   {
     name: 'cluster0',
+    auth_type: '',
   },
   {
     name: 'cluster1',
+    auth_type: '',
   },
   {
     name: 'cluster2',
+    auth_type: '',
   },
   {
     name: 'cluster3',
+    auth_type: '',
   },
 ];
 
@@ -36,7 +40,7 @@ const Template: Story<RecentClusterStoryProps> = args => {
     const clusters = getRecentClusters();
     localStorage.setItem('recent_clusters', '[]');
     for (const clusterName of clusters) {
-      helpers.setRecentCluster({ name: clusterName });
+      helpers.setRecentCluster(clusterName);
     }
   });
 

--- a/frontend/src/components/cluster/ClusterChooserPopup.stories.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.stories.tsx
@@ -99,6 +99,6 @@ Scrollbar.args = {
   clusters: ourState(
     Array(20)
       .fill(0)
-      .map((_, i) => ({ name: `cluster${i}` }))
+      .map((_, i) => ({ name: `cluster${i}`, auth_type: '' }))
   ).config.clusters,
 };

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -261,6 +261,9 @@ function setRecentCluster(cluster: string | Cluster) {
   localStorage.setItem(recentClustersStorageKey, JSON.stringify(newClusters));
 }
 
+/**
+ * @returns the list of recent clusters from localStorage.
+ */
 function getRecentClusters() {
   const currentClustersStr = localStorage.getItem(recentClustersStorageKey) || '[]';
   const recentClusters = JSON.parse(currentClustersStr) as string[];
@@ -287,6 +290,9 @@ function setTablesRowsPerPage(perPage: number) {
   localStorage.setItem(tablesRowsPerPageKey, perPage.toString());
 }
 
+/**
+ * @returns the 'VERSION' of the app and the 'GIT_VERSION' of the app.
+ */
 function getVersion() {
   return {
     VERSION: process.env.REACT_APP_HEADLAMP_VERSION,
@@ -294,7 +300,10 @@ function getVersion() {
   };
 }
 
-function getProductName() {
+/**
+ * @returns the product name of the app, or undefined if it's not set.
+ */
+function getProductName(): string | undefined {
   return process.env.REACT_APP_HEADLAMP_PRODUCT_NAME;
 }
 

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -247,10 +247,17 @@ function setAppVersion(value: string) {
 
 const recentClustersStorageKey = 'recent_clusters';
 
-function setRecentCluster(cluster: Cluster) {
+/**
+ * Adds the cluster name to the list of recent clusters in localStorage.
+ *
+ * @param cluster - the cluster to add to the list of recent clusters. Can be the name, or a Cluster object.
+ * @returns void
+ */
+function setRecentCluster(cluster: string | Cluster) {
   const recentClusters = getRecentClusters();
-  const currentClusters = recentClusters.filter(name => name !== cluster.name);
-  const newClusters = [cluster.name, ...currentClusters].slice(0, 3);
+  const clusterName = typeof cluster === 'string' ? cluster : cluster.name;
+  const currentClusters = recentClusters.filter(name => name !== clusterName);
+  const newClusters = [clusterName, ...currentClusters].slice(0, 3);
   localStorage.setItem(recentClustersStorageKey, JSON.stringify(newClusters));
 }
 

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1217,6 +1217,16 @@ function connectStream(
   }
 }
 
+/**
+ * Combines a base path and a path to create a full path.
+ *
+ * Doesn't matter if the start or the end has a single slash, the result will always have a single slash.
+ *
+ * @param base - The base path.
+ * @param path - The path to combine with the base path.
+ *
+ * @returns The combined path.
+ */
 function combinePath(base: string, path: string) {
   if (base.endsWith('/')) base = base.slice(0, -1); // eslint-disable-line no-param-reassign
   if (path.startsWith('/')) path = path.slice(1); // eslint-disable-line no-param-reassign

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -488,6 +488,16 @@ async function repeatStreamFunc(
   };
 }
 
+/**
+ * Repeats a factory method call across multiple API endpoints until a
+ * successful response is received or all endpoints have been exhausted.
+ *
+ * This is especially useful for Kubernetes beta APIs that then stabalize.
+ * @param apiEndpoints - An array of API endpoint objects returned by the `apiFactory` function.
+ * @param funcName - The name of the factory method to call on each endpoint.
+ *
+ * @returns A function that cancels the factory method call.
+ */
 function repeatFactoryMethod(apiEndpoints: ApiFactoryReturn[], funcName: keyof ApiFactoryReturn) {
   return async (...args: Parameters<ApiFactoryReturn[typeof funcName]>) => {
     for (let i = 0; i < apiEndpoints.length; i++) {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1465,10 +1465,14 @@ export function listPortForward(cluster: string) {
   );
 }
 
+// @todo: Move drainNode and drainNodeStatus to a drainNode.ts
+
 /**
  * Drain a node
- * @param cluster
- * @param nodeName
+ *
+ * @param cluster - The cluster to drain the node
+ * @param nodeName - The node name to drain
+ *
  * @returns {Promise<JSON>}
  * @throws {Error} if the request fails
  * @throws {Error} if the response is not ok

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -170,7 +170,15 @@ export interface QueryParameters {
   watch?: string;
 }
 
-//refreshToken checks if the token is about to expire and refreshes it if so.
+/**
+ * Refreshes the token if it is about to expire.
+ *
+ * @param token - The token to refresh. For null token it just does nothing.
+ *
+ * @note Sets the token with `setToken` if the token is refreshed.
+ * @note Uses global `isTokenRefreshInProgress` to prevent multiple token
+ * refreshes at the same time.
+ */
 async function refreshToken(token: string | null) {
   if (!token || isTokenRefreshInProgress) {
     return;

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1503,18 +1503,26 @@ export function drainNode(cluster: string, nodeName: string) {
   });
 }
 
+interface DrainNodeStatus {
+  id: string;
+  cluster: string;
+}
+
 /**
- * Get the status of the drain node process
- * @param cluster
- * @param nodeName
- * @returns {Promise<JSON>}
+ * Get the status of the drain node process.
+ *
+ * It is used in the node detail page.
+ * As draining a node is a long running process, we poll this endpoint to get
+ * the status of the drain node process.
+ *
+ * @param cluster - The cluster to get the status of the drain node process for.
+ * @param nodeName - The node name to get the status of the drain node process for.
+ *
+ * @returns - The response from the API.
  * @throws {Error} if the request fails
  * @throws {Error} if the response is not ok
- *
- * This function is used to get the status of the drain node process. It is used in the node detail page.
- * As draining a node is a long running process, we poll this endpoint to get the status of the drain node process.
  */
-export function drainNodeStatus(cluster: string, nodeName: string) {
+export function drainNodeStatus(cluster: string, nodeName: string): Promise<DrainNodeStatus> {
   return fetch(`${helpers.getAppUrl()}drain-node-status?cluster=${cluster}&nodeName=${nodeName}`, {
     method: 'GET',
     headers: new Headers({
@@ -1522,7 +1530,7 @@ export function drainNodeStatus(cluster: string, nodeName: string) {
       ...JSON_HEADERS,
     }),
   }).then(response => {
-    return response.json().then(data => {
+    return response.json().then((data: DrainNodeStatus) => {
       if (!response.ok) {
         throw new Error('Something went wrong');
       }

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1452,6 +1452,13 @@ export function stopOrDeletePortForward(cluster: string, id: string, stopOrDelet
   );
 }
 
+/**
+ * Lists the port forwards for the specified cluster.
+ *
+ * @param cluster - The cluster to list the port forwards.
+ *
+ * @returns the list of port forwards for the cluster.
+ */
 export function listPortForward(cluster: string) {
   return fetch(`${helpers.getAppUrl()}portforward/list?cluster=${cluster}`).then(response =>
     response.json()

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1367,6 +1367,26 @@ export async function deleteCluster(cluster: string) {
   );
 }
 
+// @todo: Move startPortForward, stopPortForward, and getPortForwardStatus to a portForward.ts
+
+// @todo: the return type is missing for the following functions.
+//       See PortForwardState in PortForward.tsx
+
+/**
+ * Starts a portforward with the given details.
+ *
+ * @param cluster - The cluster to portforward for.
+ * @param namespace - The namespace to portforward for.
+ * @param podname - The pod to portforward for.
+ * @param containerPort - The container port to portforward for.
+ * @param service - The service to portforward for.
+ * @param serviceNamespace - The service namespace to portforward for.
+ * @param port - The port to portforward for.
+ * @param id - The id to portforward for.
+ *
+ * @returns The response from the API.
+ * @throws {Error} if the request fails.
+ */
 export function startPortForward(
   cluster: string,
   namespace: string,

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -611,6 +611,9 @@ function singleApiFactory(group: string, version: string, resource: string) {
   };
 }
 
+// @todo: just use args from simpleApiFactoryWithNamespace, rather than `args`?
+//        group: string, version: string, resource: string, includeScale: boolean = false
+
 export function apiFactoryWithNamespace(
   ...args:
     | Parameters<typeof simpleApiFactoryWithNamespace>
@@ -665,6 +668,7 @@ function simpleApiFactoryWithNamespace(
   const apiRoot = getApiRoot(group, version);
   const results: {
     scale?: ReturnType<typeof apiScaleFactory>;
+    // @todo: Need to write types for these properties instead.
     [other: string]: any;
   } = {
     list: (

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -423,6 +423,23 @@ export type StreamErrCb = (err: Error & { status?: number }, cancelStreamFunc?: 
 
 type ApiFactoryReturn = ReturnType<typeof apiFactory> | ReturnType<typeof apiFactoryWithNamespace>;
 
+// @todo: repeatStreamFunc could be improved for performance by remembering when a URL
+//       is 404 and not trying it again... and again.
+
+/**
+ * Repeats a streaming function call across multiple API endpoints until a
+ * successful response is received or all endpoints have been exhausted.
+ *
+ * This is especially useful for Kubernetes beta APIs that then stabalize.
+ * So the APIs are available at different endpoints on different versions of Kubernetes.
+ *
+ * @param apiEndpoints - An array of API endpoint objects returned by the `apiFactory` function.
+ * @param funcName - The name of the streaming function to call on each endpoint.
+ * @param errCb - A callback function to handle errors that occur during the streaming function call.
+ * @param args - Additional arguments to pass to the streaming function.
+ *
+ * @returns A function that cancels the streaming function call.
+ */
 async function repeatStreamFunc(
   apiEndpoints: ApiFactoryReturn[],
   funcName: keyof ApiFactoryReturn,

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -516,6 +516,16 @@ function repeatFactoryMethod(apiEndpoints: ApiFactoryReturn[], funcName: keyof A
   };
 }
 
+// @todo: in apiFactory, and multipleApiFactory use rather than 'args'...
+//        `group: string, version: string, resource: string`
+
+/**
+ * Creates an API client for a single or multiple Kubernetes resources.
+ *
+ * @param args - The arguments to pass to either `singleApiFactory` or `multipleApiFactory`.
+ *
+ * @returns An API client for the specified Kubernetes resource(s).
+ */
 export function apiFactory(
   ...args: Parameters<typeof singleApiFactory> | Parameters<typeof multipleApiFactory>
 ) {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -573,6 +573,15 @@ function multipleApiFactory(
   };
 }
 
+// @todo: singleApiFactory should have a return type rather than just what it returns.
+
+/**
+ * @returns An object with methods for interacting with a single API endpoint.
+ *
+ * @param group - The API group.
+ * @param version - The API version.
+ * @param resource - The API resource.
+ */
 function singleApiFactory(group: string, version: string, resource: string) {
   if (isDebugVerbose('k8s/apiProxy@singleApiFactory')) {
     console.debug('k8s/apiProxy@singleApiFactory', { group, version, resource });

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -863,7 +863,7 @@ export function remove(url: string, requestOptions = {}) {
 }
 
 /**
- * Streams the results of a Kubernetes API request.
+ * Streams the results of a Kubernetes API request into a 'cb' callback.
  *
  * @param url - The URL of the Kubernetes API endpoint.
  * @param name - The name of the Kubernetes API resource.

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -58,11 +58,116 @@ export interface ClusterRequest {
   kubeconfig?: string;
 }
 
+// @todo: QueryParamaters should be specific to different resources.
+//        Because some only support some paramaters.
+
+/**
+ * QueryParamaters is a map of query parameters for the Kubernetes API.
+ */
 export interface QueryParameters {
-  labelSelector?: string;
+  /**
+   * Continue token for paging through large result sets.
+   *
+   * The continue option should be set when retrieving more results from the server.
+   * Since this value is server defined, clients may only use the continue value
+   * from a previous query result with identical query parameters
+   * (except for the value of continue) and the server may reject a continue value
+   * it does not recognize. If the specified continue value is no longer valid
+   * whether due to expiration (generally five to fifteen minutes) or a
+   * configuration change on the server, the server will respond with a
+   * 410 ResourceExpired error together with a continue token. If the client
+   * needs a consistent list, it must restart their list without the continue field.
+   * Otherwise, the client may send another list request with the token received
+   * with the 410 error, the server will respond with a list starting from the next
+   * key, but from the latest snapshot, which is inconsistent from the previous
+   * list results - objects that are created, modified, or deleted after the first
+   * list request will be included in the response, as long as their keys are after
+   * the "next key".
+   *
+   * This field is not supported when watch is true. Clients may start a watch from
+   * the last resourceVersion value returned by the server and not miss any modifications.
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks
+   */
+  continue?: string;
+  /**
+   * dryRun causes apiserver to simulate the request, and report whether the object would be modified.
+   * Can be '' or 'All'
+   *
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run
+   */
+  dryRun?: string;
+  /**
+   * fieldSeletor restricts the list of returned objects by their fields. Defaults to everything.
+   *
+   * @see https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+   */
   fieldSelector?: string;
-  limit?: number;
-  [prop: string]: any;
+  /**
+   * labelSelector restricts the list of returned objects by their labels. Defaults to everything.
+   *
+   * @see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+   * @see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+   */
+  labelSelector?: string;
+  /**
+   * limit is a maximum number of responses to return for a list call.
+   *
+   * If more items exist, the server will set the continue field on the list
+   * metadata to a value that can be used with the same initial query to retrieve
+   * the next set of results. Setting a limit may return fewer than the requested
+   * amount of items (up to zero items) in the event all requested objects are
+   * filtered out and clients should only use the presence of the continue field
+   * to determine whether more results are available. Servers may choose not to
+   * support the limit argument and will return all of the available results.
+   * If limit is specified and the continue field is empty, clients may assume
+   * that no more results are available.
+   *
+   * This field is not supported if watch is true.
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks
+   */
+  limit?: string | number;
+  /**
+   * resourceVersion sets a constraint on what resource versions a request may be served from.
+   * Defaults to unset
+   *
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+   */
+  resourceVersion?: string;
+  /**
+   * allowWatchBookmarks means watch events with type "BOOKMARK" will also be sent.
+   *
+   * Can be 'true'
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks
+   */
+  allowWatchBookmarks?: string;
+  /**
+   * sendInitialEvents controls whether the server will send the events
+   * for a watch before sending the current list state.
+   *
+   * Can be 'true'.
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
+   */
+  sendInitialEvents?: string;
+  /**
+   * The resource version to match.
+   *
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list
+   */
+  resourceVersionMatch?: string;
+  /**
+   * If 'true', then the output is pretty printed.
+   * Can be '' or 'true'
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#output-options
+   */
+  pretty?: string;
+  /**
+   * watch instead of a list or get, watch for changes to the requested object(s).
+   *
+   * Can be 1.
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+   */
+  watch?: string;
 }
 
 //refreshToken checks if the token is about to expire and refreshes it if so.
@@ -523,9 +628,30 @@ function simpleApiFactoryWithNamespace(
   }
 }
 
+/**
+ * Converts k8s queryParams to a URL query string.
+ *
+ * @param queryParams - The k8s API query parameters to convert.
+ * @returns The query string (starting with '?'), or empty string.
+ */
 function asQuery(queryParams?: QueryParameters): string {
-  return !!queryParams && !!Object.keys(queryParams).length
-    ? '?' + new URLSearchParams(queryParams).toString()
+  if (queryParams === undefined) {
+    return '';
+  }
+
+  let newQueryParams;
+  if (typeof queryParams.limit === 'number' || typeof queryParams.limit === 'string') {
+    newQueryParams = {
+      ...queryParams,
+      limit:
+        typeof queryParams.limit === 'number' ? queryParams.limit.toString() : queryParams.limit,
+    };
+  } else {
+    newQueryParams = { ..._.omit(queryParams, 'limit') };
+  }
+
+  return !!newQueryParams && !!Object.keys(newQueryParams).length
+    ? '?' + new URLSearchParams(newQueryParams).toString()
     : '';
 }
 

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -254,7 +254,12 @@ async function refreshToken(token: string | null) {
   }
 }
 
-// getClusterAuthType returns the auth type of the cluster.
+/**
+ * @returns Auth type of the cluster, or an empty string if the cluster is not found.
+ * It could return 'oidc' or '' for example.
+ *
+ * @param cluster - Name of the cluster.
+ */
 function getClusterAuthType(cluster: string): string {
   const state = store.getState();
   const authType: string = state.config?.clusters?.[cluster]?.['auth_type'] || '';

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -540,6 +540,15 @@ export function apiFactory(
   return singleApiFactory(...(args as Parameters<typeof singleApiFactory>));
 }
 
+/**
+ * Creates an API endpoint object for multiple API endpoints.
+ * It first tries the first endpoint, then the second, and so on until it
+ * gets a successful response.
+ *
+ * @param args - An array of arguments to pass to the `singleApiFactory` function.
+ *
+ * @returns An API endpoint object.
+ */
 function multipleApiFactory(
   ...args: Parameters<typeof singleApiFactory>[]
 ): ReturnType<typeof singleApiFactory> {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1423,6 +1423,17 @@ export function startPortForward(
   });
 }
 
+// @todo: stopOrDelete true is confusing, rename this param to justStop?
+/**
+ * Stops or deletes a portforward with the specified details.
+ *
+ * @param cluster - The cluster to portforward for.
+ * @param id - The id to portforward for.
+ * @param stopOrDelete - Whether to stop or delete the portforward. True for stop, false for delete.
+ *
+ * @returns The response from the API.
+ * @throws {Error} if the request fails.
+ */
 export function stopOrDeletePortForward(cluster: string, id: string, stopOrDelete: boolean = true) {
   return fetch(`${helpers.getAppUrl()}portforward`, {
     method: 'DELETE',

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1128,6 +1128,18 @@ export function stream(url: string, cb: StreamResultsCb, args: StreamArgs) {
   }
 }
 
+/**
+ * Connects to a WebSocket stream at the specified path and returns an object
+ * with a `close` function and a `socket` property. Sends messages to `cb` callback.
+ *
+ * @param path - The path of the WebSocket stream to connect to.
+ * @param cb - The function to call with each message received from the stream.
+ * @param onFail - The function to call if the stream is closed unexpectedly.
+ * @param isJson - Whether the messages should be parsed as JSON.
+ * @param additionalProtocols - An optional array of additional WebSocket protocols to use.
+ *
+ * @returns An object with a `close` function and a `socket` property.
+ */
 function connectStream(
   path: string,
   cb: StreamResultsCb,

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -414,7 +414,11 @@ export async function clusterRequest(
   return response.json();
 }
 
+// @todo: there should be more specific args and types on StreamResultsCb than '...args: any'.
+
+/** The callback that's called when some results are streamed in. */
 export type StreamResultsCb = (...args: any[]) => void;
+/** The callback that's called when there's an error streaming the results. */
 export type StreamErrCb = (err: Error & { status?: number }, cancelStreamFunc?: () => void) => void;
 
 type ApiFactoryReturn = ReturnType<typeof apiFactory> | ReturnType<typeof apiFactoryWithNamespace>;

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -297,19 +297,27 @@ export async function request(
 }
 
 /**
+ * The options for `clusterRequest`.
+ */
+export interface ClusterRequestParams extends RequestParams {
+  cluster?: string | null;
+  autoLogoutOnAuthError?: boolean;
+}
+
+/**
  * Sends a request to the backend. If the cluster is required in the params parameter, it will
  * be used as a request to the respective Kubernetes server.
  *
  * @param path - The path to the API endpoint.
  * @param params - Optional parameters for the request.
- * @param queryParams - Optional query parameters for the request.
+ * @param queryParams - Optional query parameters for the k8s request.
  *
  * @returns A Promise that resolves to the JSON response from the API server.
  * @throws An ApiError if the response status is not ok.
  */
 export async function clusterRequest(
   path: string,
-  params: RequestParams = {},
+  params: ClusterRequestParams = {},
   queryParams?: QueryParameters
 ) {
   interface RequestHeaders {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -30,10 +30,19 @@ const MIN_LIFESPAN_FOR_TOKEN_REFRESH = 10; // sec
 
 let isTokenRefreshInProgress = false;
 
-export interface RequestParams {
-  timeout?: number; // ms
+// @todo: Params is a confusing name for options, because params are also query params.
+/**
+ * Options for the request.
+ */
+export interface RequestParams extends RequestInit {
+  /** Number of milliseconds to wait for a response. */
+  timeout?: number;
+  /** Is the request expected to receive JSON data? */
   isJSON?: boolean;
-  [prop: string]: any;
+  /** Cluster context name. */
+  cluster?: string | null;
+  /** Whether to automatically log out the user if there is an authentication error. */
+  autoLogoutOnAuthError?: boolean;
 }
 
 export interface ClusterRequest {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1292,6 +1292,17 @@ export interface ApiError extends Error {
   status: number;
 }
 
+// @todo: is metrics() used anywhere? I can't find so, maybe in a plugin?
+
+/**
+ * Gets the metrics for the specified resource. Gets new metrics every 10 seconds.
+ *
+ * @param url - The url of the resource to get metrics for.
+ * @param onMetrics - The function to call with the metrics.
+ * @param onError - The function to call if there's an error.
+ *
+ * @returns A function to cancel the metrics request.
+ */
 export async function metrics(
   url: string,
   onMetrics: (arg: KubeMetrics[]) => void,

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1233,6 +1233,17 @@ function combinePath(base: string, path: string) {
   return `${base}/${path}`;
 }
 
+// @todo: apply() and other requests return Promise<any> Can we get it to return a better type?
+
+/**
+ * Applies the provided body to the Kubernetes API.
+ *
+ * Tries to POST, and if there's a conflict it does a PUT to the api endpoint.
+ *
+ * @param body - The kubernetes object body to apply.
+ *
+ * @returns The response from the kubernetes API server.
+ */
 export async function apply(body: KubeObjectInterface): Promise<JSON> {
   const bodyToApply = _.cloneDeep(body);
 

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -26,9 +26,14 @@ function getAllowedNamespaces() {
   return clusterSettings.allowedNamespaces || [];
 }
 
+//@todo: kubeconfig.go AuthType also doesn't document what '' means for auth_type.
 export interface Cluster {
   name: string;
   useToken?: boolean;
+  /**
+   * Either 'oidc' or ''.
+   */
+  auth_type: string;
   [propName: string]: any;
 }
 

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -26,18 +26,31 @@ function getAllowedNamespaces() {
   return clusterSettings.allowedNamespaces || [];
 }
 
-//@todo: kubeconfig.go AuthType also doesn't document what '' means for auth_type.
 export interface Cluster {
   name: string;
   useToken?: boolean;
   /**
-   * Either 'oidc' or ''.
+   * Either 'oidc' or ''. '' means unknown.
    */
   auth_type: string;
   [propName: string]: any;
 }
 
+/**
+ * This is the base interface for all Kubernetes resources, i.e. it contains fields
+ * that all Kubernetes resources have.
+ */
 export interface KubeObjectInterface {
+  /**
+   * Kind is a string value representing the REST resource this object represents.
+   * Servers may infer this from the endpoint the client submits requests to.
+   *
+   * In CamelCase.
+   *
+   * Cannot be updated.
+   *
+   * @see {@link https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds | more info}
+   */
   kind: string;
   apiVersion?: string;
   metadata: KubeMetadata;
@@ -48,27 +61,160 @@ export interface StringDict {
   [key: string]: string;
 }
 
+/**
+ * KubeMetadata contains the metadata that is common to all Kubernetes objects.
+ *
+ * @see {@link https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata | Metadata} for more details.
+ */
 export interface KubeMetadata {
-  uid: string;
-  name: string;
-  namespace?: string;
-  creationTimestamp: string;
-  deletionTimestamp?: string;
-  resourceVersion?: string;
-  selfLink?: string;
-  labels?: StringDict;
+  /**
+   * A map of string keys and values that can be used by external tooling to store and
+   * retrieve arbitrary metadata about this object
+   * @see {@link https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ | annotations docs} for more details.
+   */
   annotations?: StringDict;
-  ownerReferences?: KubeOwnerReference[];
-  managedFields?: KubeManagedFields[];
+  /**
+   * An RFC 3339 date of the date and time an object was created
+   */
+  creationTimestamp: string;
+  /**
+   * Number of seconds allowed for this object to gracefully terminate before it
+   * will be removed from the system. Only set when deletionTimestamp is also set.
+   * May only be shortened.
+   * Read-only.
+   */
+  deletionGracePeriodSeconds?: number;
+  /**
+   * An RFC 3339 date of the date and time after which this resource will be deleted.
+   * This field is set by the server when a graceful deletion is requested by the
+   * user, and is not directly settable by a client. The resource will be deleted
+   * (no longer visible from resource lists, and not reachable by name) after the
+   * time in this field except when the object has a finalizer set. In case the
+   * finalizer is set the deletion of the object is postponed at least until the
+   * finalizer is removed. Once the deletionTimestamp is set, this value may not
+   * be unset or be set further into the future, although it may be shortened or
+   * the resource may be deleted prior to this time.
+   */
+  deletionTimestamp?: string;
+  /**
+   * Must be empty before the object is deleted from the registry. Each entry is
+   * an identifier for the responsible component that will remove the entry from
+   * the list. If the deletionTimestamp of the object is non-nil, entries in this
+   * list can only be removed. Finalizers may be processed and removed in any order.
+   * Order is NOT enforced because it introduces significant risk of stuck finalizers.
+   * finalizers is a shared field, any actor with permission can reorder it.
+   * If the finalizer list is processed in order, then this can lead to a situation
+   * in which the component responsible for the first finalizer in the list is
+   * waiting for a signal (field value, external system, or other) produced by a
+   * component responsible for a finalizer later in the list, resulting in a deadlock.
+   * Without enforced ordering finalizers are free to order amongst themselves and
+   * are not vulnerable to ordering changes in the list.
+   *
+   * patch strategy: merge
+   */
+  finalizers?: string[];
+  /**
+   * GenerateName is an optional prefix, used by the server, to generate a unique
+   * name ONLY IF the Name field has not been provided. If this field is used,
+   * the name returned to the client will be different than the name passed.
+   * This value will also be combined with a unique suffix. The provided value
+   * has the same validation rules as the Name field, and may be truncated by
+   * the length of the suffix required to make the value unique on the server.
+   * If this field is specified and the generated name exists, the server will
+   * return a 409. Applied only if Name is not specified.
+   *
+   * @see {@link https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency | more info}
+   */
+  generateName?: string;
+  /**
+   * A sequence number representing a specific generation of the desired state.
+   * Populated by the system.
+   * Read-only.
+   */
   generation?: number;
+  /**
+   * A map of string keys and values that can be used to organize and categorize objects
+   *
+   * @see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+   */
+  labels?: StringDict;
+  /**
+   * Maps workflow-id and version to the set of fields that are managed by that workflow.
+   * This is mostly for internal housekeeping, and users typically shouldn't need to set
+   * or understand this field. A workflow can be the user's name, a controller's name, or
+   * the name of a specific apply path like "ci-cd". The set of fields is always in the
+   * version that the workflow used when modifying the object.
+   */
+  managedFields?: KubeManagedFieldsEntry[];
+  /**
+   * Uniquely identifies this object within the current namespace (see the identifiers docs).
+   * This value is used in the path when retrieving an individual object.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/overview/working-with-objects/names/ | Names docs} for more details.
+   */
+  name: string;
+  /**
+   * Namespace defines the space within which each name must be unique. An empty namespace is
+   * equivalent to the "default" namespace, but "default" is the canonical representation.
+   * Not all objects are required to be scoped to a namespace - the value of this field for
+   * those objects will be empty. Must be a DNS_LABEL. Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ | Namespaces docs} for more details.
+   */
+  namespace?: string;
+  /**
+   * List of objects depended by this object. If ALL objects in the list have been deleted,
+   * this object will be garbage collected. If this object is managed by a controller,
+   * then an entry in this list will point to this controller, with the controller field
+   * set to true. There cannot be more than one managing controller.
+   */
+  ownerReferences?: KubeOwnerReference[];
+  /**
+   * Identifies the internal version of this object that can be used by clients to
+   * determine when objects have changed. This value MUST be treated as opaque by
+   * clients and passed unmodified back to the server. Clients should not assume
+   * that the resource version has meaning across namespaces, different kinds of
+   * resources, or different servers.
+   *
+   * @see {@link https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency | concurrency control docs} for more details
+   */
+  resourceVersion?: string;
+  /**
+   * Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
+   */
+  selfLink?: string;
+  /**
+   * UID is the unique in time and space value for this object. It is typically generated by
+   * the server on successful creation of a resource and is not allowed to change on PUT
+   * operations. Populated by the system. Read-only.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids | UIDs docs} for more details.
+   */
+  uid: string;
 }
 
 export interface KubeOwnerReference {
+  /** API version of the referent. */
   apiVersion: string;
+  /**
+   * If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot
+   * be deleted from the key-value store until this reference is removed.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion | foreground deletion}
+   * for how the garbage collector interacts with this field and enforces the foreground deletion.
+   *
+   * Defaults to false. To set this field, a user needs "delete" permission of the owner,
+   * otherwise 422 (Unprocessable Entity) will be returned.
+   *
+   */
   blockOwnerDeletion: boolean;
+  /** If true, this reference points to the managing controller. */
   controller: boolean;
+  /** Kind of the referent. */
   kind: string;
+  /** Name of the referent. */
   name: string;
+  /** UID of the referent. */
   uid: string;
 }
 
@@ -76,15 +222,58 @@ export interface ApiListOptions extends QueryParameters {
   namespace?: string | string[];
 }
 
-export interface KubeManagedFields {
+/**
+ * ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the
+ * resource that the fieldset applies to.
+ */
+export interface KubeManagedFieldsEntry {
+  /**
+   * APIVersion defines the version of this resource that this field set applies to.
+   * The format is "group/version" just like the top-level APIVersion field.
+   * It is necessary to track the version of a field set because it cannot be
+   * automatically converted.
+   */
   apiVersion: string;
+  /**
+   * FieldsType is the discriminator for the different fields format and version.
+   * There is currently only one possible value: "FieldsV1"
+   */
   fieldsType: string;
+  /**
+   * FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+   */
   fieldsV1: object;
+  /**
+   * Manager is an identifier of the workflow managing these fields.
+   */
   manager: string;
+  /**
+   * Operation is the type of operation which lead to this ManagedFieldsEntry being
+   * created. The only valid values for this field are 'Apply' and 'Update'.
+   */
   operation: string;
+  /**
+   * Subresource is the name of the subresource used to update that object, or empty
+   * string if the object was updated through the main resource. The value of this
+   * field is used to distinguish between managers, even if they share the same name.
+   * For example, a status update will be distinct from a regular update using the
+   * same manager name. Note that the APIVersion field is not related to the
+   * Subresource field and it always corresponds to the version of the main resource.
+   */
   subresource: string;
+  /**
+   * Time is the timestamp of when the ManagedFields entry was added.The timestamp
+   * will also be updated if a field is added, the manager changes any of the owned
+   * fields value or removes a field. The timestamp does not update when a field is
+   * removed from the entry because another manager took it over.
+   */
   timestamp: string;
 }
+
+/**
+ * @deprecated For backwards compatibility, please use KubeManagedFieldsEntry
+ */
+export interface KubeManagedFields extends KubeManagedFieldsEntry {}
 
 // We have to define a KubeObject implementation here because the KubeObject
 // class is defined within the function and therefore not inferable.
@@ -122,6 +311,13 @@ export interface AuthRequestResourceAttrs {
   namespace?: string;
 }
 
+// @todo: uses of makeKubeObject somehow end up in an 'any' type.
+
+/**
+ * @returns A KubeObject implementation for the given object name.
+ *
+ * @param objectName The name of the object to create a KubeObject implementation for.
+ */
 export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
   objectName: string
 ): KubeObjectIface<T> {
@@ -213,6 +409,16 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       return this.apiEndpoint.isNamespaced;
     }
 
+    // @todo: apiList has 'any' return type.
+    /**
+     * Returns the API endpoint for this object.
+     *
+     * @param onList - Callback function to be called when the list is retrieved.
+     * @param onError - Callback function to be called when an error occurs.
+     * @param opts - Options to be passed to the API endpoint.
+     *
+     * @returns The API endpoint for this object.
+     */
     static apiList<U extends KubeObject>(
       onList: (arg: U[]) => void,
       onError?: (err: ApiError) => void,
@@ -541,69 +747,329 @@ export type KubeObject = InstanceType<KubeObjectClass>;
 
 export type Time = number | string | null;
 
+// @todo: There are different Condition types, including PodCondition, NodeCondition, etc.
+// We should have appropriate types for each of them, because they can be slightly different.
+// eg. DaemonSetCondition does not have lastProbeTime.
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podcondition-v1-core
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#nodecondition-v1-core
+
 export interface KubeCondition {
-  type: string;
-  status: string;
+  /** Last time we probed the condition. */
   lastProbeTime: Time;
   lastTransitionTime?: Time;
   lastUpdateTime?: Time;
-  reason?: string;
   message?: string;
+  /** Unique, one-word, CamelCase reason for the condition's last transition. */
+  reason?: string;
+  /** Status of the condition, one of True, False, Unknown. */
+  status: string;
+  type: string;
 }
 
+/**
+ *
+ * @link https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#container-v1-core
+ */
 export interface KubeContainer {
-  name: string;
-  image: string;
-  command?: string[];
+  /**
+   * Arguments to the entrypoint. The container image's CMD is used if this is not provided.
+   * Variable references $(VAR_NAME) are expanded using the container's environment.
+   * If a variable cannot be resolved, the reference in the input string will be unchanged.
+   * Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME)
+   * syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+   * Escaped references will never be expanded, regardless of whether the variable exists or not.
+   * Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell | more information}
+   */
   args?: string[];
-  ports?: {
-    name?: string;
-    containerPort: number;
-    protocol: string;
-  }[];
-  resources?: {
-    limits?: {
-      cpu?: string;
-      memory?: string;
-    };
-    requests?: {
-      cpu?: string;
-      memory?: string;
-    };
-  };
+  /**
+   * Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if
+   * this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+   * If a variable cannot be resolved, the reference in the input string will be unchanged.
+   * Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME)
+   * syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+   * Escaped references will never be expanded, regardless of whether the variable exists or not.
+   * Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell | more information}
+   */
+  command?: string[];
+
+  /** List of environment variables to set in the container. Cannot be updated. */
   env?: {
+    /** Name of the environment variable. Must be a C_IDENTIFIER. */
     name: string;
+    /**
+     * Variable references $(VAR_NAME) are expanded using the previously defined environment variables
+     * in the container and any service environment variables. If a variable cannot be resolved, the
+     * reference in the input string will be unchanged. Double $$ are reduced to a single $, which
+     * allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+     * string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether
+     * the variable exists or not. Defaults to "".
+     */
     value?: string;
+    /** Source for the environment variable's value. Cannot be used if value is not empty. */
     valueFrom?: {
+      /** Selects a key of a ConfigMap. */
+      configMapKeyRef?: {
+        /** The key to select. */
+        key: string;
+        /** Name of the referent. */
+        name: string;
+        /** Specify whether the ConfigMap or its key must be defined */
+        optional?: boolean;
+      };
+      /**
+       * Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`,
+       * `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP,
+       * status.podIP, status.podIPs.
+       */
       fieldRef?: {
+        /** Version of the schema the FieldPath is written in terms of, defaults to "v1". */
         apiVersion: string;
+        /** Path of the field to select in the specified API version. */
         fieldPath: string;
       };
-      secretKeyRef?: {
-        key: string;
-        name: string;
+      /**
+       * Selects a resource of the container: only resources limits and requests
+       * (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory
+       *  and requests.ephemeral-storage) are currently supported.
+       */
+      resourceFieldRef?: {
+        /** Container name: required for volumes, optional for env vars */
+        containerName?: string;
+        /**
+         * Specifies the output format of the exposed resources, defaults to "1".
+         *
+         * @see {@link https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#quantity-resource-core | Quantity}
+         */
+        divisor?: string;
+        /** Required: resource to select */
+        resource: string;
       };
-      configMapKeyRef?: {
+      /** Selects a key of a secret in the pod's namespace */
+      secretKeyRef?: {
+        /** The key of the secret to select from. Must be a valid secret key. */
         key: string;
+        /** Name of the referent. */
         name: string;
+        /** Specify whether the Secret or its key must be defined */
+        optional?: boolean;
       };
     };
   }[];
   envFrom?: {
+    /** SecretEnvSource	The Secret to select from */
+    secretRef?: {
+      /** Name of the referent. */
+      name: string;
+      /** Specify whether the Secret must be defined */
+      optional?: boolean;
+    };
     configMapRef?: {
+      /** Name of the referent. */
+      name: string;
+      /** Specify whether the ConfigMap must be defined */
+      optional?: boolean;
+    };
+    /** An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER. */
+    prefix?: string;
+  }[];
+
+  /**
+   * Container image name. This field is optional to allow higher level config management to
+   * default or override container images in workload controllers like Deployments and StatefulSets.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/containers/images | more info}
+   */
+  image: string;
+
+  /**
+   * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is
+   * specified, or IfNotPresent otherwise. Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/containers/images#updating-images | more info}
+   */
+  imagePullPolicy: string;
+
+  // @todo: Add lifecycle field.
+
+  /**
+   * Periodic probe of container liveness. Container will be restarted if the probe fails.
+   * Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes | more info}
+   */
+  livenessProbe?: KubeContainerProbe;
+
+  /**
+   * Name of the container specified as a DNS_LABEL.
+   * Each container in a pod must have a unique name (DNS_LABEL).
+   *
+   * Cannot be updated.
+   */
+  name: string;
+
+  /**
+   * List of ports to expose from the container. Not specifying a port here DOES NOT prevent that
+   * port from being exposed. Any port which is listening on the default "0.0.0.0" address inside
+   * a container will be accessible from the network. Modifying this array with strategic merge
+   * patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+   *
+   * Cannot be updated.
+   *
+   * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#containerport-v1-core
+   */
+  ports?: {
+    /** Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536. */
+    containerPort: number;
+    /** What host IP to bind the external port to. */
+    hostIP?: string;
+    /**
+     * Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+     * If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+     */
+    hostPort?: number;
+    /** If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services. */
+    name?: string;
+    /** Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP". */
+    protocol?: string;
+  }[];
+  /**
+   * Periodic probe of container service readiness. Container will be removed from service endpoints
+   * if the probe fails.
+   *
+   * Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes | more info}
+   */
+  readinessProbe?: KubeContainerProbe;
+  /** Resources resize policy for the container. */
+  resizePolicy?: {
+    /**
+     * Name of the resource to which this resource resize policy applies.
+     * Supported values: cpu, memory.
+     */
+    resourceName: string;
+    /**
+     * Restart policy to apply when specified resource is resized.
+     * If not specified, it defaults to NotRequired.
+     */
+    restartPolicy?: string;
+  }[];
+  /**
+   * Compute Resources required by this container. Cannot be updated.
+   *
+   * @see {@link https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ | more info}
+   *
+   * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core
+   */
+  resources?: {
+    claims?: {
+      /**
+       * Name must match the name of one entry in pod.spec.resourceClaims of the Pod where
+       * this field is used. It makes that resource available inside a container.
+       */
       name: string;
     };
-  }[];
+    /**
+     * Limits describes the maximum amount of compute resources allowed.
+     *
+     * @see {@link https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ | more info}
+     *
+     * Can also have hugpages like: "hugepages-2Mi": "100Mi" // Requesting 100 Mebibytes of 2 MiB HugePages
+     */
+    limits?: {
+      /** example "100m", 100 milliCPU (0.1 CPU core) */
+      cpu?: string;
+      /** example , "256Mi" 256 Mebibytes */
+      memory?: string;
+    };
+    requests?: {
+      /** example "500m", 500 milliCPU (0.5 CPU core) */
+      cpu?: string;
+      /** example , "1Gi" 1 Gibibyte */
+      memory?: string;
+    };
+  };
+
+  // @todo:
+  // securityContext SecurityContext	SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  // startupProbe Probe	StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  /**
+   * Path at which the file to which the container's termination message will be written is mounted
+   * into the container's filesystem. Message written is intended to be brief final status, such as
+   * an assertion failure message. Will be truncated by the node if greater than 4096 bytes.
+   * The total message length across all containers will be limited to 12kb.
+   * Defaults to /dev/termination-log.
+   *
+   * Cannot be updated.
+   */
+  terminationMessagePath?: string;
+
+  /**
+   * Indicate how the termination message should be populated. File will use the contents of
+   * terminationMessagePath to populate the container status message on both success and failure.
+   * FallbackToLogsOnError will use the last chunk of container log output if the termination message
+   * file is empty and the container exited with an error. The log output is limited to 2048 bytes or
+   * 80 lines, whichever is smaller. Defaults to File.
+   *
+   * Cannot be updated.
+   */
+  terminationMessagePolicy?: string;
+
   volumeMounts?: {
     name: string;
     readOnly: boolean;
     mountPath: string;
   }[];
-  livenessProbe?: KubeContainerProbe;
-  readinessProbe?: KubeContainerProbe;
-  imagePullPolicy: string;
-  terminationMessagePath?: string;
-  terminationMessagePolicy?: string;
+
+  /**
+   * Whether this container should allocate a buffer for stdin in the container runtime.
+   * If this is not set, reads from stdin in the container will always result in EOF.
+   *
+   * Default is false.
+   */
+  stdin?: boolean;
+  /**
+   * Whether the container runtime should close the stdin channel after it has been opened
+   * by a single attach. When stdin is true the stdin stream will remain open across
+   * multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start,
+   * is empty until the first client attaches to stdin, and then remains open and accepts data
+   * until the client disconnects, at which time stdin is closed and remains closed until the
+   * container is restarted. If this flag is false, a container processes that reads from stdin
+   * will never receive an EOF.
+   *
+   * Default is false
+   */
+  stdinOnce?: boolean;
+  /**
+   * Whether this container should allocate a TTY for itself, also requires
+   * 'stdin' to be true.
+   *
+   * Default is false.
+   */
+  tty?: boolean;
+  /**
+   * volumeDevices is the list of block devices to be used by the container.
+   *
+   * patch strategy: merge
+   * patch merge key: devicePath
+   */
+  volumeDevices?: {
+    /** devicePath is the path inside of the container that the device will be mapped to. */
+    devicePath: string;
+    /** name must match the name of a persistentVolumeClaim in the pod */
+    name: string;
+  }[];
+  /**
+   * Container's working directory. If not specified, the container runtime's default
+   * will be used, which might be configured in the container image.
+   * Cannot be updated.
+   */
+  workingDir?: string;
 }
 
 export interface KubeContainerProbe {


### PR DESCRIPTION
Improve some of the docs and types in lib/k8s. For https://github.com/headlamp-k8s/headlamp/issues/1295

- frontend: cluster: Add docs and some missing fields
- frontend: cluster: Add auth_type to Cluster interface
- frontend: helpers: Add docs for getRecentClusters, getVersion, getProductName
- frontend: helpers: Add docs for setRecentCluster
- frontend: apiProxy: Improve docs for drainNodeStatus
- frontend: apiProxy: Improve docs for drainNode
- frontend: apiProxy: Add docs for listPortForward
- frontend: apiProxy: Add docs for stopOrDeletePortForward
- frontend: apiProxy: Add docs for startPortForward
- frontend: apiProxy: Add docs for metrics
- frontend: apiProxy: Add docs for apply
- frontend: apiProxy: Add docs for combinePath
- frontend: apiProxy: Add docs for connectStream
- frontend: apiProxy: Improve docs for streamResult
- frontend: apiProxy: Add notes about apiFactoryWithNamespace, simpleApiFactoryWithNamespace
- frontend: apiProxy: Add docs for singleApiFactory
- frontend: apiProxy: Add docs for multipleApiFactory
- frontend: apiProxy: Add docs for apiFactory
- frontend: apiProxy: Add docs for repeatFactoryMethod
- frontend: apiProxy: Add docs for repeatStreamFunc
- frontend: apiProxy: Add some docs for StreamResultsCb StreamErrCb
- frontend: apiProxy: Improve docs for ClusterRequestParams and clusterRequest
- frontend: apiProxy: Add docs for getClusterAuthType
- frontend: apiProxy: Add docs for refreshToken
- frontend: apiProxy: Add more fields to QueryParams and document
- frontend: apiProxy: Add docs for RequestParams, improve types
