### PR TITLE
Improve Custom Resources UX

### DIFF
--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
@@ -480,7 +480,7 @@ exports[`Storyshots Sidebar/Sidebar In Cluster Sidebar Closed 1`] = `
                               <span
                                 class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
                               >
-                                CRDs
+                                Custom Resources
                               </span>
                             </div>
                             <span
@@ -1605,7 +1605,7 @@ exports[`Storyshots Sidebar/Sidebar In Cluster Sidebar Open 1`] = `
                               <span
                                 class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
                               >
-                                CRDs
+                                Custom Resources
                               </span>
                             </div>
                             <span
@@ -2777,7 +2777,7 @@ exports[`Storyshots Sidebar/Sidebar Selected Item With Sidebar Omitted 1`] = `
                               <span
                                 class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
                               >
-                                CRDs
+                                Custom Resources
                               </span>
                             </div>
                             <span

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -71,7 +71,7 @@ function prepareRoutes(
         },
         {
           name: 'crds',
-          label: t('glossary|CRDs'),
+          label: t('glossary|Custom Resources'),
         },
       ],
     },

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -33,7 +33,7 @@ export interface SectionHeaderProps {
 }
 
 export default function SectionHeader(props: SectionHeaderProps) {
-  const { noPadding = false, headerStyle = 'main' } = props;
+  const { noPadding = false, headerStyle = 'main', titleSideActions = [] } = props;
   const classes = useStyles({ noPadding, headerStyle });
   const actions = props.actions || [];
   const titleVariants: { [key: string]: Variant } = {
@@ -51,10 +51,10 @@ export default function SectionHeader(props: SectionHeaderProps) {
       className={classes.sectionHeader}
       spacing={2}
     >
-      {props.title && (
-        <>
-          <Grid item>
-            <Box display="flex">
+      <Grid item>
+        {(!!props.title || titleSideActions.length > 0) && (
+          <Box display="flex" alignItems="center">
+            {!!props.title && (
               <Typography
                 variant={titleVariants[headerStyle]}
                 noWrap
@@ -62,11 +62,15 @@ export default function SectionHeader(props: SectionHeaderProps) {
               >
                 {props.title}
               </Typography>
-              <Box ml={1}>{props.titleSideActions}</Box>
-            </Box>
-          </Grid>
-        </>
-      )}
+            )}
+            {!!titleSideActions && (
+              <Box ml={1} justifyContent="center">
+                {titleSideActions}
+              </Box>
+            )}
+          </Box>
+        )}
+      </Grid>
       {actions.length > 0 && (
         <Grid item>
           <Grid item container alignItems="center" justifyContent="flex-end">

--- a/frontend/src/components/crd/CustomResourceDetails.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.tsx
@@ -5,9 +5,8 @@ import { useParams } from 'react-router-dom';
 import { ResourceClasses } from '../../lib/k8s';
 import { ApiError } from '../../lib/k8s/apiProxy';
 import CustomResourceDefinition, { KubeCRD, makeCustomResourceClass } from '../../lib/k8s/crd';
-import { createRouteURL } from '../../lib/router';
 import { localeDate } from '../../lib/util';
-import { HoverInfoLabel, NameValueTableRow, ObjectEventList, SectionBox } from '../common';
+import { HoverInfoLabel, Link, NameValueTableRow, ObjectEventList, SectionBox } from '../common';
 import Empty from '../common/EmptyContent';
 import Loader from '../common/Loader';
 import { ConditionsTable, MainInfoSection, PageGrid } from '../common/Resource';
@@ -138,8 +137,23 @@ function CustomResourceDetailsRenderer(props: CustomResourceDetailsRendererProps
     <PageGrid>
       <MainInfoSection
         resource={item}
-        backLink={createRouteURL(crd.detailsRoute, { name: crd.metadata.name })}
-        extraInfo={getExtraInfo(extraColumns, item!.jsonData)}
+        extraInfo={[
+          {
+            name: t('frequent|Definition'),
+            value: (
+              <Link
+                routeName="crd"
+                params={{
+                  name: crd.metadata.name,
+                }}
+              >
+                {crd.metadata.name}
+              </Link>
+            ),
+          },
+          ...getExtraInfo(extraColumns, item!.jsonData),
+        ]}
+        backLink=""
       />
       {item!.jsonData.status?.conditions && (
         <SectionBox>

--- a/frontend/src/components/crd/CustomResourceList.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceList.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { KubeObjectClass } from '../../lib/k8s/cluster';
+import CustomResourceDefinition from '../../lib/k8s/crd';
+import { overrideKubeObject, TestContext, TestContextProps } from '../../test';
+import CustomResourceList from './CustomResourceList';
+import { CRDMockMethods } from './storyHelper';
+
+interface MockerStory {
+  useApiGet?: KubeObjectClass['useApiGet'];
+  routerParams?: TestContextProps['routerMap'];
+}
+
+export default {
+  title: 'crd/CustomResourceList',
+  argTypes: {},
+  decorators: [Story => <Story />],
+} as Meta;
+
+const Template: Story<MockerStory> = args => {
+  const { useApiGet, routerParams = {} } = args;
+  const routerMap: TestContextProps['routerMap'] = routerParams;
+
+  overrideKubeObject(CustomResourceDefinition, {
+    useApiGet,
+  });
+
+  return (
+    <TestContext routerMap={routerMap}>
+      <CustomResourceList />
+    </TestContext>
+  );
+};
+
+export const List = Template.bind({});
+List.args = {
+  useApiGet: CRDMockMethods.usePhonyApiGet,
+  routerParams: {
+    crd: 'mydefinition.phonyresources.io',
+  },
+};

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -1,0 +1,185 @@
+import { Box, makeStyles } from '@material-ui/core';
+import { JSONPath } from 'jsonpath-plus';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { KubeObject } from '../../lib/k8s/cluster';
+import CRD, { KubeCRD, makeCustomResourceClass } from '../../lib/k8s/crd';
+import { localeDate } from '../../lib/util';
+import { Link, Loader, PageGrid, SectionHeader, SimpleTableGetterColumn } from '../common';
+import BackLink from '../common/BackLink';
+import Empty from '../common/EmptyContent';
+import ResourceListView from '../common/Resource/ResourceListView';
+import { ResourceTableProps } from '../common/Resource/ResourceTable';
+
+export default function CustomResourceList() {
+  const { t } = useTranslation('glossary');
+  const { crd: crdName } = useParams<{ crd: string }>();
+  const [crd, error] = CRD.useGet(crdName);
+
+  if (!crd && !error) {
+    return <Loader title={t('crd|Loading custom resource definition')} />;
+  }
+
+  if (!!error) {
+    return (
+      <Empty color="error">
+        {t('crd|Error getting custom resource definition {{ crdName }}: {{ errorMessage }}', {
+          crdName,
+          errorMessage: error,
+        })}
+      </Empty>
+    );
+  }
+
+  return <CustomResourceListRenderer crd={crd} />;
+}
+
+const useStyle = makeStyles({
+  link: {
+    cursor: 'pointer',
+  },
+});
+
+function CustomResourceLink(props: { resource: KubeCRD; crd: CRD; [otherProps: string]: any }) {
+  const classes = useStyle();
+  const { resource, crd, ...otherProps } = props;
+
+  return (
+    <Link
+      className={classes.link}
+      routeName="customresource"
+      params={{
+        crName: resource.metadata.name,
+        crd: crd.metadata.name,
+        namespace: resource.metadata.namespace || '-',
+      }}
+      {...otherProps}
+    >
+      {resource.metadata.name}
+    </Link>
+  );
+}
+
+export interface CustomResourceListProps {
+  crd: CRD;
+}
+
+function CustomResourceListRenderer(props: CustomResourceListProps) {
+  const { crd } = props;
+  const { t } = useTranslation(['glossary', 'crd']);
+
+  return (
+    <PageGrid>
+      <BackLink />
+      <SectionHeader
+        title={t('{{ resourceKind }}', { resourceKind: crd.spec.names.kind })}
+        actions={[
+          <Box mr={2}>
+            <Link routeName="crd" params={{ name: crd.metadata.name }}>
+              {t('crd|CRD: {{ crdName }}', { crdName: crd.metadata.name })}
+            </Link>
+          </Box>,
+        ]}
+      />
+      <CustomResourceListTable crd={crd} />
+    </PageGrid>
+  );
+}
+
+function getValueWithJSONPath(item: KubeCRD, jsonPath: string): string {
+  let value: string | undefined;
+  try {
+    // Extract the value from the json item
+    value = JSONPath({ path: '$' + jsonPath, json: item.jsonData });
+  } catch (err) {
+    console.error(`Failed to get value from JSONPath ${jsonPath} on CR item ${item}`);
+  }
+
+  // Make sure the value will be represented in string form (to account for
+  // e.g. cases where we may get an array).
+  return value?.toString() || '';
+}
+
+export interface CustomResourceTableProps {
+  crd: CRD;
+}
+
+function CustomResourceListTable(props: CustomResourceTableProps) {
+  const { t } = useTranslation('glossary');
+  const { crd } = props;
+
+  const apiGroup = React.useMemo(() => {
+    return crd.getMainAPIGroup();
+  }, [crd]);
+
+  const CRClass = React.useMemo(() => {
+    return makeCustomResourceClass([apiGroup], crd.metadata.namespace);
+  }, [apiGroup, crd.metadata.namespace]);
+
+  if (!CRClass) {
+    return <Empty>{t('crd|No custom resources found')}</Empty>;
+  }
+
+  const additionalPrinterCols = React.useMemo(() => {
+    const currentVersion = apiGroup[1];
+    const colsFromSpec =
+      crd.jsonData.spec.versions.find(
+        (version: KubeCRD['spec']['versions'][number]) => version.name === currentVersion
+      )?.additionalPrinterColumns || [];
+    const cols: SimpleTableGetterColumn[] = [];
+    for (let i = 0; i < colsFromSpec.length; i++) {
+      const idx = i;
+      const colSpec = colsFromSpec[idx];
+      // Skip creation date because we already show it by default
+      if (colSpec.jsonPath === '.metadata.creationTimestamp') {
+        continue;
+      }
+
+      cols.push({
+        label: colSpec.name,
+        getter: resource => {
+          let value = getValueWithJSONPath(resource, colSpec.jsonPath);
+          if (colSpec.type === 'date') {
+            value = localeDate(new Date(value));
+          }
+
+          return value;
+        },
+      });
+    }
+
+    return cols;
+  }, [crd, apiGroup]);
+
+  const cols = React.useMemo(() => {
+    const colsToDisplay: ResourceTableProps['columns'] = [
+      {
+        label: t('frequent|Name'),
+        getter: (resource: KubeObject) => <CustomResourceLink resource={resource} crd={crd} />,
+        sort: (c1: KubeObject, c2: KubeObject) => {
+          return c1.metadata.name.localeCompare(c2.metadata.name);
+        },
+      },
+      ...additionalPrinterCols,
+      'age',
+    ];
+
+    if (crd.isNamespaced) {
+      colsToDisplay.splice(1, 0, 'namespace');
+    }
+
+    return colsToDisplay;
+  }, [crd, additionalPrinterCols]);
+
+  return (
+    <ResourceListView
+      title=""
+      headerProps={{
+        noNamespaceFilter: !crd.isNamespaced,
+      }}
+      resourceClass={CRClass}
+      columns={cols}
+    />
+  );
+}

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -103,11 +103,12 @@ function getValueWithJSONPath(item: KubeCRD, jsonPath: string): string {
 
 export interface CustomResourceTableProps {
   crd: CRD;
+  title?: string;
 }
 
-function CustomResourceListTable(props: CustomResourceTableProps) {
+export function CustomResourceListTable(props: CustomResourceTableProps) {
   const { t } = useTranslation('glossary');
-  const { crd } = props;
+  const { crd, title = '' } = props;
 
   const apiGroup = React.useMemo(() => {
     return crd.getMainAPIGroup();
@@ -174,7 +175,7 @@ function CustomResourceListTable(props: CustomResourceTableProps) {
 
   return (
     <ResourceListView
-      title=""
+      title={title}
       headerProps={{
         noNamespaceFilter: !crd.isNamespaced,
       }}

--- a/frontend/src/components/crd/Details.tsx
+++ b/frontend/src/components/crd/Details.tsx
@@ -78,7 +78,7 @@ export default function CustomResourceDefinitionDetails() {
             },
             {
               name: t('Version'),
-              value: item.spec.version,
+              value: item.getMainAPIGroup()[1],
             },
             {
               name: t('Scope'),
@@ -88,6 +88,19 @@ export default function CustomResourceDefinitionDetails() {
               name: t('Subresources'),
               value: item.spec.subresources && Object.keys(item.spec.subresources).join(' & '),
               hide: !item.spec.subresources,
+            },
+            {
+              name: t('Resource'),
+              value: (
+                <Link
+                  routeName="customresources"
+                  params={{
+                    crd: item.metadata.name,
+                  }}
+                >
+                  {item.spec.names.kind}
+                </Link>
+              ),
             },
           ]
         }

--- a/frontend/src/components/crd/Details.tsx
+++ b/frontend/src/components/crd/Details.tsx
@@ -1,59 +1,15 @@
-import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { ApiError } from '../../lib/k8s/apiProxy';
-import CRD, { KubeCRD, makeCustomResourceClass } from '../../lib/k8s/crd';
+import CRD from '../../lib/k8s/crd';
 import { Link, ObjectEventList } from '../common';
 import Loader from '../common/Loader';
 import { ConditionsTable, MainInfoSection, PageGrid } from '../common/Resource';
-import ResourceTable from '../common/Resource/ResourceTable';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 import DetailsViewSection from '../DetailsViewSection';
-
-function getAPIGroups(item: KubeCRD) {
-  const group = item.spec.group;
-  const version = item.spec.version;
-  const name = item.spec.names.plural as string;
-
-  let versions: any[] = [];
-  if (!version && item.spec.versions.length > 0) {
-    item.spec.versions.map(versionItem => {
-      versions.unshift([group, versionItem.name, name]);
-    });
-  } else {
-    versions = [[group, version, name]];
-  }
-
-  return versions;
-}
-
-const useStyle = makeStyles({
-  link: {
-    cursor: 'pointer',
-  },
-});
-
-function CustomResourceLink(props: { resource: KubeCRD; crd: CRD; [otherProps: string]: any }) {
-  const classes = useStyle();
-  const { resource, crd, ...otherProps } = props;
-
-  return (
-    <Link
-      className={classes.link}
-      routeName="customresource"
-      params={{
-        crName: resource.metadata.name,
-        crd: crd.metadata.name,
-        namespace: resource.metadata.namespace || '-',
-      }}
-      {...otherProps}
-    >
-      {resource.metadata.name}
-    </Link>
-  );
-}
+import { CustomResourceListTable } from './CustomResourceList';
 
 export default function CustomResourceDefinitionDetails() {
   const { name } = useParams<{ name: string }>();
@@ -152,40 +108,9 @@ export default function CustomResourceDefinitionDetails() {
       <SectionBox title={t('Conditions')}>
         <ConditionsTable resource={item.jsonData} showLastUpdate={false} />
       </SectionBox>
-      <SectionBox title={t('Objects')}>
-        <CRObjectsTable crd={item} />
-      </SectionBox>
+      <CustomResourceListTable title={t('Objects')} crd={item} />
       <DetailsViewSection resource={item} />
       {item && <ObjectEventList object={item} />}
     </PageGrid>
-  );
-}
-
-interface CRObjectsTableProps {
-  crd: CRD;
-}
-
-function CRObjectsTable(props: CRObjectsTableProps) {
-  const { crd } = props;
-  const { t } = useTranslation('glossary');
-
-  const CRClass = makeCustomResourceClass(getAPIGroups(crd.jsonData), crd.metadata.namespace);
-
-  return (
-    <ResourceTable
-      resourceClass={CRClass}
-      columns={[
-        {
-          label: t('frequent|Name'),
-          getter: obj => <CustomResourceLink resource={obj} crd={crd} />,
-        },
-        {
-          label: t('glossary|Namespace'),
-          getter: obj => obj.metadata.namespace || '-',
-        },
-        'age',
-      ]}
-      reflectInURL="objects"
-    />
   );
 }

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -4,18 +4,31 @@ import { Link } from '../common';
 import ResourceListView from '../common/Resource/ResourceListView';
 
 export default function CustomResourceDefinitionList() {
-  const { t } = useTranslation('glossary');
+  const { t } = useTranslation(['glossary', 'frequent']);
 
   return (
     <ResourceListView
-      title={t('crd|Custom Resource Definitions')}
+      title={t('glossary|Custom Resources')}
       headerProps={{
         noNamespaceFilter: true,
       }}
       resourceClass={CRD}
       columns={[
         {
-          label: t('frequent|Name'),
+          label: t('glossary|Resource'),
+          getter: crd => (
+            <Link
+              routeName="customresources"
+              params={{
+                crd: crd.metadata.name,
+              }}
+            >
+              {crd.spec.names.kind}
+            </Link>
+          ),
+        },
+        {
+          label: t('frequent|Definition'),
           getter: crd => (
             <Link
               routeName="crd"
@@ -23,9 +36,17 @@ export default function CustomResourceDefinitionList() {
                 name: crd.metadata.name,
               }}
             >
-              {crd.spec.names.kind}
+              {crd.metadata.name}
             </Link>
           ),
+          sort: (c1: CRD, c2: CRD) => {
+            if (c1.metadata.name < c2.metadata.name) {
+              return -1;
+            } else if (c1.metadata.name > c2.metadata.name) {
+              return 1;
+            }
+            return 0;
+          },
         },
         {
           label: t('frequent|Group'),
@@ -36,18 +57,6 @@ export default function CustomResourceDefinitionList() {
           label: t('Scope'),
           getter: crd => crd.spec.scope,
           sort: true,
-        },
-        {
-          label: t('frequent|Full name'),
-          getter: crd => crd.metadata.name,
-          sort: (c1: CRD, c2: CRD) => {
-            if (c1.metadata.name < c2.metadata.name) {
-              return -1;
-            } else if (c1.metadata.name > c2.metadata.name) {
-              return 1;
-            }
-            return 0;
-          },
         },
         'age',
       ]}

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
@@ -146,18 +146,33 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
                   </span>
                 </dd>
                 <dt
-                  class="MuiGrid-root makeStyles-metadataLast makeStyles-metadataNameCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+                  class="MuiGrid-root makeStyles-metadataNameCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                 >
                   Scope
                 </dt>
                 <dd
-                  class="MuiGrid-root makeStyles-metadataLast makeStyles-metadataCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+                  class="MuiGrid-root makeStyles-metadataCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
                 >
                   <span
                     class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
                   >
                     Namespaced
                   </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root makeStyles-metadataLast makeStyles-metadataNameCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+                >
+                  Resource
+                </dt>
+                <dd
+                  class="MuiGrid-root makeStyles-metadataLast makeStyles-metadataCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    MyCustomResource
+                  </a>
                 </dd>
               </dl>
             </div>
@@ -736,7 +751,7 @@ exports[`Storyshots crd/CustomResourceDefinition List 1`] = `
           <h1
             class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
           >
