### PR TITLE
Fixes for headlamp-plugin tests and story tests for change-logo and tables examples

### DIFF
--- a/plugins/examples/change-logo/package-lock.json
+++ b/plugins/examples/change-logo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "change-logo",
       "version": "0.0.1",
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.6.1"
+        "@kinvolk/headlamp-plugin": "^0.7.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4890,9 +4890,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.6.1.tgz",
-      "integrity": "sha512-ZnZlxGLCBlhBlRuz6uQc/mMhWTFHjirSo90P2mRGfL5/BPffsiJOuvRmcXYMTXwnsTk8nN3DRiCXCVShm8VwpQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.7.2.tgz",
+      "integrity": "sha512-tJ/IcnLadTludbhTp/DZuOFDkKe25qecxAVb8kZ6W1CO/zSIM5a3OVXVe9XTDAKFzroim+RgrH+51wA6bOogZg==",
       "dev": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
@@ -4926,6 +4926,7 @@
         "@svgr/webpack": "^6.2.1",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
+        "@testing-library/user-event": "^14.5.1",
         "@types/humanize-duration": "^3.27.1",
         "@types/js-yaml": "^4.0.3",
         "@types/json-patch": "0.0.30",
@@ -14607,6 +14608,19 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -50058,9 +50072,9 @@
       }
     },
     "@kinvolk/headlamp-plugin": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.6.1.tgz",
-      "integrity": "sha512-ZnZlxGLCBlhBlRuz6uQc/mMhWTFHjirSo90P2mRGfL5/BPffsiJOuvRmcXYMTXwnsTk8nN3DRiCXCVShm8VwpQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.7.2.tgz",
+      "integrity": "sha512-tJ/IcnLadTludbhTp/DZuOFDkKe25qecxAVb8kZ6W1CO/zSIM5a3OVXVe9XTDAKFzroim+RgrH+51wA6bOogZg==",
       "dev": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
@@ -50094,6 +50108,7 @@
         "@svgr/webpack": "^6.2.1",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
+        "@testing-library/user-event": "^14.5.1",
         "@types/humanize-duration": "^3.27.1",
         "@types/js-yaml": "^4.0.3",
         "@types/json-patch": "0.0.30",
@@ -57442,6 +57457,13 @@
         "@testing-library/dom": "^8.0.0",
         "@types/react-dom": "<18.0.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/plugins/examples/change-logo/package.json
+++ b/plugins/examples/change-logo/package.json
@@ -28,6 +28,6 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.6.1"
+    "@kinvolk/headlamp-plugin": "^0.7.2"
   }
 }

