### PR TITLE
frontend: app: Fix lint to ignore generated app js

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,0 +1,4 @@
+../app/electron/i18next.config.js
+../app/electron/main.js
+../app/electron/preload.js
+../app/electron/windowSize.js


### PR DESCRIPTION
If you've been building the app, then the generated .js files are included in the `npm run lint`. With this file the generated js files are ignored, so the lint works.


### how to test?

- make the app js
- cd frontend && npm run lint
- there should be no false warnings/errors from the app generated js
