### PR TITLE
frontend: Fix alignment for calendar Icon

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -161,7 +161,8 @@ export interface HoverInfoLabelProps {
 
 const useHoverInfoLabelStyles = makeStyles({
   display: {
-    display: 'inline-block',
+    display: 'flex',
+    justifyContent: 'flex-end',
   },
   noWrap: {
     whiteSpace: 'nowrap',
@@ -170,6 +171,7 @@ const useHoverInfoLabelStyles = makeStyles({
     marginRight: '0.2rem',
     marginLeft: '0.2rem',
     color: 'unset !important',
+    alignSelf: 'center',
   },
 });
 


### PR DESCRIPTION
### Issue related:  #958 

## Description:
When navigating to a timestamp using the date and calendar option, there has been an alignment issue noticed. This fix ensures that the date and calendar display are properly aligned to enhance user readability and aesthetics.

## Changes:

- [x]  Adjusted CSS properties for date element to ensure proper alignment.

**Before**
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/8d2946a9-6e08-44bd-943b-642309d0d404)

**After**
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/23e58ae9-bfda-4804-92eb-3600350fb01e)