--- a/plugins/examples/change-logo/src/ReactiveLogo.stories.tsx
+++ b/plugins/examples/change-logo/src/ReactiveLogo.stories.tsx
@@ -1,0 +1,43 @@
+import { AppLogoProps } from '@kinvolk/headlamp-plugin/lib';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReactiveLogo } from './index';
+
+export default {
+  title: 'ReactiveLogo',
+  component: ReactiveLogo,
+  decorators: [
+    Story => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: Story<AppLogoProps> = args => <ReactiveLogo {...args} />;
+
+export const SmallDark = Template.bind({});
+SmallDark.args = {
+  logoType: 'small',
+  themeName: 'dark',
+};
+
+export const SmallLight = Template.bind({});
+SmallLight.args = {
+  logoType: 'small',
+  themeName: 'light',
+};
+
+export const LargeDark = Template.bind({});
+LargeDark.args = {
+  logoType: 'large',
+  themeName: 'dark',
+};
+
+export const LargeLight = Template.bind({});
+LargeLight.args = {
+  logoType: 'large',
+  themeName: 'light',
+};

--- a/plugins/examples/change-logo/src/__snapshots__/ReactiveLogo.stories.storyshot
+++ b/plugins/examples/change-logo/src/__snapshots__/ReactiveLogo.stories.storyshot
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots ReactiveLogo Large Dark 1`] = `
+<div>
+  <p>
+    large dark theme logo
+  </p>
+</div>
+`;
+
+exports[`Storyshots ReactiveLogo Large Light 1`] = `
+<div>
+  <p>
+    large light theme logo
+  </p>
+</div>
+`;
+
+exports[`Storyshots ReactiveLogo Small Dark 1`] = `
+<div>
+  <p>
+    small dark theme logo
+  </p>
+</div>
+`;
+
+exports[`Storyshots ReactiveLogo Small Light 1`] = `
+<div>
+  <p>
+    small light theme logo
+  </p>
+</div>
+`;

--- a/plugins/examples/change-logo/src/index.tsx
+++ b/plugins/examples/change-logo/src/index.tsx
@@ -30,7 +30,7 @@ function SimpleLogo(props: AppLogoProps) {
 /**
  * This logo example shows how you can customize the logo more for different conditions.
  */
-function ReactiveLogo(props: AppLogoProps) {
+export function ReactiveLogo(props: AppLogoProps) {
   const { logoType, themeName } = props;
 
   if (logoType === 'small' && themeName === 'dark') {

--- a/plugins/examples/change-logo/src/storybook.test.tsx
+++ b/plugins/examples/change-logo/src/storybook.test.tsx
@@ -1,0 +1,3 @@
+import { initTests } from '@kinvolk/headlamp-plugin/config/storyshots/storyshots-test';
+
+initTests();

--- a/plugins/examples/tables/package-lock.json
+++ b/plugins/examples/tables/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tables",
       "version": "0.0.1",
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.6.1"
+        "@kinvolk/headlamp-plugin": "^0.7.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4783,9 +4783,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.6.1.tgz",
-      "integrity": "sha512-ZnZlxGLCBlhBlRuz6uQc/mMhWTFHjirSo90P2mRGfL5/BPffsiJOuvRmcXYMTXwnsTk8nN3DRiCXCVShm8VwpQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.7.2.tgz",
+      "integrity": "sha512-tJ/IcnLadTludbhTp/DZuOFDkKe25qecxAVb8kZ6W1CO/zSIM5a3OVXVe9XTDAKFzroim+RgrH+51wA6bOogZg==",
       "dev": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
@@ -4819,6 +4819,7 @@
         "@svgr/webpack": "^6.2.1",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
+        "@testing-library/user-event": "^14.5.1",
         "@types/humanize-duration": "^3.27.1",
         "@types/js-yaml": "^4.0.3",
         "@types/json-patch": "0.0.30",
@@ -14356,6 +14357,19 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/plugins/examples/tables/package.json
+++ b/plugins/examples/tables/package.json
@@ -30,6 +30,6 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.6.1"
+    "@kinvolk/headlamp-plugin": "^0.7.2"
   }
 }

--- a/plugins/examples/tables/src/ContextMenu.stories.tsx
+++ b/plugins/examples/tables/src/ContextMenu.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ContextMenu, ContextMenuProps } from './index';
+
+export default {
+  title: 'ContextMenu',
+  component: ContextMenu,
+  decorators: [
+    Story => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: Story<ContextMenuProps> = args => <ContextMenu {...args} />;
+
+export const OpenMenu = Template.bind({});
+OpenMenu.args = {
+  detailsLink: 'https://headlamp.dev/',
+};

--- a/plugins/examples/tables/src/__snapshots__/ContextMenu.stories.storyshot
+++ b/plugins/examples/tables/src/__snapshots__/ContextMenu.stories.storyshot
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots ContextMenu Open Menu 1`] = `
+<div>
+  <button
+    aria-label="Open pod context menu"
+    class="MuiButtonBase-root MuiIconButton-root"
+    tabindex="0"
+    title="Open pod context menu"
+    type="button"
+  >
+    <span
+      class="MuiIconButton-label"
+    >
+      <span />
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</div>
+`;

--- a/plugins/examples/tables/src/index.tsx
+++ b/plugins/examples/tables/src/index.tsx
@@ -5,9 +5,15 @@ import { Menu, MenuItem, Typography } from '@material-ui/core';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
-// Will show a 3-dot menu with two options: Details and Delete.
-function ContextMenu(props: { pod: Pod }) {
-  const { pod } = props;
+export interface ContextMenuProps {
+  detailsLink: string;
+}
+
+/**
+ * Will show a 3-dot menu with two options: Details and Delete.
+ */
+export function ContextMenu(props: ContextMenuProps) {
+  const { detailsLink } = props;
   const [anchorEl, setAnchorEl] = React.useState(null);
   const history = useHistory();
 
@@ -29,7 +35,7 @@ function ContextMenu(props: { pod: Pod }) {
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
         <MenuItem
           onClick={() => {
-            history.push(pod.getDetailsLink());
+            history.push(detailsLink);
           }}
         >
           <Typography>Details</Typography>
@@ -66,7 +72,7 @@ registerResourceTableColumnsProcessor(function setupContextMenuForPodsList({ id,
     columns.push({
       label: '',
       getter: (pod: Pod) => {
-        return <ContextMenu pod={pod} />;
+        return <ContextMenu detailsLink={pod.getDetailsLink()} />;
       },
     });
   }

--- a/plugins/examples/tables/src/storybook.test.tsx
+++ b/plugins/examples/tables/src/storybook.test.tsx
@@ -1,0 +1,3 @@
+import { initTests } from '@kinvolk/headlamp-plugin/config/storyshots/storyshots-test';
+
+initTests();

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -296,9 +296,10 @@ function start() {
  * @param packageFolder {string} - folder where the package, or folder of packages is.
  * @param scriptName {string} - name of the script to run.
  * @param cmdLine {string} - command line to run.
+ * @param env {object} - environment variables to run the command with.
  * @returns {0 | 1} - Exit code, where 0 is success, 1 is failure.
  */
-function runScriptOnPackages(packageFolder, scriptName, cmdLine) {
+function runScriptOnPackages(packageFolder, scriptName, cmdLine, env) {
   if (!fs.existsSync(packageFolder)) {
     console.error(`"${packageFolder}" does not exist. Not ${scriptName}-ing.`);
     return 1;
@@ -378,6 +379,7 @@ function runScriptOnPackages(packageFolder, scriptName, cmdLine) {
       child_process.execSync(cmdLineToUse, {
         stdio: 'inherit',
         encoding: 'utf8',
+        env: { ...process.env, ...(env || {}) },
       });
     } catch (e) {
       console.error(`Problem running ${scriptName} inside of "${folder}"\r\n`);
@@ -516,7 +518,7 @@ function format(packageFolder, check) {
   const cmdLine = check
     ? `prettier --config package.json --check src`
     : 'prettier --config package.json --write src';
-  return runScriptOnPackages(packageFolder, 'format', cmdLine);
+  return runScriptOnPackages(packageFolder, 'format', cmdLine, {});
 }
 
 /**
@@ -822,7 +824,7 @@ function lint(packageFolder, fix) {
   const script = `eslint -c package.json --max-warnings 0 --ext .js,.ts,.tsx src/${
     fix ? ' --fix' : ''
   }`;
-  return runScriptOnPackages(packageFolder, 'lint', script);
+  return runScriptOnPackages(packageFolder, 'lint', script, {});
 }
 
 /**
@@ -833,7 +835,7 @@ function lint(packageFolder, fix) {
  */
 function tsc(packageFolder) {
   const script = 'tsc --noEmit';
-  return runScriptOnPackages(packageFolder, 'tsc', script);
+  return runScriptOnPackages(packageFolder, 'tsc', script, {});
 }
 
 /**
@@ -872,7 +874,7 @@ function storybook(packageFolder) {
  */
 function storybook_build(packageFolder) {
   const script = `build-storybook -c node_modules/@kinvolk/headlamp-plugin/config/.storybook`;
-  return runScriptOnPackages(packageFolder, 'storybook-build', script);
+  return runScriptOnPackages(packageFolder, 'storybook-build', script, {});
 }
 
 /**
@@ -883,7 +885,7 @@ function storybook_build(packageFolder) {
  */
 function test(packageFolder) {
   const script = `react-scripts test --transformIgnorePatterns "/node_modules/(?!monaco-editor|spacetime|d3|internmap|react-markdown|xterm|github-markdown-css|vfile|unist-.+|unified|bail|is-plain-obj|trough|remark-.+|mdast-util-.+|micromark|parse-entities|character-entities|property-information|comma-separated-tokens|hast-util-whitespace|remark-.+|space-separated-tokens|decode-named-character-reference|@kinvolk/headlamp-plugin)"`;
-  return runScriptOnPackages(packageFolder, 'test', script);
+  return runScriptOnPackages(packageFolder, 'test', script, { UNDER_TEST: 'true' });
 }
 
 const headlampPluginBin = fs.realpathSync(process.argv[1]);

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -882,7 +882,7 @@ function storybook_build(packageFolder) {
  * @returns {0 | 1} Exit code, where 0 is success, 1 is failure.
  */
 function test(packageFolder) {
-  const script = `react-scripts test --transformIgnorePatterns "/node_modules/(?!d3|internmap|react-markdown|xterm|github-markdown-css|vfile|unist-.+|unified|bail|is-plain-obj|trough|remark-.+|mdast-util-.+|micromark|parse-entities|character-entities|property-information|comma-separated-tokens|hast-util-whitespace|remark-.+|space-separated-tokens|decode-named-character-reference|@kinvolk/headlamp-plugin)"`;
+  const script = `react-scripts test --transformIgnorePatterns "/node_modules/(?!monaco-editor|spacetime|d3|internmap|react-markdown|xterm|github-markdown-css|vfile|unist-.+|unified|bail|is-plain-obj|trough|remark-.+|mdast-util-.+|micromark|parse-entities|character-entities|property-information|comma-separated-tokens|hast-util-whitespace|remark-.+|space-separated-tokens|decode-named-character-reference|@kinvolk/headlamp-plugin)"`;
   return runScriptOnPackages(packageFolder, 'test', script);
 }
 

--- a/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
+++ b/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 // jsdom used by react-scripts test doesn't include TextEncoder/TextDecoder polyfills
 import { TextDecoder, TextEncoder } from 'util';
 global.TextEncoder = TextEncoder;
-// @ts-expect-error
+// @ts-ignore
 global.TextDecoder = TextDecoder;
 
 /**

--- a/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
+++ b/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
@@ -30,11 +30,6 @@ export function initTests() {
       // We use React Testing library here
       const converter = new OurConverter();
       const snapshotFilename = converter.getSnapshotFileName(context);
-      console.log('snapshotFilename', snapshotFilename);
-
-      // get abs snapshotFilename, since it is relative
-      const absSnapshotFilename = path.join(process.cwd(), snapshotFilename);
-      console.log('absSnapshotFilename', absSnapshotFilename);
 
       // Re-render for state changes:
       // https://github.com/storybookjs/storybook/issues/7745#issuecomment-801940326

--- a/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
+++ b/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
@@ -2,6 +2,12 @@ import initStoryshots, { Stories2SnapsConverter } from '@storybook/addon-storysh
 import * as rtl from '@testing-library/react';
 import path from 'path';
 
+// jsdom used by react-scripts test doesn't include TextEncoder/TextDecoder polyfills
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+// @ts-expect-error
+global.TextDecoder = TextDecoder;
+
 /**
  * The storyshot addon has some bug where the path is src/
  *  and the cwd is src, so it makes src/src folders.

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "main": "lib/index.js",
   "types": "./lib/additional.d.ts",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "main": "lib/index.js",
   "types": "./lib/additional.d.ts",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "main": "lib/index.js",
   "types": "./lib/additional.d.ts",


### PR DESCRIPTION
Whilst writing some plugin tests also fixed some headlamp-plugin issues running tests.

- headlamp-plugin: Fix for test runner to add polyfill TextEncoder
- headlamp-plugin: Add some more transform ignores for the test runner
- headlamp-plugin: storyshots workaround bugfix updated due to a dependency update
- headlamp-plugin: Add UNDER_TEST environment variable when testing
- plugins/examples/change-logo: Add ReactiveLogo.stories
- plugins/examples/tables: Add ContextMenu.stories


### How to test?

Run the tests, and see the stories in the storybooks.
The tests should pass, and you should see the stories.

```bash
cd plugins/examples/tables
npm i
npm run test
npm run storybook

cd plugins/examples/change-logo
npm i
npm run test
npm run storybook
```