### PR TITLE
Use kubeconfig namespace

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -776,7 +776,8 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			Server:   context.Cluster.Server,
 			AuthType: context.AuthType(),
 			Metadata: map[string]interface{}{
-				"source": context.SourceStr(),
+				"source":    context.SourceStr(),
+				"namespace": context.KubeContext.Namespace,
 			},
 		})
 	}

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -22,7 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const staticTestPath = "headlamp_testdata/static_files/"
+const (
+	staticTestPath = "headlamp_testdata/static_files/"
+	minikubeName   = "minikube"
+)
 
 // Is supposed to return the index.html if there is no static file.
 func TestSpaHandlerMissing(t *testing.T) {
@@ -318,8 +321,31 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	clusters := c.getClusters()
+
 	assert.Equal(t, http.StatusCreated, r.Code)
-	assert.Equal(t, 2, len(c.getClusters()))
+	assert.Equal(t, 2, len(clusters))
+
+	var contextWithoutNamespace *Cluster
+
+	var minikubeCluster *Cluster
+
+	for i, cluster := range clusters {
+		if cluster.Name == minikubeName {
+			// Using the slice addressing here to avoid the
+			// implicit memory aliasing in the loop.
+			minikubeCluster = &clusters[i]
+		} else if cluster.Name == "docker-desktop" {
+			contextWithoutNamespace = &clusters[i]
+		}
+	}
+
+	assert.NotNil(t, contextWithoutNamespace)
+	assert.Equal(t, "", contextWithoutNamespace.Metadata["namespace"])
+
+	assert.NotNil(t, minikubeCluster)
+	assert.Equal(t, minikubeName, minikubeCluster.Name)
+	assert.Equal(t, "default", minikubeCluster.Metadata["namespace"])
 }
 
 //nolint:funlen
@@ -443,8 +469,8 @@ func TestDrainAndCordonNode(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		drainNodePayload.Cluster = "minikube"
-		drainNodePayload.NodeName = "minikube"
+		drainNodePayload.Cluster = minikubeName
+		drainNodePayload.NodeName = minikubeName
 
 		rr, err := getResponse(tc.handler, "POST", "/drain-node", drainNodePayload)
 		if err != nil {

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -87,6 +87,7 @@ func TestContext(t *testing.T) {
 
 	require.Equal(t, "minikube", testContext.Name)
 	require.NotNil(t, testContext.ClientConfig())
+	require.Equal(t, "default", testContext.KubeContext.Namespace)
 
 	restConf, err := testContext.RESTConfig()
 	require.NoError(t, err)

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -85,9 +85,11 @@ func TestStartPortForward(t *testing.T) {
 	req := &http.Request{}
 	resp := httptest.NewRecorder()
 
+	const minikubeName = "minikube"
+
 	// create request
 	reqPayload := map[string]interface{}{
-		"cluster":    "minikube",
+		"cluster":    minikubeName,
 		"pod":        podName,
 		"namespace":  "headlamp",
 		"targetPort": targetPort,
@@ -144,7 +146,7 @@ func TestStartPortForward(t *testing.T) {
 
 	// create stop request
 	reqPayload = map[string]interface{}{
-		"cluster":      "minikube",
+		"cluster":      minikubeName,
 		"id":           pfRespPayload["id"],
 		"stopOrDelete": true,
 	}
@@ -228,7 +230,7 @@ func TestStartPortForward(t *testing.T) {
 
 	// create delete request
 	reqPayload = map[string]interface{}{
-		"cluster":      "minikube",
+		"cluster":      minikubeName,
 		"id":           pfRespPayload["id"],
 		"stopOrDelete": false,
 	}


### PR DESCRIPTION
User are sometimes interested in using the namespace that's set up in their kubeconfig, associated with the context/cluster they're using in Headlamp.
These changes accomplish that.

How to test:
- [ ] Set up a namespace in a context in the kubeconfig, then go to that cluster's settings in Headlamp: the placeholder default namespace should be the same as set in the kubeconfig
- [ ] Apply some resource without specifying the namespace: the default namespace where it's applied should automatically be the one set in the kubeconfig