### PR TITLE
frontend: Check whether the volumeName is valid when listing PVCs

### DIFF
--- a/frontend/src/components/storage/ClaimList.stories.tsx
+++ b/frontend/src/components/storage/ClaimList.stories.tsx
@@ -6,7 +6,7 @@ import PersistentVolumeClaim, {
 import { TestContext } from '../../test';
 import PVClaimList from './ClaimList';
 
-const basePVC = {
+const basePVC: KubePersistentVolumeClaim = {
   apiVersion: 'v1',
   kind: 'PersistentVolumeClaim',
   metadata: {
@@ -40,9 +40,21 @@ const basePVC = {
 PersistentVolumeClaim.useList = () => {
   const noStorageClassNamePVC = _.cloneDeep(basePVC);
   noStorageClassNamePVC.metadata.name = 'no-storage-class-name-pvc';
-  noStorageClassNamePVC.spec.storageClassName = '';
+  noStorageClassNamePVC.spec!.storageClassName = '';
 
-  const objList = [basePVC, noStorageClassNamePVC].map(
+  const noVolumeNamePVC = _.cloneDeep(basePVC);
+  noVolumeNamePVC.metadata.name = 'no-volume-name-pvc';
+  noVolumeNamePVC.spec = {
+    accessModes: ['ReadWriteOnce'],
+    volumeMode: 'Block',
+    resources: {
+      requests: {
+        storage: '10Gi',
+      },
+    },
+  };
+
+  const objList = [basePVC, noStorageClassNamePVC, noVolumeNamePVC].map(
     pvc => new PersistentVolumeClaim(pvc as KubePersistentVolumeClaim)
   );
   return [objList, null, () => {}, () => {}] as any;

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -42,6 +42,9 @@ export default function VolumeClaimList() {
           label: t('Volume'),
           getter: volumeClaim => {
             const name = volumeClaim.spec.volumeName;
+            if (!name) {
+              return '';
+            }
             return (
               <Link routeName="persistentVolume" params={{ name }} tooltip>
                 {name}

--- a/frontend/src/components/storage/__snapshots__/ClaimList.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.stories.storyshot
@@ -451,6 +451,77 @@ exports[`Storyshots Storage/PersistentVolumeClaim List View 1`] = `
                 </p>
               </td>
             </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="/"
+                >
+                  no-volume-name-pvc
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="/"
+                >
+                  default
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                Bound
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                <span
+                  class=""
+                  title="ReadWriteOnce"
+                >
+                  ReadWriteOnce
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                8Gi
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+              >
+                Block
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                style="text-align: right;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-noWrap makeStyles-display MuiTypography-body1"
+                  title="2023-04-27T20:31:27.000Z"
+                >
+                  3mo
+                  <span />
+                </p>
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/frontend/src/lib/k8s/persistentVolumeClaim.ts
+++ b/frontend/src/lib/k8s/persistentVolumeClaim.ts
@@ -2,25 +2,27 @@ import { apiFactoryWithNamespace } from './apiProxy';
 import { KubeObjectInterface, makeKubeObject } from './cluster';
 
 export interface KubePersistentVolumeClaim extends KubeObjectInterface {
-  spec: {
-    accessModes: string[];
-    resources: {
+  spec?: {
+    accessModes?: string[];
+    resources?: {
       limits?: object;
       requests: {
         storage?: string;
         [other: string]: any;
       };
     };
-    storageClassName: string;
-    volumeMode: string;
-    volumeName: string;
+    storageClassName?: string;
+    volumeMode?: string;
+    volumeName?: string;
     [other: string]: any;
   };
-  status: {
+  status?: {
     capacity?: {
       storage?: string;
     };
-    phase: string;
+    phase?: string;
+    accessModes?: string[];
+    [other: string]: any;
   };
 }
 


### PR DESCRIPTION
If it's not a valid string, then we shouldn't try to get a link for it.

This is an attempt to fix #1444 .