### PR TITLE
frontend: Fix endpoint address field CSS

### DIFF
--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -101,7 +101,6 @@ export default function ServiceDetails() {
                       {
                         label: t('translation|Addresses'),
                         getter: endpoint => endpoint.getAddressesText(),
-                        cellProps: { style: { width: '40%', maxWidth: '40%' } },
                       },
                     ]}
                     reflectInURL="endpoints"


### PR DESCRIPTION
# Fixed Styling Issue for Endpoints Field in Service View

Fixes issue #1500

## Description
The observed styling issue in the Endpoints section of the Service View has been resolved. The table now renders correctly across all viewing sizes, displaying the relevant information without any blank boxes or misalignment, enhancing the user's ability to view and interact with endpoint information.

## Images

### Before
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/42e7be6a-f5b6-4ade-8b59-4d5c7c24aff4)

### After
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/a9511548-9e16-4c8b-b160-41d69d9139e4)

## Changes
- [x] Removed the styling logic for the Endpoints section to eliminate the blank box rendering.
- [x] Ensured consistent rendering of the table across various viewing sizes.

## Verification
- Navigated to the Service View, selected a service to view its details, and confirmed that the table under the Endpoints section now renders correctly without any blank boxes or misalignment.
- Tested the rendering on multiple viewing sizes to confirm the fix is effective.