### PR TITLE
backend: Fix backend-lint, add backend-format, document backend make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ backend:
 backend-test:
 	cd backend && go test -v -p 1 ./...
 
+.PHONY: backend-format
+backend-format:
+	cd backend && go fmt ./cmd/ ./pkg/**
+
 frontend-install:
 	cd frontend && npm install
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 all: backend frontend
 
 tools/golangci-lint: backend/go.mod backend/go.sum
-	cd backend && go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+	GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
 backend-lint: tools/golangci-lint
 	cd backend && ./tools/golangci-lint run

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# Quickstart
+
+```bash
+make backend
+make run-backend
+```
+
+See more detailed [Headlamp backend documentation on the web](
+https://headlamp.dev/docs/latest/development/backend/) 
+or in this repo at 
+[../docs/development/backend.md](../docs/development/backend.md).

--- a/docs/development/backend.md
+++ b/docs/development/backend.md
@@ -27,3 +27,25 @@ Once built, it can be run in development mode (insecure / don't use in productio
 ```bash
 make run-backend
 ```
+
+## Lint
+
+To lint the backend/ code.
+
+```bash
+make backend-lint
+```
+
+## Format
+
+To format the backend code.
+
+```bash
+make backend-format
+```
+
+## Test
+
+```bash
+make backend-test
+```


### PR DESCRIPTION
- backend: Fix `make backend-lint` so it works with modern golang
- backend: Add a README.md with a quickstart and links to docs
- Makefile: Add backend-format for formatting backend go code
- docs/development/backend: Document lint, format, and test

### related

- fixes #1371

### How to test

- [ ] `make backend-format` and `make backend-lint` should work
- [ ] documented commands and links should be correct
