### PR TITLE
Use a phony backend token when run from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ frontend-build-storybook:
 run-backend:
 	@echo "**** Warning: Running with Helm and dynamic-clusters endpoints enabled. ****"
 	@echo
-	HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev
+	HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev
 
 run-frontend:
-	cd frontend && npm start
+	cd frontend && REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp npm start
 
 frontend-lint:
 	cd frontend && npm run lint -- --max-warnings 0 && npm run format-check

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -793,7 +793,10 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 
 	// On dev mode we're loose about where connections come from
 	if config.devMode {
-		headers := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization", "Forward-To"})
+		headers := handlers.AllowedHeaders([]string{
+			"X-HEADLAMP_BACKEND-TOKEN", "X-Requested-With", "Content-Type",
+			"Authorization", "Forward-To",
+		})
 		methods := handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "DELETE", "PATCH", "OPTIONS"})
 		origins := handlers.AllowedOrigins([]string{"*"})
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,7 @@
   },
   "scripts": {
     "prestart": "npm run make-version",
-    "start": "react-scripts start",
+    "start": "cross-env HEADLAMP_BACKEND_TOKEN=headlamp react-scripts start",
     "prebuild": "npm run make-version",
     "build": "if-env PUBLIC_URL react-scripts build || cross-env PUBLIC_URL=./ react-scripts build --max_old_space_size=768 && npx shx rm -f build/frontend/index.baseUrl.html",
     "test": "cross-env UNDER_TEST=true react-scripts test",

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -358,7 +358,9 @@ function loadTableSettings(tableId: string): { id: string; show: boolean }[] {
  *
  * The app also passes the token to the headlamp-server via HEADLAMP_BACKEND_TOKEN env var.
  */
-const backendToken = new URLSearchParams(window.location.search).get('backendToken');
+const backendToken =
+  process.env.REACT_APP_HEADLAMP_BACKEND_TOKEN ||
+  new URLSearchParams(window.location.search).get('backendToken');
 
 /**
  * Returns headers for making API calls to the headlamp-server backend.


### PR DESCRIPTION
We use the make file to run Headlamp in dev mode, and since the backend token was not set up in that case, it was impossible to use this mode for testing any backend features, i.e. running npm run dev-only-app would not work for testing adding clusters, use Helm, etc.