### PR TITLE
frontend: Use the right group and version in KubeObject.getAuthorization

### DIFF
--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -76,7 +76,24 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
               />
               <div
                 class="MuiGrid-root MuiGrid-item"
-              />
+              >
+                <button
+                  aria-label="View YAML"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
+                  tabindex="0"
+                  title="View YAML"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
               <div
                 class="MuiGrid-root MuiGrid-item"
               />

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.stories.storyshot
@@ -76,7 +76,24 @@ exports[`Storyshots pdb/PDBDetailsView Default 1`] = `
               />
               <div
                 class="MuiGrid-root MuiGrid-item"
-              />
+              >
+                <button
+                  aria-label="View YAML"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
+                  tabindex="0"
+                  title="View YAML"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
               <div
                 class="MuiGrid-root MuiGrid-item"
               />

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.stories.storyshot
@@ -76,7 +76,24 @@ exports[`Storyshots PriorityClass/PriorityClassDetailsView Default 1`] = `
               />
               <div
                 class="MuiGrid-root MuiGrid-item"
-              />
+              >
+                <button
+                  aria-label="View YAML"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
+                  tabindex="0"
+                  title="View YAML"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
               <div
                 class="MuiGrid-root MuiGrid-item"
               />

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -76,7 +76,24 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
               />
               <div
                 class="MuiGrid-root MuiGrid-item"
-              />
+              >
+                <button
+                  aria-label="View YAML"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
+                  tabindex="0"
+                  title="View YAML"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <span />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
               <div
                 class="MuiGrid-root MuiGrid-item"
               />

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -570,7 +570,24 @@ function multipleApiFactory(
     put: repeatFactoryMethod(apiEndpoints, 'put'),
     delete: repeatFactoryMethod(apiEndpoints, 'delete'),
     isNamespaced: false,
+    apiInfo: args.map(apiArgs => ({
+      group: apiArgs[0],
+      version: apiArgs[1],
+      resource: apiArgs[2],
+    })),
   };
+}
+
+/**
+ * Describes the API for a certain resource.
+ */
+export interface ApiInfo {
+  /** The API group. */
+  group: string;
+  /** The API version. */
+  version: string;
+  /** The resource name. */
+  resource: string;
 }
 
 // @todo: singleApiFactory should have a return type rather than just what it returns.
@@ -608,6 +625,7 @@ function singleApiFactory(group: string, version: string, resource: string) {
     delete: (name: string, queryParams?: QueryParameters) =>
       remove(`${url}/${name}` + asQuery(queryParams)),
     isNamespaced: false,
+    apiInfo: [{ group, version, resource }],
   };
 }
 
@@ -647,6 +665,11 @@ function multipleApiFactoryWithNamespace(
     put: repeatFactoryMethod(apiEndpoints, 'put'),
     delete: repeatFactoryMethod(apiEndpoints, 'delete'),
     isNamespaced: true,
+    apiInfo: args.map(apiArgs => ({
+      group: apiArgs[0],
+      version: apiArgs[1],
+      resource: apiArgs[2],
+    })),
   };
 }
 
@@ -699,6 +722,7 @@ function simpleApiFactoryWithNamespace(
     delete: (namespace: string, name: string, queryParams?: QueryParameters) =>
       remove(`${url(namespace)}/${name}` + asQuery(queryParams)),
     isNamespaced: true,
+    apiInfo: [{ group, version, resource }],
   };
 
   if (includeScale) {


### PR DESCRIPTION
The right group and version were not being used when checking for a
resources' authorization which resulted in wrong authorization
assessments.

fixes #1490
