### PR TITLE
Normalize the color of the calendar icon

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -169,6 +169,7 @@ const useHoverInfoLabelStyles = makeStyles({
   icon: {
     marginRight: '0.2rem',
     marginLeft: '0.2rem',
+    color: 'unset !important',
   },
 });
 


### PR DESCRIPTION
# Issue Related: #986

# Description: 
In some pages the `mdi:calendar` icon is displayed with a wrong color in both dark and light themes.

# Changes: 
- [x]  Force the unset color property on the icon.

**Before:**
<img width="73" alt="Screenshot 2023-08-22 at 08 45 14" src="https://github.com/headlamp-k8s/headlamp/assets/57415533/d766cf98-08eb-4d7e-8022-884a0efa13c3">

**After:**
<img width="76" alt="Screenshot 2023-08-22 at 08 47 28" src="https://github.com/headlamp-k8s/headlamp/assets/57415533/263bdd6f-ff40-48e4-91cc-ef7602472161">