### PR TITLE
Add e2e tests

### DIFF
--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -1,18 +1,8 @@
 import { test, expect } from "@playwright/test";
+import helpers from "./helpers.spec";
 
 test("headlamp is there and so is minikube", async ({ page }) => {
-  await page.goto("/");
-
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Token/);
-
-  // Expects the URL to contain c/main/token
-  await expect(page).toHaveURL(/.*token/);
-
-  const token = process.env.HEADLAMP_TOKEN || '';
-  expect(token).not.toBe('');
-  await page.locator("#token").fill(token);
-  await page.locator("#token").press("Enter");
+  await helpers.authenticate(page);
 
   await expect(page).toHaveURL(/.*main/);
 });
@@ -25,4 +15,54 @@ test('GET /plugins/list returns plugins list', async ({ page }) => {
 
   expect(json.length).toBeGreaterThan(0);
   expect(json.some(str => str.includes('plugins/app-menus'))).toBeTruthy();
+});
+
+test('main page should have Network tab', async ({ page }) => {
+  await helpers.authenticate(page);
+
+  const networkTab = page.locator('span:has-text("Network")').first();
+  expect(await networkTab.textContent()).toBe('Network');
+});
+
+
+test('service page should have headlamp service', async ({ page }) => {
+  await helpers.authenticate(page);
+
+  await helpers.servicesPage(page);
+
+  const pageContent = await page.content();
+  expect(pageContent).toContain('headlamp');
+});
+
+test('headlamp service page should contain port', async ({ page }) => {
+  await helpers.authenticate(page);
+
+  await helpers.servicesPage(page);
+
+  // Click on the "headlamp" link
+  await page.click('a:has-text("headlamp")');
+
+  await page.waitForLoadState('load');
+
+  await page.waitForSelector('h1:has-text("Service")');
+
+  const pageContent = await page.content();
+  expect(pageContent).toContain('TCP');
+});
+
+test('main page should have Security tab', async ({ page }) => {
+  await helpers.authenticate(page);
+
+  const networkTab = page.locator('span:has-text("Security")').first();
+  expect(await networkTab.textContent()).toBe('Security');
+});
+
+test('Service account tab should have headlamp-admin', async ({ page }) => {
+  await helpers.authenticate(page);
+
+  await helpers.serviceAccountPage(page)
+
+  // Check if there is text "headlamp-admin" on the page
+  const pageContent = await page.content();
+  expect(pageContent).toContain('headlamp-admin');
 });

--- a/e2e-tests/tests/helpers.spec.ts
+++ b/e2e-tests/tests/helpers.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from "@playwright/test";
+
+const authenticate = async (page) => {
+  await page.goto("/");
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Token/);
+
+  // Expects the URL to contain c/main/token
+  await expect(page).toHaveURL(/.*token/);
+
+  const token = process.env.HEADLAMP_TOKEN || '';
+  expect(token).not.toBe('');
+
+  // Fill in the token
+  await page.locator("#token").fill(token);
+
+  // Click on the "Authenticate" button
+  await page.click('button:has-text("Authenticate")');
+  await page.waitForNavigation();
+};
+
+const servicesPage = async (page) => {
+  // Click on the "Network" button
+  await page.click('span:has-text("Network")');
+
+  // Wait for the page to load
+  await page.waitForLoadState('load');
+
+  // Wait for the Services tab to load
+  await page.waitForSelector('span:has-text("Services")');
+
+  // Click on the "Services" section
+  await page.click('span:has-text("Services")');
+
+  // Wait for the page to load
+  await page.waitForLoadState('load');
+};
+
+const serviceAccountPage = async (page) => {
+  // Click on the "Security" button
+  await page.click('span:has-text("Security")');
+
+  // Wait for the page to load
+  await page.waitForLoadState('load');
+
+  // Wait for the Service Accounts tab to load
+  await page.waitForSelector('span:has-text("Service Accounts")');
+
+  // Click on the "Service Accounts" section
+  await page.click('span:has-text("Service Accounts")');
+
+  // Wait for the page to load
+  await page.waitForLoadState('load');
+};
+
+
+const exportFunctions = {
+  authenticate,
+  servicesPage,
+  serviceAccountPage
+};
+
+export default exportFunctions;


### PR DESCRIPTION
Streamline setup for e2e tests. We do not need to authenticate repetedly now. Added helpers for it