### PR TITLE
backend: Refactor and Add tests to Portforward

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -1,0 +1,371 @@
+package portforward
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/kubeconfig"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+const (
+	RUNNING = "Running"
+	STOPPED = "Stopped"
+)
+
+const PodAvailabilityCheckTimer = 5 // seconds
+
+type portForwardRequest struct {
+	ID               string `json:"id"`
+	Namespace        string `json:"namespace"`
+	Pod              string `json:"pod"`
+	Service          string `json:"service"`
+	ServiceNamespace string `json:"serviceNamespace"`
+	TargetPort       string `json:"targetPort"`
+	Cluster          string `json:"cluster"`
+	Port             string `json:"port"`
+}
+
+func (p *portForwardRequest) Validate() error {
+	if p.Namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+
+	if p.Pod == "" {
+		return fmt.Errorf("pod name is required")
+	}
+
+	if p.TargetPort == "" {
+		return fmt.Errorf("targetPort is required")
+	}
+
+	if p.Cluster == "" {
+		return fmt.Errorf("cluster name is required")
+	}
+
+	return nil
+}
+
+type portForward struct {
+	ID               string `json:"id"`
+	closeChan        chan struct{}
+	Pod              string `json:"pod"`
+	Service          string `json:"service"`
+	ServiceNamespace string `json:"serviceNamespace"`
+	Namespace        string `json:"namespace"`
+	Cluster          string `json:"cluster"`
+	Port             string `json:"port"`
+	TargetPort       string `json:"targetPort"`
+	Status           string `json:"status"`
+	Error            string `json:"error"`
+}
+
+func getFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// StartPortForward handles the port forward request.
+func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache[interface{}],
+	w http.ResponseWriter, r *http.Request,
+) {
+	var p portForwardRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, "failed to marshal port forward payload "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+
+	reqToken := r.Header.Get("Authorization")
+	splitToken := strings.Split(reqToken, "Bearer ")
+
+	var token string
+	if reqToken != "" || len(splitToken) > 2 {
+		token = splitToken[1]
+	}
+
+	if err := p.Validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if p.Port == "" {
+		// if no port is specified find a available port
+		freePort, err := getFreePort()
+		if err != nil || freePort == 0 {
+			http.Error(w, "can't find any available port "+err.Error(), http.StatusInternalServerError)
+		}
+
+		p.Port = strconv.Itoa(freePort)
+	}
+
+	kContext, err := kubeConfigStore.GetContext(p.Cluster)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	err = startPortForward(kContext, cache, p, token)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err = json.NewEncoder(w).Encode(p); err != nil {
+		http.Error(w, "failed to write json payload to response write "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// startPortForward starts a port forward.
+//
+//nolint:funlen
+func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{}],
+	p portForwardRequest, token string,
+) error {
+	clientset, err := kContext.ClientSetWithToken(token)
+	if err != nil {
+		return fmt.Errorf("failed to create portforward request: %v", err)
+	}
+
+	rConf, err := kContext.RESTConfig()
+	if err != nil {
+		return fmt.Errorf("failed to create portforward request: %v", err)
+	}
+
+	rConf.BearerToken = token
+
+	roundTripper, upgrader, err := spdy.RoundTripperFor(rConf)
+	if err != nil {
+		log.Printf("Error: failed to create round tripper: %s", err)
+		return fmt.Errorf("failed to create portforward request")
+	}
+
+	requestURL := fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward", rConf.Host, p.Namespace, p.Pod)
+
+	reqURL, err := url.Parse(requestURL)
+	if err != nil {
+		return fmt.Errorf("portforward request: failed to parse url: %v", err)
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, reqURL)
+	stopChan, readyChan := make(chan struct{}), make(chan struct{}, 1)
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf(p.Port + ":" + p.TargetPort)},
+		stopChan, readyChan, out, errOut)
+	if err != nil {
+		return fmt.Errorf("portforward request: failed to create portforward: %v", err)
+	}
+
+	portForwardToStore := portForward{
+		ID:               p.ID,
+		closeChan:        stopChan,
+		Pod:              p.Pod,
+		Cluster:          p.Cluster,
+		Namespace:        p.Namespace,
+		Service:          p.Service,
+		ServiceNamespace: p.ServiceNamespace,
+		TargetPort:       p.TargetPort,
+		Status:           RUNNING,
+		Port:             p.Port,
+		Error:            "",
+	}
+
+	go func() {
+		if err = forwarder.ForwardPorts(); err != nil { // Locks until stopChan is closed.
+			log.Printf("Error: failed to forward ports: %s", err)
+			stopChan <- struct{}{}
+
+			portForwardToStore.Error = err.Error()
+			portforwardstore(cache, portForwardToStore)
+		}
+	}()
+
+	<-readyChan
+
+	if errOut.String() == "" {
+		portforwardstore(cache, portForwardToStore)
+	}
+
+	/* check every PodAvailabilityCheckTimer seconds if the pod for which we started a portforward is running
+	if not then we close the channel
+	*/
+	ticker := time.NewTicker(PodAvailabilityCheckTimer * time.Second)
+
+	go func() {
+		for range ticker.C {
+			err := checkIfPodIsRunning(clientset, p.Namespace, p.Pod)
+			if err != nil {
+				if errors.Is(err, syscall.ECONNREFUSED) {
+					continue
+				}
+
+				log.Printf("portforward: failed to get pod: %s", err)
+				stopChan <- struct{}{}
+
+				portForwardToStore.Error = err.Error()
+
+				portforwardstore(cache, portForwardToStore)
+				ticker.Stop()
+			}
+		}
+	}()
+
+	return nil
+}
+
+func checkIfPodIsRunning(clientset *kubernetes.Clientset, namespace string, pod string) error {
+	ctx := context.Background()
+
+	p, err := clientset.CoreV1().Pods(namespace).Get(ctx, pod, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if p.Status.Phase != corev1.PodRunning {
+		return errors.New("pod is not running")
+	}
+
+	return nil
+}
+
+// stopOrDeletePortForwardRequest is the payload for stop or delete port forward request handler.
+type stopOrDeletePortForwardRequest struct {
+	ID           string `json:"id"`
+	Cluster      string `json:"cluster"`
+	StopOrDelete bool   `json:"stopOrDelete"`
+}
+
+func (r *stopOrDeletePortForwardRequest) Validate() error {
+	if r.ID == "" {
+		return errors.New("invalid request, id is required")
+	}
+
+	if r.Cluster == "" {
+		return errors.New("invalid request, cluster is required")
+	}
+
+	return nil
+}
+
+// StopOrDeletePortForward handles stop or delete port forward request.
+func StopOrDeletePortForward(cache cache.Cache[interface{}], w http.ResponseWriter, r *http.Request) {
+	var p stopOrDeletePortForwardRequest
+
+	err := json.NewDecoder(r.Body).Decode(&p)
+	if err != nil {
+		log.Printf("Error decoding delete portforward payload %s", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	if err := p.Validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = stopOrDeletePortForward(cache, p.Cluster, p.ID, p.StopOrDelete)
+	if err == nil {
+		if _, err := w.Write([]byte("stopped")); err != nil {
+			http.Error(w, "failed to write response "+err.Error(), http.StatusInternalServerError)
+		}
+
+		return
+	}
+
+	http.Error(w, "failed to delete port forward "+err.Error(), http.StatusInternalServerError)
+}
+
+// GetPortForwards handles get port forwards request.
+func GetPortForwards(cache cache.Cache[interface{}], w http.ResponseWriter, r *http.Request) {
+	cluster := r.URL.Query().Get("cluster")
+	if cluster == "" {
+		http.Error(w, "cluster is required", http.StatusBadRequest)
+		return
+	}
+
+	ports := getPortForwardList(cache, cluster)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(ports); err != nil {
+		http.Error(w, "failed to write json payload to response "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// GetPortForwardByID handles get port forward by id request.
+func GetPortForwardByID(cache cache.Cache[interface{}], w http.ResponseWriter, r *http.Request) {
+	cluster := r.URL.Query().Get("cluster")
+	if cluster == "" {
+		http.Error(w, "cluster is required", http.StatusBadRequest)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	p, err := getPortForwardByID(cache, cluster, id)
+	if err != nil {
+		http.Error(w, "no portforward running with id "+id, http.StatusNotFound)
+		return
+	}
+
+	type payload struct {
+		ID        string `json:"id"`
+		Pod       string `json:"pod"`
+		Service   string `json:"service"`
+		Cluster   string `json:"cluster"`
+		Namespace string `json:"namespace"`
+	}
+
+	portForwardStruct := payload{
+		ID:        p.ID,
+		Pod:       p.Pod,
+		Namespace: p.Namespace,
+		Cluster:   p.Cluster,
+		Service:   p.Service,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(portForwardStruct); err != nil {
+		http.Error(w, "failed to write json payload "+err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -1,0 +1,255 @@
+package portforward_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/kubeconfig"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/portforward"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getDefaultKubeConfigPath(t *testing.T) string {
+	t.Helper()
+
+	user, err := user.Current()
+	require.NoError(t, err)
+
+	homeDirectory := user.HomeDir
+
+	return filepath.Join(homeDirectory, ".kube", "config")
+}
+
+//nolint:funlen
+func TestStartPortForward(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {
+		t.Skip("skipping integration test")
+	}
+
+	// create cache
+	ch := cache.New[interface{}]()
+
+	// create kubeconfig store
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	// load kubeconfig
+	kubeConfigPath := getDefaultKubeConfigPath(t)
+	kContexts, err := kubeconfig.LoadContextsFromFile(kubeConfigPath, kubeconfig.KubeConfig)
+	require.NoError(t, err)
+	require.NotEmpty(t, kContexts)
+
+	kc := kContexts[0]
+	err = kubeConfigStore.AddContext(&kc)
+	require.NoError(t, err)
+
+	// find a pod to portforward to
+	clientSet, err := kc.ClientSetWithToken("")
+	require.NoError(t, err)
+	require.NotNil(t, clientSet)
+
+	podList, err := clientSet.CoreV1().Pods("headlamp").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, podList)
+
+	podName := ""
+	targetPort := ""
+	// select the pod and make sure it has a port to forward to.
+	for _, pod := range podList.Items {
+		if len(pod.Spec.Containers) > 0 && len(pod.Spec.Containers[0].Ports) > 0 {
+			podName = pod.Name
+			targetPort = fmt.Sprint(pod.Spec.Containers[0].Ports[0].ContainerPort)
+		}
+	}
+
+	require.NotEmpty(t, podName)
+	require.NotEmpty(t, targetPort)
+
+	// start portforward
+	req := &http.Request{}
+	resp := httptest.NewRecorder()
+
+	// create request
+	reqPayload := map[string]interface{}{
+		"cluster":    "minikube",
+		"pod":        podName,
+		"namespace":  "headlamp",
+		"targetPort": targetPort,
+	}
+
+	jsonReq, err := json.Marshal(reqPayload)
+	require.NoError(t, err)
+
+	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
+
+	portforward.StartPortForward(kubeConfigStore, ch, resp, req)
+
+	res := resp.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	data, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	require.Contains(t, string(data), targetPort)
+
+	// get port from response
+	var pfRespPayload map[string]interface{}
+	err = json.Unmarshal(data, &pfRespPayload)
+	require.NoError(t, err)
+
+	port := pfRespPayload["port"].(string)
+
+	// To test the pod uptime check is working
+	time.Sleep(7 * time.Second)
+
+	// check if portforward is running
+	req, err = http.NewRequestWithContext(context.Background(), "GET",
+		fmt.Sprintf("http://localhost:%s/config", port), nil)
+	require.NoError(t, err)
+
+	pfResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer pfResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, pfResp.StatusCode)
+
+	pfRespData, err := io.ReadAll(pfResp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, pfRespData)
+
+	assert.Contains(t, string(pfRespData), "incluster")
+
+	// stop portforward
+	req = &http.Request{}
+	resp = httptest.NewRecorder()
+
+	// create stop request
+	reqPayload = map[string]interface{}{
+		"cluster":      "minikube",
+		"id":           pfRespPayload["id"],
+		"stopOrDelete": true,
+	}
+
+	jsonReq, err = json.Marshal(reqPayload)
+	require.NoError(t, err)
+
+	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
+
+	portforward.StopOrDeletePortForward(ch, resp, req)
+
+	res = resp.Result()
+	defer res.Body.Close()
+
+	stopRespBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Contains(t, string(stopRespBody), "stopped")
+
+	// check if portforward is stopped
+	chState, err := ch.Get(context.Background(), "PORT_FORWARD_minikube"+pfRespPayload["id"].(string))
+	require.NoError(t, err)
+
+	chData, err := json.Marshal(chState)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(chData), "Stopped")
+
+	// list portforwards
+	req = &http.Request{}
+	resp = httptest.NewRecorder()
+	req.URL = &url.URL{}
+	req.URL.RawQuery = "cluster=minikube"
+
+	portforward.GetPortForwards(ch, resp, req)
+
+	res = resp.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	data, err = io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	var pfListRespPayload []map[string]interface{}
+	err = json.Unmarshal(data, &pfListRespPayload)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, pfListRespPayload)
+	assert.Contains(t, pfListRespPayload[0]["id"], pfRespPayload["id"])
+	assert.Contains(t, pfListRespPayload[0]["status"], "Stopped")
+	assert.Equal(t, "[", string(string(data)[0]))
+
+	// test fetching a portforward by id
+	req = &http.Request{}
+	resp = httptest.NewRecorder()
+	req.URL = &url.URL{}
+	req.URL.RawQuery = "cluster=minikube&id=" + pfRespPayload["id"].(string)
+
+	portforward.GetPortForwardByID(ch, resp, req)
+
+	res = resp.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	data, err = io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	var pfRespPayloadByID map[string]interface{}
+	err = json.Unmarshal(data, &pfRespPayloadByID)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, pfRespPayloadByID)
+	assert.Contains(t, pfRespPayloadByID["id"], pfRespPayload["id"])
+
+	// delete portforward
+	req = &http.Request{}
+	resp = httptest.NewRecorder()
+
+	// create delete request
+	reqPayload = map[string]interface{}{
+		"cluster":      "minikube",
+		"id":           pfRespPayload["id"],
+		"stopOrDelete": false,
+	}
+
+	jsonReq, err = json.Marshal(reqPayload)
+	require.NoError(t, err)
+
+	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
+
+	portforward.StopOrDeletePortForward(ch, resp, req)
+
+	res = resp.Result()
+	defer res.Body.Close()
+
+	deleteRespBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Contains(t, string(deleteRespBody), "stopped")
+
+	// check if portforward is deleted
+	chState, err = ch.Get(context.Background(), "PORT_FORWARD_minikube"+pfRespPayload["id"].(string))
+	require.Error(t, err)
+	require.Nil(t, chState)
+}

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -1,0 +1,174 @@
+package portforward
+
+import (
+	"context"
+	"testing"
+
+	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPortforwardKeyGenerator tests portforwardKeyGenerator function.
+func TestPortforwardKeyGenerator(t *testing.T) {
+	tests := []struct {
+		name string
+		p    portForward
+		want string
+	}{
+		{"only_cluster_id", portForward{ID: "id", Cluster: "cluster"}, "PORT_FORWARD_clusterid"},
+		{"only_service", portForward{Cluster: "cluster", Service: "service"}, "PORT_FORWARD_clusterservice"},
+		{"only_pod", portForward{Cluster: "cluster", Pod: "pod"}, "PORT_FORWARD_clusterpod"},
+		{"service_and_pod", portForward{Cluster: "cluster", Service: "service", Pod: "pod"}, "PORT_FORWARD_clusterservice"},
+		{"id_and_service", portForward{Cluster: "cluster", ID: "id", Service: "service"}, "PORT_FORWARD_clusterid"},
+		{"id_and_pod", portForward{Cluster: "cluster", ID: "id", Pod: "pod"}, "PORT_FORWARD_clusterid"},
+		{
+			"id_and_service_and_pod",
+			portForward{Cluster: "cluster", ID: "id", Service: "service", Pod: "pod"},
+			"PORT_FORWARD_clusterid",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		testname := tt.name
+		t.Run(testname, func(t *testing.T) {
+			key := portforwardKeyGenerator(tt.p)
+			assert.Equal(t, tt.want, key)
+		})
+	}
+}
+
+// TestPortforwardStore tests portforwardstore function.
+func TestPortforwardStore(t *testing.T) {
+	cache := cache.New[interface{}]()
+	p := portForward{ID: "id", Cluster: "cluster"}
+	portforwardstore(cache, p)
+
+	key := portforwardKeyGenerator(p)
+
+	pFromCache, err := cache.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, p, pFromCache.(portForward))
+}
+
+// TestGetPortForwardByID tests getPortForwardByID function.
+func TestGetPortForwardByID(t *testing.T) {
+	cache := cache.New[interface{}]()
+	p := portForward{ID: "id", Cluster: "cluster"}
+	err := cache.Set(context.Background(), portforwardKeyGenerator(p), p)
+	require.NoError(t, err)
+
+	pFromCache, err := getPortForwardByID(cache, "cluster", "id")
+	require.NoError(t, err)
+	assert.Equal(t, p, pFromCache)
+
+	_, err = getPortForwardByID(cache, "cluster", "id2")
+	assert.Error(t, err)
+
+	err = cache.Set(context.Background(), portforwardKeyGenerator(portForward{ID: "id2", Cluster: "cluster"}), "test")
+	require.NoError(t, err)
+
+	_, err = getPortForwardByID(cache, "cluster", "id2")
+	assert.Error(t, err)
+}
+
+// TestStopOrDeletePortForward tests stopOrDeletePortForward function.
+func TestStopOrDeletePortForward(t *testing.T) {
+	cache := cache.New[interface{}]()
+	ch := make(chan struct{}, 1)
+
+	p := portForward{ID: "id", Cluster: "cluster", closeChan: ch}
+
+	err := cache.Set(context.Background(), portforwardKeyGenerator(p), p)
+	require.NoError(t, err)
+
+	err = stopOrDeletePortForward(cache, "cluster", "id", true)
+	assert.NoError(t, err)
+
+	chanValue := <-ch
+	assert.Equal(t, struct{}{}, chanValue)
+
+	pFromCache, err := getPortForwardByID(cache, "cluster", "id")
+	require.NoError(t, err)
+	assert.NotEqual(t, portForward{}, pFromCache)
+	assert.Equal(t, STOPPED, pFromCache.Status)
+
+	err = stopOrDeletePortForward(cache, "cluster", "id", false)
+	require.NoError(t, err)
+
+	_, err = cache.Get(context.Background(), portforwardKeyGenerator(p))
+	assert.Error(t, err)
+}
+
+// TestGetPortForwardList tests getPortForwardList function.
+func TestGetPortForwardList(t *testing.T) {
+	p1 := portForward{ID: "id1", Cluster: "cluster1"}
+	p2 := portForward{ID: "id2", Cluster: "cluster1"}
+	p3 := portForward{ID: "id3", Cluster: "cluster2"}
+
+	cache := cache.New[interface{}]()
+
+	err := cache.Set(context.Background(), portforwardKeyGenerator(p1), p1)
+	require.NoError(t, err)
+
+	err = cache.Set(context.Background(), portforwardKeyGenerator(p2), p2)
+	require.NoError(t, err)
+
+	err = cache.Set(context.Background(), portforwardKeyGenerator(p3), p3)
+	require.NoError(t, err)
+
+	pfList := getPortForwardList(cache, "cluster1")
+	assert.ElementsMatch(t, []portForward{p1, p2}, pfList)
+
+	pfList = getPortForwardList(cache, "cluster2")
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []portForward{p3}, pfList)
+}
+
+// Test portForwardRequest.Validate() function.
+func TestPortForwardRequestValidate(t *testing.T) {
+	req := portForwardRequest{}
+
+	err := req.Validate()
+	assert.EqualError(t, err, "namespace is required")
+
+	req.Namespace = "namespace"
+
+	err = req.Validate()
+	assert.EqualError(t, err, "pod name is required")
+
+	req.Pod = "pod"
+
+	err = req.Validate()
+	assert.EqualError(t, err, "targetPort is required")
+
+	req.TargetPort = "targetPort"
+
+	err = req.Validate()
+	assert.EqualError(t, err, "cluster name is required")
+
+	req.Cluster = "cluster"
+
+	err = req.Validate()
+	assert.NoError(t, err)
+}
+
+// TestStopOrDeletePortForwardRequest.Validate() function.
+func TestStopOrDeletePortForwardRequestValidate(t *testing.T) {
+	req := stopOrDeletePortForwardRequest{}
+
+	err := req.Validate()
+	assert.EqualError(t, err, "invalid request, id is required")
+
+	req.ID = "id"
+
+	err = req.Validate()
+	assert.EqualError(t, err, "invalid request, cluster is required")
+
+	req.Cluster = "cluster"
+
+	err = req.Validate()
+	assert.NoError(t, err)
+}

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -1,0 +1,97 @@
+package portforward
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
+)
+
+const storeKeyPrefix = "PORT_FORWARD_"
+
+// portforwardKeyGenerator generates a unique key
+// based on the cluster name, id,service name, and pod name.
+func portforwardKeyGenerator(p portForward) string {
+	if p.ID != "" {
+		return storeKeyPrefix + p.Cluster + p.ID
+	}
+
+	key := storeKeyPrefix + p.Cluster
+
+	if p.Service != "" {
+		key += p.Service
+	} else if p.Pod != "" {
+		key += p.Pod
+	}
+
+	return key
+}
+
+// portforwardstore stores a port forward in the cache.
+func portforwardstore(cache cache.Cache[interface{}], p portForward) {
+	key := portforwardKeyGenerator(p)
+
+	err := cache.Set(context.Background(), key, p)
+	if err != nil {
+		log.Printf("Error storing portforward %s", err)
+	}
+}
+
+// stopOrDeletePortForward stops or deletes a port forward by its cluster and id.
+// It takes three parameters: cluster is the name of the cluster, id is the unique identifier of the port forward,
+// isStopRequest is a boolean value indicating whether to stop or delete the port forward.
+// It returns an error value indicating whether the operation is successful or not.
+func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id string, isStopRequest bool) error {
+	portforward, err := getPortForwardByID(cache, cluster, id)
+	if err != nil {
+		return err
+	}
+
+	if isStopRequest {
+		// close the channel to stop the portforward
+		portforward.closeChan <- struct{}{}
+		portforward.Status = STOPPED
+		portforwardstore(cache, portforward)
+	} else {
+		err := cache.Delete(context.Background(), portforwardKeyGenerator(portforward))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getPortForwardList returns a list of port forwards by its cluster name.
+func getPortForwardList(cache cache.Cache[interface{}], cluster string) []portForward {
+	portforwards, err := cache.GetAll(context.Background(), func(key string) bool {
+		return strings.HasPrefix(key, storeKeyPrefix+cluster)
+	})
+	if err != nil {
+		return nil
+	}
+
+	portForwards := []portForward{}
+	for _, v := range portforwards {
+		portForwards = append(portForwards, v.(portForward))
+	}
+
+	return portForwards
+}
+
+// getPortForwardByID returns a port forward by its cluster name and id.
+func getPortForwardByID(cache cache.Cache[interface{}], cluster string, id string) (portForward, error) {
+	cacheValue, err := cache.Get(context.Background(), storeKeyPrefix+cluster+id)
+	if err != nil {
+		return portForward{}, fmt.Errorf("failed to get portforward from cache: %v", err)
+	}
+
+	pf, ok := cacheValue.(portForward)
+	if !ok {
+		return portForward{}, fmt.Errorf("failed to convert cache value to portforward")
+	}
+
+	return pf, nil
+}


### PR DESCRIPTION
this patch refactors the Portforward
feature and moves it to a separate package.
this refactor uses the cache to store the
state of portforwards and adds tests.