### PR TITLE
github: Add a signing option to the app-artifacts-mac workflow

### DIFF
--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -7,6 +7,10 @@ on:
         description: 'Headlamp ref/branch/tag'
         required: true
         default: 'main'
+      signBinaries:
+        description: Notarize app
+        default: false
+        type: boolean
 jobs:
   build-mac:
     runs-on: macos-latest
@@ -23,7 +27,24 @@ jobs:
         go-version: '1.20.*'
     - name: Dependencies
       run: brew install make
-    - name: App Mac
+    - name: Build Backend and Frontend
+      run: |
+        make
+    - name: Add MacOS certs
+      run: cd ./app/mac/scripts/ && sh ./setup-certificate.sh
+      env:
+        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+    - name: Build Notarized App Mac
+      if: ${{ inputs.signBinaries }}
+      run: |
+        make app-mac
+      env:
+        APPLEID: ${{ secrets.APPLEID }}
+        APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+        APPLETEAMID: ${{ secrets.APPLETEAMID }}
+    - name: Build App Mac
+      if: ${{ ! inputs.signBinaries }}
       run: |
         make app-mac
     - name: Upload artifact

--- a/app/mac/scripts/notarize.js
+++ b/app/mac/scripts/notarize.js
@@ -3,7 +3,7 @@ const { notarize } = require('@electron/notarize');
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
-  if (electronPlatformName !== 'darwin' || process.env.CI === 'true') {
+  if (electronPlatformName !== 'darwin' || !process.env.APPLEID) {
     return;
   }
 

--- a/app/mac/scripts/setup-certificate.sh
+++ b/app/mac/scripts/setup-certificate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# This script was taken from https://shipshape.io/blog/signing-electron-apps-with-github-actions/
+# and sets up the certificate for signing Headlamp on macOS in GitHub Actions.
+
+KEY_CHAIN=build.keychain
+CERTIFICATE_P12=certificate.p12
+
+# Recreate the certificate from the secure environment variable
+echo $APPLE_CERTIFICATE | base64 --decode > $CERTIFICATE_P12
+
+#create a keychain
+security create-keychain -p actions $KEY_CHAIN
+
+# Make the keychain the default so identities are found
+security default-keychain -s $KEY_CHAIN
+
+# Unlock the keychain
+security unlock-keychain -p actions $KEY_CHAIN
+
+security import $CERTIFICATE_P12 -k $KEY_CHAIN -P $APPLE_CERTIFICATE_PASSWORD -T /usr/bin/codesign;
+
+security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
+
+# remove certs
+rm -fr *.p12


### PR DESCRIPTION
This commit allows the mentioned workflow to sign the builds if the user chooses to.