### PR TITLE
Show spinner when workloads are loading

### DIFF
--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -93,7 +93,7 @@ export default function Overview() {
           {workloads.map(({ className: name }) => (
             <Grid item lg={3} md={4} xs={6} key={name}>
               <WorkloadCircleChart
-                workloadData={workloadsData[name] || []}
+                workloadData={workloadsData[name] || null}
                 // @todo: Use a plural from from the class itself when we have it
                 title={name + 's'}
                 partialLabel={t('translation|Failed')}

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -22,19 +22,16 @@ interface WorkloadDict {
 }
 
 export default function Overview() {
-  const [workloadsData, dispatch] = React.useReducer(setWorkloads, {});
+  const [workloadsData, setWorkloadsData] = React.useState<WorkloadDict>({});
   const location = useLocation();
   const filterFunc = useFilterFunc(['.jsonData.kind']);
   const { t } = useTranslation('glossary');
 
-  function setWorkloads(
-    workloads: WorkloadDict,
-    { items, kind }: { items: Workload[]; kind: string }
-  ) {
-    const data = { ...workloads };
-    data[kind] = items;
-
-    return data;
+  function setWorkloads(newWorkloads: WorkloadDict) {
+    setWorkloadsData(workloads => ({
+      ...workloads,
+      ...newWorkloads,
+    }));
   }
 
   function getPods(item: Workload) {
@@ -79,11 +76,12 @@ export default function Overview() {
   ];
   workloads.forEach((workloadClass: KubeObject) => {
     workloadClass.useApiList(
-      (items: InstanceType<typeof workloadClass>[]) =>
-        dispatch({ items, kind: workloadClass.className }),
+      (items: InstanceType<typeof workloadClass>[]) => {
+        setWorkloads({ [workloadClass.className]: items });
+      },
       (err: ApiError) => {
         console.error(`Workloads list: Failed to get list for ${workloadClass.className}: ${err}`);
-        dispatch({ items: [], kind: workloadClass.className });
+        setWorkloads({ [workloadClass.className]: [] });
       }
     );
   });


### PR DESCRIPTION
This PR fixes #1483 (check it out for testing instructions) and simplifies the logic for the workloads state as well.
It also adds a spinner to the tiled charts.
fixes #1489 