### PR TITLE
Improve CR permissions and class generation

### DIFF
--- a/frontend/src/components/crd/CustomResourceDetails.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { ResourceClasses } from '../../lib/k8s';
 import { ApiError } from '../../lib/k8s/apiProxy';
-import CustomResourceDefinition, { KubeCRD, makeCustomResourceClass } from '../../lib/k8s/crd';
+import CustomResourceDefinition, { KubeCRD } from '../../lib/k8s/crd';
 import { localeDate } from '../../lib/util';
 import { HoverInfoLabel, Link, NameValueTableRow, ObjectEventList, SectionBox } from '../common';
 import Empty from '../common/EmptyContent';
@@ -114,12 +114,10 @@ function CustomResourceDetailsRenderer(props: CustomResourceDetailsRendererProps
 
   const { t } = useTranslation('glossary');
 
-  let CRClass: ReturnType<typeof makeCustomResourceClass> | null = null;
+  const CRClass = React.useMemo(() => {
+    return crd.makeCRClass();
+  }, [crd]);
 
-  const versions: [string, string, string][] = (crd.jsonData as KubeCRD).spec.versions.map(
-    versionInfo => [crd.spec.group, versionInfo.name, crd.spec.names.plural]
-  );
-  CRClass = makeCustomResourceClass(versions, !!namespace);
   CRClass.useApiGet(setItem, crName, namespace, setError);
 
   const apiVersion = item?.jsonData.apiVersion?.split('/')[1] || '';

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { KubeObject } from '../../lib/k8s/cluster';
-import CRD, { KubeCRD, makeCustomResourceClass } from '../../lib/k8s/crd';
+import CRD, { KubeCRD } from '../../lib/k8s/crd';
 import { localeDate } from '../../lib/util';
 import { Link, Loader, PageGrid, SectionHeader, SimpleTableGetterColumn } from '../common';
 import BackLink from '../common/BackLink';
@@ -118,8 +118,8 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
   }, [crd]);
 
   const CRClass = React.useMemo(() => {
-    return makeCustomResourceClass([apiGroup], crd.metadata.namespace);
-  }, [apiGroup, crd.metadata.namespace]);
+    return crd.makeCRClass();
+  }, [crd]);
 
   if (!CRClass) {
     return <Empty>{t('translation|No custom resources found')}</Empty>;


### PR DESCRIPTION
This PR simplifies the use of CR classes by adding a new method for generating them out of CRD objects, and also fixes the permissions issues reported in #1552.

fixes #1552 

@Denis220795 , thanks again for reporting another important issue with a great insight that made this fix easier to do.
Can you try this branch and check if the issue if fixed for you?