### PR TITLE
frontend CronJob: Add owner ref when manually spawning jobs

### DIFF
--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -54,6 +54,22 @@ function SpawnJobDialog(props: {
   job.metadata.namespace = namespace;
   job.apiVersion = 'batch/v1';
   job.metadata.name = jobName;
+  job.metadata.annotations = {
+    ...job.metadata.annotations,
+    'cronjob.kubernetes.io/instantiate': 'manual',
+  };
+  if (!!cronJob.jsonData) {
+    job.metadata.ownerReferences = [
+      {
+        apiVersion: cronJob.jsonData.apiVersion,
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: cronJob.jsonData.kind,
+        name: cronJob.metadata.name,
+        uid: cronJob.metadata.uid,
+      },
+    ];
+  }
 
   function handleClose() {
     setOpenJobDialog(false);


### PR DESCRIPTION
Otherwise they are just loose jobs and don't appear in the CronJob's
table.


## How to test
- [ ] Set up a CronJob and go to its details page; click the spawn button there and create a job from it; wait a few secs: the job should show in the CronJob's jobs table.
- [ ] When viewing the spawned Job's details it shows the CronJob as the owner reference

fixes #1399

