### PR TITLE
Show spinners when cluster changes

### DIFF
--- a/frontend/src/components/App/Notifications/notificationsSlice.test.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.test.ts
@@ -48,7 +48,7 @@ describe('notificationsSlice', () => {
       getItem: jest.fn(),
       setItem: jest.fn(),
     };
-    global.localStorage = mockLocalStorage as any;
+    localStorage = mockLocalStorage as any;
 
     store = configureStore({
       reducer: {

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -25,13 +25,11 @@ const useOverviewStyle = makeStyles({
 });
 
 export default function Overview() {
-  const [pods, setPods] = React.useState<Pod[] | null>(null);
-  const [nodes, setNodes] = React.useState<Node[] | null>(null);
   const { t } = useTranslation(['translation']);
   const classes = useOverviewStyle();
 
-  Pod.useApiList(setPods);
-  Node.useApiList(setNodes);
+  const [pods] = Pod.useList();
+  const [nodes] = Node.useList();
 
   const [nodeMetrics, metricsError] = Node.useMetrics();
 

--- a/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
@@ -66,40 +66,76 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                         </div>
                         <p
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom makeStyles-legend css-9vf8gf-MuiTypography-root"
-                        />
+                        >
+                          0.00 / 36 units
+                        </p>
                       </div>
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          aria-busy="true"
+                          aria-busy="false"
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
                           
                           <div
-                            class="makeStyles-loaderContainer MuiBox-root css-11ra0t9"
+                            class="recharts-wrapper makeStyles-chart"
+                            style="position: relative; cursor: default; width: 112px; height: 112px;"
                           >
-                            <span
-                              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-wdedfu-MuiCircularProgress-root"
-                              role="progressbar"
-                              style="width: 40px; height: 40px;"
-                              title="Loading data for "
+                            <svg
+                              class="recharts-surface"
+                              cx="70"
+                              cy="70"
+                              height="112"
+                              version="1.1"
+                              viewBox="0 0 112 112"
+                              width="112"
                             >
-                              <svg
-                                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
-                                viewBox="22 22 44 44"
+                              <title />
+                              <desc />
+                              <defs>
+                                <clippath
+                                  id="recharts1-clip"
+                                >
+                                  <rect
+                                    height="102"
+                                    width="102"
+                                    x="5"
+                                    y="5"
+                                  />
+                                </clippath>
+                              </defs>
+                              <g
+                                class="recharts-layer recharts-pie"
                               >
-                                <circle
-                                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
-                                  cx="44"
-                                  cy="44"
-                                  fill="none"
-                                  r="20.2"
-                                  stroke-width="3.6"
-                                />
-                              </svg>
-                            </span>
+                                <g
+                                  class="recharts-layer"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                </g>
+                                <text
+                                  class="recharts-text recharts-label"
+                                  offset="5"
+                                  style="font-size: 16.8px; fill: #000;"
+                                  text-anchor="middle"
+                                  x="61"
+                                  y="61"
+                                >
+                                  <tspan
+                                    dy="0.355em"
+                                    x="61"
+                                  >
+                                    0.0 %
+                                  </tspan>
+                                </text>
+                              </g>
+                            </svg>
                           </div>
                         </div>
                       </div>
@@ -129,40 +165,76 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                         </div>
                         <p
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom makeStyles-legend css-9vf8gf-MuiTypography-root"
-                        />
+                        >
+                          0.00 / 143.63 GB
+                        </p>
                       </div>
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          aria-busy="true"
+                          aria-busy="false"
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
                           
                           <div
-                            class="makeStyles-loaderContainer MuiBox-root css-11ra0t9"
+                            class="recharts-wrapper makeStyles-chart"
+                            style="position: relative; cursor: default; width: 112px; height: 112px;"
                           >
-                            <span
-                              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-wdedfu-MuiCircularProgress-root"
-                              role="progressbar"
-                              style="width: 40px; height: 40px;"
-                              title="Loading data for "
+                            <svg
+                              class="recharts-surface"
+                              cx="70"
+                              cy="70"
+                              height="112"
+                              version="1.1"
+                              viewBox="0 0 112 112"
+                              width="112"
                             >
-                              <svg
-                                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
-                                viewBox="22 22 44 44"
+                              <title />
+                              <desc />
+                              <defs>
+                                <clippath
+                                  id="recharts3-clip"
+                                >
+                                  <rect
+                                    height="102"
+                                    width="102"
+                                    x="5"
+                                    y="5"
+                                  />
+                                </clippath>
+                              </defs>
+                              <g
+                                class="recharts-layer recharts-pie"
                               >
-                                <circle
-                                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
-                                  cx="44"
-                                  cy="44"
-                                  fill="none"
-                                  r="20.2"
-                                  stroke-width="3.6"
-                                />
-                              </svg>
-                            </span>
+                                <g
+                                  class="recharts-layer"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                </g>
+                                <text
+                                  class="recharts-text recharts-label"
+                                  offset="5"
+                                  style="font-size: 16.8px; fill: #000;"
+                                  text-anchor="middle"
+                                  x="61"
+                                  y="61"
+                                >
+                                  <tspan
+                                    dy="0.355em"
+                                    x="61"
+                                  >
+                                    0.0 %
+                                  </tspan>
+                                </text>
+                              </g>
+                            </svg>
                           </div>
                         </div>
                       </div>
@@ -193,40 +265,79 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                         </div>
                         <p
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom makeStyles-legend css-9vf8gf-MuiTypography-root"
-                        />
+                        >
+                          4 / 8 Requested
+                        </p>
                       </div>
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          aria-busy="true"
+                          aria-busy="false"
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
                           
                           <div
-                            class="makeStyles-loaderContainer MuiBox-root css-11ra0t9"
+                            class="recharts-wrapper makeStyles-chart"
+                            style="position: relative; cursor: default; width: 112px; height: 112px;"
                           >
-                            <span
-                              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-wdedfu-MuiCircularProgress-root"
-                              role="progressbar"
-                              style="width: 40px; height: 40px;"
-                              title="Loading data for "
+                            <svg
+                              class="recharts-surface"
+                              cx="70"
+                              cy="70"
+                              height="112"
+                              version="1.1"
+                              viewBox="0 0 112 112"
+                              width="112"
                             >
-                              <svg
-                                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
-                                viewBox="22 22 44 44"
+                              <title />
+                              <desc />
+                              <defs>
+                                <clippath
+                                  id="recharts5-clip"
+                                >
+                                  <rect
+                                    height="102"
+                                    width="102"
+                                    x="5"
+                                    y="5"
+                                  />
+                                </clippath>
+                              </defs>
+                              <g
+                                class="recharts-layer recharts-pie"
                               >
-                                <circle
-                                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
-                                  cx="44"
-                                  cy="44"
-                                  fill="none"
-                                  r="20.2"
-                                  stroke-width="3.6"
-                                />
-                              </svg>
-                            </span>
+                                <g
+                                  class="recharts-layer"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                  />
+                                </g>
+                                <text
+                                  class="recharts-text recharts-label"
+                                  offset="5"
+                                  style="font-size: 16.8px; fill: #000;"
+                                  text-anchor="middle"
+                                  x="61"
+                                  y="61"
+                                >
+                                  <tspan
+                                    dy="0.355em"
+                                    x="61"
+                                  >
+                                    50.0 %
+                                  </tspan>
+                                </text>
+                              </g>
+                            </svg>
                           </div>
                         </div>
                       </div>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.stories.storyshot
@@ -69,7 +69,7 @@ exports[`Storyshots Charts/PercentageCircle Percent 50 1`] = `
         <desc />
         <defs>
           <clippath
-            id="recharts7-clip"
+            id="recharts13-clip"
           >
             <rect
               height="150"
@@ -151,7 +151,7 @@ exports[`Storyshots Charts/PercentageCircle Percent 100 1`] = `
         <desc />
         <defs>
           <clippath
-            id="recharts5-clip"
+            id="recharts11-clip"
           >
             <rect
               height="150"

--- a/frontend/src/components/common/TileChart/__snapshots__/TileChart.stories.storyshot
+++ b/frontend/src/components/common/TileChart/__snapshots__/TileChart.stories.storyshot
@@ -53,7 +53,7 @@ exports[`Storyshots Charts/TileChart With Progress 1`] = `
               <desc />
               <defs>
                 <clippath
-                  id="recharts9-clip"
+                  id="recharts15-clip"
                 >
                   <rect
                     height="102"

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -2,6 +2,7 @@ import Grid from '@mui/material/Grid';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import { useCluster } from '../../lib/k8s';
 import { ApiError } from '../../lib/k8s/apiProxy';
 import { KubeObject, Workload } from '../../lib/k8s/cluster';
 import CronJob from '../../lib/k8s/cronJob';
@@ -26,6 +27,11 @@ export default function Overview() {
   const location = useLocation();
   const filterFunc = useFilterFunc(['.jsonData.kind']);
   const { t } = useTranslation('glossary');
+  const cluster = useCluster();
+
+  React.useEffect(() => {
+    setWorkloadsData({});
+  }, [cluster]);
 
   function setWorkloads(newWorkloads: WorkloadDict) {
     setWorkloadsData(workloads => ({

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -4,7 +4,7 @@ import React from 'react';
 import helpers from '../../helpers';
 import { createRouteURL } from '../router';
 import { getCluster, timeAgo, useErrorState } from '../util';
-import { useConnectApi } from '.';
+import { useCluster, useConnectApi } from '.';
 import { ApiError, apiFactory, apiFactoryWithNamespace, post, QueryParameters } from './apiProxy';
 import CronJob from './cronJob';
 import DaemonSet from './daemonSet';
@@ -527,6 +527,13 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
     ): [U[] | null, ApiError | null, (items: U[]) => void, (err: ApiError | null) => void] {
       const [objList, setObjList] = React.useState<U[] | null>(null);
       const [error, setError] = useErrorState(setObjList);
+      const cluster = useCluster();
+
+      // Reset the list and error when the cluster changes.
+      React.useEffect(() => {
+        setObjList(null);
+        setError(null);
+      }, [cluster]);
 
       function setList(items: U[] | null) {
         setObjList(items);


### PR DESCRIPTION
Headlamp has a convention where lists of items are set as null which means we are still fetching the objects, and a spinner should be shown instead of an empty or filled list.
However, if we seamlessly replace the cluster for which the list of items are being shown, then the list will hold the old items until new ones are prepared. So there's no perception for the user that there's a loading state.

This PR fixes this for the cluster and workloads overview. The first is fixed by resetting the items list in the useList hook, and using this hook in the cluster overview (instead of useApiList). The workloads overview is a bit more elaborate and replacing useApiList with useList is more complicated, so in this case we reset the object holding the workloads when the cluster changes (directly in the overvierw component).

How to test:
-[ ] Go to the cluster overview, then switch to a different cluster (it will show the login and redirect to the cluster view), choose the previous cluster again: this time the login screen should no longer be shown and you'll see the spinners show up for the charts and table (without this PR, it'll not show spinners, the data is just changed)

cc/ @lijianzhi01 