### PR TITLE
frontend: Fix regression when applying resources

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -562,7 +562,12 @@ async function resourceDefToApiFactory(
   // this way we always get the right plural name and we also avoid eventually getting
   // the wrong "known" resource because e.g. there can be CustomResources with the same
   // kind as a known resource.
-  const apiResult: APIResourceList = await request(`/apis/${resourceDef.apiVersion}`, {}, false);
+  const apiPrefix = !!apiGroup ? 'apis' : 'api';
+  const apiResult: APIResourceList = await request(
+    `/${apiPrefix}/${resourceDef.apiVersion}`,
+    {},
+    false
+  );
   if (!apiResult) {
     throw new Error(`Unkown apiVersion: ${resourceDef.apiVersion}`);
   }


### PR DESCRIPTION
We started using the "apis" prefix when applying resources but need also to distinguish when "api" is needed.

How to test:
- [ ] Apply a non-grouped resource like [Pod](https://kubernetes.io/docs/concepts/workloads/pods/): it should allow applying the resource
- [ ] Apply a grouped resource like [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/): it should allow applying the resource
- [ ] Apply a [CR whose name matches a default one:](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) it should allow applying the resource