### PR TITLE
Removing the force unset property, setting the color to the theme pal…

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -170,7 +170,6 @@ const useHoverInfoLabelStyles = makeStyles({
   icon: {
     marginRight: '0.2rem',
     marginLeft: '0.2rem',
-    color: 'unset !important',
     alignSelf: 'center',
   },
 });

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -181,7 +181,7 @@ function Table(props: ResourceTableProps) {
                   <DateLabel
                     date={resource.metadata.creationTimestamp}
                     format="mini"
-                    iconProps={{ color: theme.palette.grey.A700 }}
+                    iconProps={{ color: theme.palette.text.primary }}
                   />
                 ),
               sort: (n1: KubeObject, n2: KubeObject) =>


### PR DESCRIPTION
# Issue Related: #986

# Description: 
In some pages the `mdi:calendar` icon is displayed with a wrong color in both dark and light themes.

# Changes: 
- [x]  Removed the forced unset color property from the useHoverInfoLabelStyles in [Label.tsx](https://github.com/headlamp-k8s/headlamp/blob/a4c9417b495bfa28b4cabc5c8cb9021a68a0cb8d/frontend/src/components/common/Label.tsx#L162)
- [x] Changed the defined iconProps of the DateLabel to the 'theme.palette.text.primary' in [ResourceTable.tsx](https://github.com/headlamp-k8s/headlamp/blob/a4c9417b495bfa28b4cabc5c8cb9021a68a0cb8d/frontend/src/components/common/Resource/ResourceTable.tsx#L184).

While working on the issue #986 I noticed that the parent svg element that contains the svg path for the icon calendar was rendered with a inline style of `style { color: rgb(97, 97, 97); }`. I tried to modify this behavior from the [Label.tsx](https://github.com/headlamp-k8s/headlamp/blob/a4c9417b495bfa28b4cabc5c8cb9021a68a0cb8d/frontend/src/components/common/Label.tsx) file trying to modify the iconProps or set the element style to empty, but nothing of this solved the issue.

Later I found that in the [ResourceTable.tsx](https://github.com/headlamp-k8s/headlamp/blob/a4c9417b495bfa28b4cabc5c8cb9021a68a0cb8d/frontend/src/components/common/Resource/ResourceTable.tsx) a iconProps for the [DataLabel](https://github.com/headlamp-k8s/headlamp/blob/a4c9417b495bfa28b4cabc5c8cb9021a68a0cb8d/frontend/src/components/common/Label.tsx#L208) being passed with the properties for the grey inline color. Changing this property to the `theme.palette.text.primary` is enough to ensure the correct color on both light and dark themes.

``` diff
 <DateLabel
    date={resource.metadata.creationTimestamp}
    format="mini"
-   iconProps={{ color: theme.palette.grey.A700 }}
+  iconProps={{ color: theme.palette.text.primary }}
/>