### PR TITLE
Makefile: Dockerfile: Add support for custom IMAGE_BASE and Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,18 @@ plugins-test:
 	cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js
 	cd plugins/headlamp-plugin && ./test-plugins-examples.sh
 
+# IMAGE_BASE can be used to specify a base final image.
+#   IMAGE_BASE=debian:latest make image
 image:
+	@if [ -n "${IMAGE_BASE}" ]; then \
+		BUILD_ARG="--build-arg IMAGE_BASE=${IMAGE_BASE}"; \
+	else \
+		BUILD_ARG=""; \
+	fi; \
 	$(DOCKER_CMD) buildx build \
 	--pull \
 	--platform=$(DOCKER_PLATFORM) \
+	$$BUILD_ARG \
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile \
 	.

--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -126,6 +126,22 @@ options can be appended to the main command as arguments.
 make image
 ```
 
+### Custom container base images
+
+The Dockerfile takes a build argument for the base image used. You can specify the 
+base image used using the IMAGE_BASE environment variable with make.
+
+```bash
+IMAGE_BASE=debian:latest make image
+```
+
+If no IMAGE_BASE is specified, then a default image is used (see Dockerfile for exact default image used).
+
+This is useful if there are requirements on what base images can be used in an environment.
+
+So far Debian variants (including Ubuntu), and Alpine Linux are supported. 
+If you have other requirements, please get in touch.
+
 ### Running the container image
 
 With docker you can run the Headlamp image(`ghcr.io/headlamp-k8s/headlamp:latest`).


### PR DESCRIPTION
Support for apt-get using Debian-like systems.

- Fixes https://github.com/headlamp-k8s/headlamp/issues/1072
- Adds a section in the documentation about how to specify different base images.

## How to test

1) Try a base image with a Debian base image.
```bash
IMAGE_BASE=debian:latest make image
```

2) See that the default used is alpine.

```bash
make image
```
