### PR TITLE
lib/k8s/apiProxy.ts: Correct typo 'handel' to 'handle'

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1308,7 +1308,7 @@ export async function metrics(
   onMetrics: (arg: KubeMetrics[]) => void,
   onError?: (err: ApiError) => void
 ) {
-  const handel = setInterval(getMetrics, 10000);
+  const handle = setInterval(getMetrics, 10000);
 
   async function getMetrics() {
     try {
@@ -1326,7 +1326,7 @@ export async function metrics(
   }
 
   function cancel() {
-    clearInterval(handel);
+    clearInterval(handle);
   }
 
   getMetrics();


### PR DESCRIPTION
Fixed a small typo in the code where 'handel' should be 'handle'.