### PR TITLE
app: Fix running on windows, improve quickstart docs, document scripts, better ctrl+c handling

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,35 @@
+# Headlamp app
+
+## Quickstart
+
+### Running the app on Ubuntu WSL
+
+Headlamp on WSL requires some packages installed (maybe it requires more) to run the app.
+
+```bash
+sudo apt install libgconf-2-4 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1 libnss3 libasound2 firefox libgstreamer-plugins-bad1.0-0 libegl1 libnotify4 libopengl0 libwoff1 libharfbuzz-icu0 libgstreamer-gl1.0-0 libwebpdemux2 libenchant1c2a libsecret-1-0 libhyphen0 libevdev2 libgles2 gstreamer1.0-libav
+```
+
+To get going with development run these:
+
+```bash
+npm install
+npm start
+```
+
+Note, it runs the development servers for the backend and the frontend as well. So if you have them running already you may want to stop them first.
+
+## scripts
+
+- `npm run build`: Copies in all the files and compiles the code. Builds into an unpacked folder in dist/. Useful for testing.
+- `npm run compile-electron`: Compiles the TypeScript code in electron/ folder into JavaScript.
+- `npm run copy-icons`: Copies the icons from the frontend/ folders into build/icons.
+- `npm run copy-plugins`: Is used to bundle plugins in the .plugins folder into the built app.
+- `npm run dev`: Uses the built code in ../frontend from `npm run build` in that folder.
+- `npm run dev-only-app`: Uses the development front end server.
+- `npm run i18n`: Extract the translations discovered in the electron/ folder source code.
+- `npm run package`: Creates binary packages for different platforms and outputs them in the dist/ folder.
+- `npm run package-msi`: Creates the windows installer format msi package in the dist/ folder.
+- `npm run prod-deps`: Creates production dependencies for built apps in a prod_deps/ folder.
+- `npm start`: Starts the app in dev mode along with the backend server, and the frontend development server.
+- `npm run test`: Runs the tests. See the \*.test.js files in the electron/ folder.

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
   "productName": "Headlamp",
   "scripts": {
     "compile-electron": "babel electron --out-dir electron/ --extensions .ts",
-    "start": "cd ../ && make backend && make run-backend  & cd ../frontend/ && export BROWSER=none && npm start",
+    "start": "cd ../ && make backend && make run-backend  & cd ../frontend/ && cross-env BROWSER=none npm start",
     "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
     "copy-icons": "mkdirp build/icons && copyfiles -f ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && npm run prod-deps && electron-builder --dir --publish never",

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "package": "npm run build && electron-builder build --publish never",
     "package-msi": "npm run build && node windows/msi/build.js",
     "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
-    "start": "cd ../ && make backend && make run-backend & cd ../frontend/ && cross-env BROWSER=none npm start & cd ../app/ && npm run dev-only-app",
+    "start": "node scripts/start.js",
     "test": "jest"
   },
   "build": {

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
   "productName": "Headlamp",
   "scripts": {
     "compile-electron": "babel electron --out-dir electron/ --extensions .ts",
-    "start": "cd ../ && make backend && make run-backend  & cd ../frontend/ && cross-env BROWSER=none npm start",
+    "start": "cd ../ && make backend && make run-backend & cd ../frontend/ && cross-env BROWSER=none npm start & cd ../app/ && npm run dev-only-app",
     "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
     "copy-icons": "mkdirp build/icons && copyfiles -f ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && npm run prod-deps && electron-builder --dir --publish never",

--- a/app/package.json
+++ b/app/package.json
@@ -6,18 +6,18 @@
   "homepage": "https://github.com/headlamp-k8s/headlamp/#readme",
   "productName": "Headlamp",
   "scripts": {
-    "compile-electron": "babel electron --out-dir electron/ --extensions .ts",
-    "start": "cd ../ && make backend && make run-backend & cd ../frontend/ && cross-env BROWSER=none npm start & cd ../app/ && npm run dev-only-app",
-    "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
-    "copy-icons": "mkdirp build/icons && copyfiles -f ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && npm run prod-deps && electron-builder --dir --publish never",
-    "package": "npm run build && electron-builder build --publish never",
-    "package-msi": "npm run build && node windows/msi/build.js",
+    "compile-electron": "babel electron --out-dir electron/ --extensions .ts",
+    "copy-icons": "mkdirp build/icons && copyfiles -f ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
+    "copy-plugins": "npx --no-install rimraf build/.plugins && mkdirp build/.plugins && copyfiles ../.plugins build/.plugins",
     "dev": "npm run compile-electron && cross-env ELECTRON_DEV=1 electron .",
     "dev-only-app": "npm run compile-electron && cross-env ELECTRON_DEV=1 ELECTRON_START_URL=http://localhost:3000 EXTERNAL_SERVER=true electron .",
     "i18n": "npx --no-install i18next ./electron/main.ts -c ./electron/i18next-parser.config.js",
-    "test": "jest",
-    "copy-plugins": "npx --no-install rimraf build/.plugins && mkdirp build/.plugins && copyfiles ../.plugins build/.plugins"
+    "package": "npm run build && electron-builder build --publish never",
+    "package-msi": "npm run build && node windows/msi/build.js",
+    "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
+    "start": "cd ../ && make backend && make run-backend & cd ../frontend/ && cross-env BROWSER=none npm start & cd ../app/ && npm run dev-only-app",
+    "test": "jest"
   },
   "build": {
     "appId": "com.kinvolk.headlamp",

--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -1,0 +1,44 @@
+/**
+ * This script is used to start the backend, frontend and app in parallel.
+ * So ctrl+c will terminate all of them.
+ *
+ * Assumes being run from within the app/ folder
+ */
+const { spawn } = require('child_process');
+
+const serverProcess = spawn('cd ../ && make backend && make run-backend', [], {
+  stdio: 'inherit',
+  shell: true,
+});
+
+let frontendCmd =
+  'cd ../frontend/ && ../app/node_modules/.bin/cross-env BROWSER=none FORCE_COLOR=true npm start';
+if (process.platform !== 'win32') {
+  // to prevent clearing the screen
+  frontendCmd += ' | cat';
+}
+const frontendProcess = spawn(frontendCmd, [], {
+  stdio: 'inherit',
+  shell: true,
+});
+
+let appProcess = null;
+
+// Wait a little bit so the frontend server starts listening.
+setTimeout(() => {
+  appProcess = spawn('npm run dev-only-app', [], {
+    stdio: 'inherit',
+    shell: true,
+  });
+}, 1000);
+
+// Handle Ctrl+C (SIGINT) to terminate both processes
+process.on('SIGINT', () => {
+  console.log('Ctrl+C pressed. Terminating the background process...');
+  serverProcess.kill('SIGINT');
+  frontendProcess.kill('SIGINT');
+  if (appProcess) {
+    appProcess.kill('SIGINT');
+  }
+  process.exit(0);
+});


### PR DESCRIPTION
- app: Fix for windows when using unsupported export
- app: Make `npm start` start the app
- app: Fix scripts so they are listed in alphabetical order
- app: Add a README.md with a Quickstart
- app: Add start script which handles ctrl+c quiting better (So that headlamp-server, frontend and app are quit when ctrl+c is done in the controlling terminal where `npm start` is run.)


Related:

- fixes #1372 
- fixes #1370
- fixes #1376


### How to test?

- [ ] run app `npm start` on windows with cmd
- [ ] run app `npm start` should start the backend, frontend and the app.
- [ ] ctrl + c should close the app, the backend and frontend servers.
- [ ] Quickstart in README should work
