### PR TITLE
Fix automatic back link

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -165,5 +165,5 @@ export function PreviousRouteProvider({ children }: React.PropsWithChildren<{}>)
 
 export function useHasPreviousRoute() {
   const routeLevels = React.useContext(PreviousRouteContext);
-  return routeLevels > 1;
+  return routeLevels >= 1;
 }


### PR DESCRIPTION
We use the browser's back function but only when we know that the user has navigated to more than one link. However, the logic to check this was off.

How to test:
- [ ] Open Headlamp in a pod's details view; click on a link from there (like its controller), then click the back link in that new page's details view: it should go back to the original pod's details view