### PR TITLE
frontend: Fixes endpoint address renders

### DIFF
--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -1,4 +1,5 @@
 import { InlineIcon } from '@iconify/react';
+import { Box } from '@material-ui/core';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -100,7 +101,13 @@ export default function ServiceDetails() {
                       },
                       {
                         label: t('translation|Addresses'),
-                        getter: endpoint => endpoint.getAddressesText(),
+                        getter: endpoint => (
+                          <Box display="flex" flexDirection="column">
+                            {endpoint.getAddresses().map((address: string) => (
+                              <ValueLabel>{address}</ValueLabel>
+                            ))}
+                          </Box>
+                        ),
                       },
                     ]}
                     reflectInURL="endpoints"

--- a/frontend/src/lib/k8s/endpoints.ts
+++ b/frontend/src/lib/k8s/endpoints.ts
@@ -44,7 +44,7 @@ class Endpoints extends makeKubeObject<KubeEndpoint>('endpoint') {
   }
 
   getAddressesText() {
-    this.getAddresses().join(', ');
+    return this.getAddresses().join(', ');
   }
 
   getAddresses() {


### PR DESCRIPTION
# Fix Address Field Rendering in Service Detail View

Fixes issue #1515 

## Description
This PR addresses the rendering issue of the address field within the Endpoints section of the Service Detail View. The corrections ensure that the address field now displays the appropriate information without any truncation or misalignment, enhancing the user's interaction with endpoint address information.

## Images

### Before
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/0371742d-181f-4571-b4bf-e7d3dce05d8d)

### After
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/0c79b1da-9abb-432a-be16-4c79b27155c8)

## Changes
- [x] Adjusted rendering logic to properly handle different viewing sizes and correctly populate the address field.

## Verification
- Navigated to the Service Detail View, scrolled down to the Endpoints section, and confirmed that the address field now renders correctly.
- Tested the rendering on multiple viewing sizes and different browsers to confirm the fix is effective.

## Acknowledgements
A special thank you to @Src0p for their invaluable contributions to this PR. Their insights and suggestions significantly enhanced the quality of the changes, and their willingness to share expertise has greatly benefited the project. 

Thank you for your hard work and dedication!