### PR TITLE
frontend: Adds time to log download file name

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -99,10 +99,13 @@ export function LogViewer(props: LogViewerProps) {
   };
 
   function downloadLog() {
+    // Cuts off the last 5 digits of the timestamp to remove the milliseconds
+    const time = new Date().toISOString().replace(/:/g, '-').slice(0, -5);
+
     const element = document.createElement('a');
     const file = new Blob(logs, { type: 'text/plain' });
     element.href = URL.createObjectURL(file);
-    element.download = `${downloadName}.txt`;
+    element.download = `${downloadName}_${time}.txt`;
     // Required for FireFox
     document.body.appendChild(element);
     element.click();


### PR DESCRIPTION
# Add Timestamp Suffix to Downloaded Log Filenames

Fixes issue #1482 

## Description
In order to differentiate downloaded log files from one another, this update appends a timestamp suffix to the filename, reflecting the exact moment the file is downloaded. This enhancement ensures clearer organization and retrieval of log files, particularly when multiple downloads occur.

## Changes
- [x] Implemented a timestamp suffix to the log file name during the download process.

## Before and After
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/082e5ecf-c8a6-4893-a132-433723010e9e)

