### PR TITLE
Fix standard name CRDs

### DIFF
--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -58,9 +58,11 @@ export function makeCustomResourceClass(
   isNamespaced: boolean
 ) {
   // Used for tests
-  const knownClass = ResourceClasses[args[0][2]];
-  if (!!knownClass) {
-    return knownClass;
+  if (process.env.UNDER_TEST === 'true') {
+    const knownClass = ResourceClasses[args[0][2]];
+    if (!!knownClass) {
+      return knownClass;
+    }
   }
 
   const apiFunc = !!isNamespaced ? apiFactoryWithNamespace : apiFactory;

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -11,12 +11,14 @@ import Registry, * as registryToExport from './registry';
 
 window.pluginLib = {
   ApiProxy: require('../lib/k8s/apiProxy'),
-  Crd: require('../lib/k8s/crd'),
   ReactMonacoEditor: require('@monaco-editor/react'),
   MonacoEditor: require(process.env.NODE_ENV === 'test'
     ? 'monaco-editor/esm/vs/editor/editor.api.js'
     : 'monaco-editor'),
   K8s: require('../lib/k8s'),
+  // Anything that is part of the lib/k8s/ folder should be imported after the K8s import, to
+  // avoid circular dependencies' issues.
+  Crd: require('../lib/k8s/crd'),
   CommonComponents: require('../components/common'),
   MuiCore: require('@material-ui/core'),
   MuiStyles: require('@material-ui/styles'),


### PR DESCRIPTION
When applying a resource, we tried to get a match for a known/default resource (CronJob, Pod, etc.) but this may result in trying to apply a resource using the wrong API when we have a CustomResource that has a name matching any exiting default resource's. This patch always tries to get the API details from the server for the API version of the data we need to apply, thus ensuring we always get the right API.

How to test:
- [ ] Set up a CronTab CRD from the [example](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) in the official k8s docs; then try to apply the YAML for a custom CronTab `*`: it should not work on `main`, but should work with this PR

`*`:
```yaml
apiVersion: "stable.example.com/v1"
kind: CronTab
metadata:
  name: my-new-cron-object
spec:
  cronSpec: "* * * * */5"
  image: my-awesome-cron-image
  replicas: 5
```