-            Custom Resource Definitions
+            Custom Resources
           </h1>
           <div
             class="MuiBox-root MuiBox-root"
@@ -822,7 +837,28 @@ exports[`Storyshots crd/CustomResourceDefinition List 1`] = `
                 class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
                 scope="col"
               >
-                Name
+                Resource
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell MuiTableCell-sizeSmall"
+                scope="col"
+              >
+                Definition
+                <button
+                  aria-label="sort swap"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
               </th>
               <th
                 class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell MuiTableCell-sizeSmall"
@@ -850,27 +886,6 @@ exports[`Storyshots crd/CustomResourceDefinition List 1`] = `
                 scope="col"
               >
                 Scope
-                <button
-                  aria-label="sort swap"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <span />
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell MuiTableCell-sizeSmall"
-                scope="col"
-              >
-                Full name
                 <button
                   aria-label="sort swap"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
@@ -930,17 +945,22 @@ exports[`Storyshots crd/CustomResourceDefinition List 1`] = `
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="/"
+                >
+                  mydefinition.phonyresources.io
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
                 my.phonyresources.io
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
               >
                 Namespaced
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
-              >
-                mydefinition.phonyresources.io
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.stories.storyshot
@@ -444,14 +444,73 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
               <div
                 class="MuiBox-root MuiBox-root"
               >
-                <h2
-                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h2 MuiTypography-noWrap"
+                <h1
+                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
                 >
                   Objects
-                </h2>
+                </h1>
                 <div
                   class="MuiBox-root MuiBox-root"
                 />
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                >
+                  <div
+                    class="MuiBox-root MuiBox-root"
+                  >
+                    <div
+                      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center"
+                    >
+                      <div
+                        class="MuiGrid-root MuiGrid-item"
+                      >
+                        <button
+                          aria-label="Show filter"
+                          class="MuiButtonBase-root MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <span />
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                      <div
+                        class="MuiGrid-root MuiGrid-item"
+                      >
+                        <button
+                          aria-label="Change columns displayed"
+                          class="MuiButtonBase-root MuiIconButton-root"
+                          tabindex="0"
+                          title="Change columns displayed"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <span />
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -471,16 +530,52 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell MuiTableCell-sizeSmall"
                       scope="col"
                     >
                       Name
+                      <button
+                        aria-label="sort swap"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiIconButton-label"
+                        >
+                          <span />
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell MuiTableCell-sizeSmall"
+                      scope="col"
+                    >
+                      Namespace
+                      <button
+                        aria-label="sort swap"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiIconButton-label"
+                        >
+                          <span />
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell MuiTableCell-sizeSmall"
                       scope="col"
                     >
-                      Namespace
+                      Test Col
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell MuiTableCell-sizeSmall"
@@ -525,7 +620,17 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      mynamespace
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                        href="/"
+                      >
+                        mynamespace
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                    >
+                      mycustomresource
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
@@ -556,7 +661,17 @@ exports[`Storyshots crd/CustomResourceDefinition Details 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     >
-                      mynamespace
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                        href="/"
+                      >
+                        mynamespace
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                    >
+                      myotherresource
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -225,6 +225,21 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   </span>
                 </dd>
                 <dt
