### PR TITLE
frontend common/Label: Do not end-align HoverInfoLabel

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -161,8 +161,7 @@ export interface HoverInfoLabelProps {
 
 const useHoverInfoLabelStyles = makeStyles({
   display: {
-    display: 'flex',
-    justifyContent: 'flex-end',
+    display: 'inline-flex',
   },
   noWrap: {
     whiteSpace: 'nowrap',


### PR DESCRIPTION
The HoverInfoLabel was changed to have its contents aligned to the
end (right, in LTR languages) as the date label used should be aligned
as such and uses this component internally. However, many other values
are represented with this label, so we cannot always align it.

This patch fixes that by making this component have an inline-flex
display, allowing for the labels+icons to be vertically aligned to the
center (reason for which it had a display:flex rule) while respecting
the text-align rule set on a wrapping element. i.e. the date labels get
aligned to the right in most tables as their cell has that text-align
rule, but other uses of the mentioned component don't get affected.

**Before the fix:**
![Screenshot showing the issue](https://github.com/headlamp-k8s/headlamp/assets/1029635/e695a5da-b282-4c6d-82b3-ef6e11215eb2)

**After the fix:**
![Screenshot showing the issue being fixed](https://github.com/headlamp-k8s/headlamp/assets/1029635/c413eccb-7110-47f6-ab75-3157f0773f6a)

### How to test:
- [ ] Go to the details view of a Custom Resource (object) that has extra columns (values in the metadata display grid that have an info icon): verify that these are not aligned to the right in the row (screenshots above)
- [ ] Go to any resource list: verify the date column is still aligned to the right