### PR TITLE
docker-ext: Fix portforward issue

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -101,6 +101,7 @@ type PortForwardPayload struct {
 	ServiceNamespace string `json:"serviceNamespace"`
 	TargetPort       string `json:"targetPort"`
 	Cluster          string `json:"cluster"`
+	Address          string `json:"address"`
 	Port             string `json:"port"`
 }
 
@@ -589,6 +590,9 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 			id := uuid.New().String()
 			p.ID = id
 		}
+		if p.Address == "" {
+			p.Address = "localhost"
+		}
 
 		reqToken := r.Header.Get("Authorization")
 		splitToken := strings.Split(reqToken, "Bearer ")
@@ -883,7 +887,7 @@ func (c *HeadlampConfig) startPortForward(p PortForwardPayload, token string) er
 	stopChan, readyChan := make(chan struct{}), make(chan struct{}, 1)
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 
-	forwarder, err := portforward.New(dialer, ports, stopChan, readyChan, out, errOut)
+	forwarder, err := portforward.NewOnAddresses(dialer, []string{p.Address}, ports, stopChan, readyChan, out, errOut)
 	if err != nil {
 		return fmt.Errorf("portforward request: failed to create portforward: %v", err)
 	}

--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - ~/.kube/:/headlamp/config:ro
     ports:
       - 64446:64446
+      - "30000-32000:30000-32000"

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1395,6 +1395,7 @@ export function startPortForward(
   service: string,
   serviceNamespace: string,
   port?: string,
+  address: string = '',
   id: string = ''
 ) {
   return fetch(`${helpers.getAppUrl()}portforward`, {
@@ -1411,6 +1412,7 @@ export function startPortForward(
       targetPort: containerPort.toString(),
       serviceNamespace,
       id: id,
+      address,
       port,
     }),
   }).then((response: Response) => {


### PR DESCRIPTION
In docker desktop since the backend is running
inside a container portforwards running in the
container are not accessible from the host machine
to fix this a range of ports from 30000 to
32000 is exposed and a value in this range is used
when starting a portforward.