+                  class="MuiGrid-root makeStyles-metadataNameCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+                >
+                  Definition
+                </dt>
+                <dd
+                  class="MuiGrid-root makeStyles-metadataCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="/"
+                  >
+                    mydefinition.phonyresources.io
+                  </a>
+                </dd>
+                <dt
                   class="MuiGrid-root makeStyles-metadataLast makeStyles-metadataNameCell MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                 >
                   Test Col

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -626,7 +626,9 @@ exports[`Storyshots hpa/HpaDetailsView Error 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >
@@ -721,7 +723,9 @@ exports[`Storyshots hpa/HpaDetailsView No Item Yet 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
@@ -387,7 +387,9 @@ exports[`Storyshots pdb/PDBDetailsView Error 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >
@@ -482,7 +484,9 @@ exports[`Storyshots pdb/PDBDetailsView No Item Yet 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
@@ -319,7 +319,9 @@ exports[`Storyshots PriorityClass/PriorityClassDetailsView Error 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >
@@ -414,7 +416,9 @@ exports[`Storyshots PriorityClass/PriorityClassDetailsView No Item Yet 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -463,7 +463,9 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Error 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >
@@ -558,7 +560,9 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView No Item Yet 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >

--- a/frontend/src/components/runtimeClass/__snapshots__/Details.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/Details.stories.storyshot
@@ -46,7 +46,9 @@ exports[`Storyshots RuntimeClass/DetailsView Runtime Class Detail 1`] = `
         <div
           class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
         >
-          
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          />
           <div
             class="MuiGrid-root MuiGrid-item"
           >

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.stories.storyshot
@@ -35,49 +35,65 @@ exports[`Storyshots WebhookConfiguration/MutatingWebhookConfig/Details With Serv
             class="MuiTouchRipple-root"
           />
         </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
+        <div
+          class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <h1
+                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              >
+                MutatingWebhookConfiguration
+              </h1>
+              <div
+                class="MuiBox-root MuiBox-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
         <div
           class="MuiBox-root MuiBox-root"
         >
-          <div
-            class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiBox-root MuiBox-root"
-              >
-                <h1
-                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
-                >
-                  MutatingWebhookConfiguration
-                </h1>
-                <div
-                  class="MuiBox-root MuiBox-root"
-                />
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-              </div>
-            </div>
-          </div>
           <div
             aria-busy="false"
             aria-live="polite"
@@ -500,13 +516,6 @@ exports[`Storyshots WebhookConfiguration/MutatingWebhookConfig/Details With Serv
     >
       <div
         class="MuiBox-root MuiBox-root"
-      />
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-    >
-      <div
-        class="MuiBox-root MuiBox-root"
       >
         <div
           class="MuiBox-root MuiBox-root"
@@ -687,49 +696,65 @@ exports[`Storyshots WebhookConfiguration/MutatingWebhookConfig/Details With URL 
             class="MuiTouchRipple-root"
           />
         </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
+        <div
+          class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <h1
+                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              >
+                MutatingWebhookConfiguration
+              </h1>
+              <div
+                class="MuiBox-root MuiBox-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
         <div
           class="MuiBox-root MuiBox-root"
         >
-          <div
-            class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiBox-root MuiBox-root"
-              >
-                <h1
-                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
-                >
-                  MutatingWebhookConfiguration
-                </h1>
-                <div
-                  class="MuiBox-root MuiBox-root"
-                />
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-              </div>
-            </div>
-          </div>
           <div
             aria-busy="false"
             aria-live="polite"
@@ -1143,13 +1168,6 @@ exports[`Storyshots WebhookConfiguration/MutatingWebhookConfig/Details With URL 
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-    >
-      <div
-        class="MuiBox-root MuiBox-root"
-      />
     </div>
     <div
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.stories.storyshot
@@ -35,49 +35,65 @@ exports[`Storyshots WebhookConfiguration/ValidatingWebhookConfig/Details With Se
             class="MuiTouchRipple-root"
           />
         </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
+        <div
+          class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <h1
+                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              >
+                ValidatingWebhookConfiguration
+              </h1>
+              <div
+                class="MuiBox-root MuiBox-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
         <div
           class="MuiBox-root MuiBox-root"
         >
-          <div
-            class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiBox-root MuiBox-root"
-              >
-                <h1
-                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
-                >
-                  ValidatingWebhookConfiguration
-                </h1>
-                <div
-                  class="MuiBox-root MuiBox-root"
-                />
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-              </div>
-            </div>
-          </div>
           <div
             aria-busy="false"
             aria-live="polite"
@@ -486,13 +502,6 @@ exports[`Storyshots WebhookConfiguration/ValidatingWebhookConfig/Details With Se
     >
       <div
         class="MuiBox-root MuiBox-root"
-      />
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-    >
-      <div
-        class="MuiBox-root MuiBox-root"
       >
         <div
           class="MuiBox-root MuiBox-root"
@@ -673,49 +682,65 @@ exports[`Storyshots WebhookConfiguration/ValidatingWebhookConfig/Details With UR
             class="MuiTouchRipple-root"
           />
         </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
+        <div
+          class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <h1
+                class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+              >
+                ValidatingWebhookConfiguration
+              </h1>
+              <div
+                class="MuiBox-root MuiBox-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root"
+      >
         <div
           class="MuiBox-root MuiBox-root"
         >
-          <div
-            class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiBox-root MuiBox-root"
-              >
-                <h1
-                  class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
-                >
-                  ValidatingWebhookConfiguration
-                </h1>
-                <div
-                  class="MuiBox-root MuiBox-root"
-                />
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
-              </div>
-            </div>
-          </div>
           <div
             aria-busy="false"
             aria-live="polite"
@@ -1115,13 +1140,6 @@ exports[`Storyshots WebhookConfiguration/ValidatingWebhookConfig/Details With UR
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-    >
-      <div
-        class="MuiBox-root MuiBox-root"
-      />
     </div>
     <div
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"

--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -44,12 +44,36 @@ class CustomResourceDefinition extends makeKubeObject<KubeCRD>('crd') {
     return 'crd';
   }
 
-  get spec() {
+  get spec(): KubeCRD['spec'] {
     return this.jsonData!.spec;
   }
 
   get plural(): string {
-    return this.spec().names.plural;
+    return this.spec.names.plural;
+  }
+
+  getMainAPIGroup(): [string, string, string] {
+    const group = this.spec.group;
+    let version = this.spec.version;
+    const name = this.spec.names.plural as string;
+
+    // Assign the 1st storage version if no version is specified,
+    // or the 1st served version if no storage version is specified.
+    if (!version && this.spec.versions.length > 0) {
+      for (const versionItem of this.spec.versions) {
+        if (!!versionItem.storage) {
+          version = versionItem.name;
+        } else if (!version) {
+          version = versionItem.name;
+        }
+      }
+    }
+
+    return [group, version, name];
+  }
+
+  get isNamespaced(): boolean {
+    return this.spec.scope === 'Namespaced';
   }
 }
 

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -14,6 +14,7 @@ import { PageGrid } from '../components/common/Resource/Resource';
 import ConfigDetails from '../components/configmap/Details';
 import ConfigMapList from '../components/configmap/List';
 import CustomResourceDetails from '../components/crd/CustomResourceDetails';
+import CustomResourceList from '../components/crd/CustomResourceList';
 import CustomResourceDefinitionDetails from '../components/crd/Details';
 import CustomResourceDefinitionList from '../components/crd/List';
 import CronJobDetails from '../components/cronjob/Details';
@@ -603,6 +604,13 @@ const defaultRoutes: {
     name: 'Custom Resource',
     sidebar: 'crds',
     component: () => <CustomResourceDetails />,
+  },
+  customresources: {
+    path: '/customresources/:crd',
+    exact: true,
+    name: 'Custom Resources',
+    sidebar: 'crds',
+    component: () => <CustomResourceList />,
   },
   notifications: {
     path: '/notifications',


### PR DESCRIPTION
fixes #1393

We now have:
* Name CRDs in the sidebar is now Custom Resources
![Sidebar with Custom Resources label](https://github.com/headlamp-k8s/headlamp/assets/1029635/e2088937-2c2f-4703-a223-edf553cbc88b)

* The list view associated with the sidebar entry has now a link to Resources and Definitions:
![New CRD list view](https://github.com/headlamp-k8s/headlamp/assets/1029635/396ad556-8e38-4bb6-a25c-5a842fd96ac2)

* Clicking on a Resource in the view above, will show the list view for those resources (if the CR spec has additional columns, these are shown too)
![Screenshot for new CR list](https://github.com/headlamp-k8s/headlamp/assets/1029635/3260274f-6ccb-4767-a3e0-09d1d5dbc98b)

* Clicking on an object in the Resource list view will show that object's details view
![Screenshot for CR details view](https://github.com/headlamp-k8s/headlamp/assets/1029635/67cd74fd-2644-40b4-aa7f-78e6cdde85c6)
  * This details view now has a Definition value, allowing to see the CRD association
* In the CRD details view (which existed before), now we have a new Resource value, allowing to access the Resource list view

![Screenshot for CRD details view](https://github.com/headlamp-k8s/headlamp/assets/1029635/287d51a2-9bb2-44af-82f9-0fc595e6fde9)


