### PR TITLE
frontend: Add init and ephemeral containers logs

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -8,7 +8,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import { makeStyles } from '@material-ui/core/styles';
 import _ from 'lodash';
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Terminal as XTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -76,7 +76,7 @@ export default function Terminal(props: TerminalProps) {
   const { item, onClose, isAttach, ...other } = props;
   const classes = useStyle();
   const [terminalContainerRef, setTerminalContainerRef] = React.useState<HTMLElement | null>(null);
-  const [container, setContainer] = React.useState<string | null>(null);
+  const [container, setContainer] = useState<string | null>(getDefaultContainer());
   const execOrAttachRef = React.useRef<execReturn | null>(null);
   const fitAddonRef = React.useRef<FitAddon | null>(null);
   const xtermRef = React.useRef<XTerminalConnected | null>(null);
@@ -84,7 +84,7 @@ export default function Terminal(props: TerminalProps) {
     available: getAvailableShells(),
     currentIdx: 0,
   });
-  const { t } = useTranslation();
+  const { t } = useTranslation(['translation', 'glossary']);
 
   function getDefaultContainer() {
     return item.spec.containers.length > 0 ? item.spec.containers[0].name : '';
@@ -424,12 +424,36 @@ export default function Terminal(props: TerminalProps) {
               value={container !== null ? container : getDefaultContainer()}
               onChange={handleContainerChange}
             >
-              {item &&
-                item.spec.containers.map(({ name }) => (
-                  <MenuItem value={name} key={name}>
-                    {name}
-                  </MenuItem>
-                ))}
+              {item?.spec?.containers && (
+                <MenuItem disabled value="">
+                  {t('glossary|Containers')}
+                </MenuItem>
+              )}
+              {item?.spec?.containers.map(({ name }) => (
+                <MenuItem value={name} key={name}>
+                  {name}
+                </MenuItem>
+              ))}
+              {item?.spec?.initContainers && (
+                <MenuItem disabled value="">
+                  {t('translation|Init Containers')}
+                </MenuItem>
+              )}
+              {item.spec.initContainers?.map(({ name }) => (
+                <MenuItem value={name} key={`init_container_${name}`}>
+                  {name}
+                </MenuItem>
+              ))}
+              {item?.spec?.ephemeralContainers && (
+                <MenuItem disabled value="">
+                  {t('glossary|Ephemeral Containers')}
+                </MenuItem>
+              )}
+              {item.spec.ephemeralContainers?.map(({ name }) => (
+                <MenuItem value={name} key={`eph_container_${name}`}>
+                  {name}
+                </MenuItem>
+              ))}
             </Select>
           </FormControl>
         </Box>

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -170,12 +170,36 @@ function PodLogViewer(props: PodLogViewerProps) {
             value={container}
             onChange={handleContainerChange}
           >
-            {item &&
-              item.spec.containers.map(({ name }) => (
-                <MenuItem value={name} key={name}>
-                  {name}
-                </MenuItem>
-              ))}
+            {item?.spec?.containers && (
+              <MenuItem disabled value="">
+                {t('glossary|Containers')}
+              </MenuItem>
+            )}
+            {item?.spec?.containers.map(({ name }) => (
+              <MenuItem value={name} key={name}>
+                {name}
+              </MenuItem>
+            ))}
+            {item?.spec?.initContainers && (
+              <MenuItem disabled value="">
+                {t('translation|Init Containers')}
+              </MenuItem>
+            )}
+            {item.spec.initContainers?.map(({ name }) => (
+              <MenuItem value={name} key={`init_container_${name}`}>
+                {name}
+              </MenuItem>
+            ))}
+            {item?.spec?.ephemeralContainers && (
+              <MenuItem disabled value="">
+                {t('glossary|Ephemeral Containers')}
+              </MenuItem>
+            )}
+            {item.spec.ephemeralContainers?.map(({ name }) => (
+              <MenuItem value={name} key={`eph_container_${name}`}>
+                {name}
+              </MenuItem>
+            ))}
           </Select>
         </FormControl>,
         <FormControl className={classes.linesFormControl}>

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -24,6 +24,7 @@
   "Containers": "Container",
   "Container Spec": "Container-Spezifikation",
   "Container": "Container",
+  "Ephemeral Containers": "",
   "Config Maps": "Config Maps",
   "Definition": "Definition",
   "CRD: {{ crdName }}": "CRD: {{ crdName }}",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -24,6 +24,7 @@
   "Containers": "Containers",
   "Container Spec": "Container Spec",
   "Container": "Container",
+  "Ephemeral Containers": "Ephemeral Containers",
   "Config Maps": "Config Maps",
   "Definition": "Definition",
   "CRD: {{ crdName }}": "CRD: {{ crdName }}",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -24,6 +24,7 @@
   "Containers": "Contenedores",
   "Container Spec": "Espec. de Contenedor",
   "Container": "Contenedor",
+  "Ephemeral Containers": "",
   "Config Maps": "Config Maps",
   "Definition": "Definición",
   "CRD: {{ crdName }}": "CRD: {{ crdName }}",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -24,6 +24,7 @@
   "Containers": "Conteneurs",
   "Container Spec": "Spécifications des conteneurs",
   "Container": "Conteneur",
+  "Ephemeral Containers": "",
   "Config Maps": "Config Maps",
   "Definition": "Définition",
   "CRD: {{ crdName }}": "CRD: {{ crdName }}",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -24,6 +24,7 @@
   "Containers": "Containers",
   "Container Spec": "Espec. de \"Container\"",
   "Container": "Container",
+  "Ephemeral Containers": "",
   "Config Maps": "Config Maps",
   "Definition": "Definição",
   "CRD: {{ crdName }}": "CRD: {{ crdName }}",

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -15,7 +15,8 @@ export interface KubePodSpec {
   nodeSelector?: {
     [key: string]: string;
   };
-  initContainers?: any[];
+  initContainers?: KubeContainer[];
+  ephemeralContainers?: KubeContainer[];
   readinessGates?: {
     conditionType: string;
   }[];


### PR DESCRIPTION
# Extend Pod Details View with Init Container Log/Exec Selection

Fixes issue #1450

## Description
This PR enhances the Pod Details View by allowing logs and exec commands to be selected by container type. Users can now choose between standard containers, init containers, and ephemeral containers (if present) for more granular access to logs and exec functionality.

## Changes
- [x] Implemented log/exec selection for standard containers in Pod Details.
- [x] Added log/exec selection capability for init containers.
- [x] Enabled log/exec selection for ephemeral containers when they exist.

## Verification
- Manual testing was conducted to ensure that logs and exec commands can be selected and are functioning for each container type within the Pod Details View.


## Images
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/eb554105-c913-4e63-9514-ef2c66681ddd)
