### PR TITLE
frontend resourceQuota: Fix cores pluralization

### DIFF
--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -214,7 +214,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                           >
-                            0 core
+                            0 cores
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
@@ -234,7 +234,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                     <span
                       class="MuiChip-label MuiChip-labelSmall"
                     >
-                      limits.cpu: 0 core/0.3 cores
+                      limits.cpu: 0 cores/0.3 cores
                     </span>
                   </div>
                 </div>
@@ -305,7 +305,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                     <span
                       class="MuiChip-label MuiChip-labelSmall"
                     >
-                      limits.cpu: 0 core/0.3 cores
+                      limits.cpu: 0 cores/0.3 cores
                     </span>
                   </div>
                 </div>
@@ -376,7 +376,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                     <span
                       class="MuiChip-label MuiChip-labelSmall"
                     >
-                      limits.cpu: 0 core/0.3 cores
+                      limits.cpu: 0 cores/0.3 cores
                     </span>
                   </div>
                 </div>
@@ -447,7 +447,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                     <span
                       class="MuiChip-label MuiChip-labelSmall"
                     >
-                      limits.cpu: 0 core/0.3 cores
+                      limits.cpu: 0 cores/0.3 cores
                     </span>
                   </div>
                 </div>
@@ -518,7 +518,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                     <span
                       class="MuiChip-label MuiChip-labelSmall"
                     >
-                      limits.cpu: 0 core/0.3 cores
+                      limits.cpu: 0 cores/0.3 cores
                     </span>
                   </div>
                 </div>

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -427,8 +427,8 @@ export function normalizeUnit(resourceType: string, quantity: string) {
       normalizedQuantity = quantity?.endsWith('m')
         ? `${Number(quantity.substring(0, quantity.length - 1)) / 1000}`
         : `${quantity}`;
-      if (normalizedQuantity === '0' || normalizedQuantity === '1') {
-        normalizedQuantity = '0 ' + 'core';
+      if (normalizedQuantity === '1') {
+        normalizedQuantity = normalizedQuantity + ' ' + 'core';
       } else {
         normalizedQuantity = normalizedQuantity + ' ' + 'cores';
       }


### PR DESCRIPTION
### **Issue related**: #1306 

### **Description**: 
The Resource Quotas page previously displayed '0 cores' for the request field due to a hardcoded value. This update replaces the static string with dynamic values based on the actual quantity, ensuring accurate representation.

### **Changes**:
- [x] Replaced hardcoded '0 core' string with the dynamic `normalizedQuantity` value.
- [x] Implemented condition to print '1 core' for singular value and '[number] cores' for plural values.
---