### PR TITLE
Add e2e tests

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -12,6 +12,7 @@ on:
     - Makefile
     - '.github/**'
     - Dockerfile
+    - 'e2e-tests/**'
 
 jobs:
   build:
@@ -38,7 +39,7 @@ jobs:
     - name: Deploy to cluster
       run:
         kubectl apply -f e2e-tests/kubernetes-headlamp-ci.yaml
-    - name: Test service URLs
+    - name: Run e2e tests
       run: |
         echo "------------------sleeping 3...------------------"
         sleep 3
@@ -55,6 +56,7 @@ jobs:
         curl -L $SERVICE_URL | grep -q "Headlamp: Kubernetes Web UI"        
         echo "------------------Getting HEADLAMP_TOKEN------------------"
         kubectl create serviceaccount headlamp-admin --namespace kube-system
+        kubectl create clusterrolebinding headlamp-admin --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
         export HEADLAMP_TOKEN=$(kubectl create token headlamp-admin --duration 24h -n kube-system)
         echo "------------------Running playwright e2e tests------------------"
         cd e2e-tests

--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -1,28 +1,75 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+import { ServicesPage } from './servicesPage';
+import { SecurityPage } from './securityPage';
 
-test("headlamp is there and so is minikube", async ({ page }) => {
-  await page.goto("/");
-
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Token/);
-
-  // Expects the URL to contain c/main/token
-  await expect(page).toHaveURL(/.*token/);
-
-  const token = process.env.HEADLAMP_TOKEN || '';
-  expect(token).not.toBe('');
-  await page.locator("#token").fill(token);
-  await page.locator("#token").press("Enter");
-
-  await expect(page).toHaveURL(/.*main/);
-});
-
+// --- Plugins tests start --- //
 test('GET /plugins/list returns plugins list', async ({ page }) => {
-  const response = await page.goto('/plugins');
+  const response: any = await page.goto('/plugins');
   expect(response).toBeTruthy();
 
   const json = await response.json();
-
   expect(json.length).toBeGreaterThan(0);
   expect(json.some(str => str.includes('plugins/app-menus'))).toBeTruthy();
 });
+// --- Plugin tests end --- //
+
+// --- Headlamp tests start --- //
+test('headlamp is there and so is minikube', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+
+  await headlampPage.authenticate();
+  await headlampPage.hasURLContaining(/.*main/);
+});
+
+test('main page should have Network tab', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+
+  await headlampPage.authenticate();
+  await headlampPage.hasNetworkTab();
+});
+
+test('service page should have headlamp service', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  const servicesPage = new ServicesPage(page);
+
+  await headlampPage.authenticate();
+  await servicesPage.navigateToServices();
+  await servicesPage.clickOnServicesSection();
+
+  // Check if there is text "headlamp" on the page
+  await headlampPage.checkPageContent('headlamp');
+});
+
+test('headlamp service page should contain port', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  const servicesPage = new ServicesPage(page);
+
+  await headlampPage.authenticate();
+  await servicesPage.navigateToServices();
+  await servicesPage.clickOnServicesSection();
+  await servicesPage.goToParticularService("headlamp");
+
+  // Check if there is text "TCP" on the page
+  await headlampPage.checkPageContent('TCP');
+});
+
+test('main page should have Security tab', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+
+  await headlampPage.authenticate();
+  await headlampPage.hasSecurityTab();
+});
+
+test('Service account tab should have headlamp-admin', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  const securityPage = new SecurityPage(page);
+
+  await headlampPage.authenticate();
+  await securityPage.navigateToSecurity();
+  await securityPage.clickOnServiceAccountsSection();
+
+  // Check if there is text "headlamp-admin" on the page
+  await headlampPage.checkPageContent('headlamp-admin');
+});
+// // --- Headlamp tests end --- //

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -1,0 +1,54 @@
+import { Page, expect } from '@playwright/test';
+
+export class HeadlampPage {
+  constructor(private page: Page) { }
+
+  async authenticate() {
+    await this.page.goto('/');
+
+    // Expect a title "to contain" a substring.
+    this.hasTitleContaining(/Token/);
+
+    // Expects the URL to contain c/main/token
+    this.hasURLContaining(/.*token/);
+
+    const token = process.env.HEADLAMP_TOKEN || '';
+    this.hasToken(token);
+
+    // Fill in the token
+    await this.page.locator("#token").fill(token);
+
+    // Click on the "Authenticate" button and wait for navigation
+    await Promise.all([
+      this.page.waitForNavigation(),
+      this.page.click('button:has-text("Authenticate")'),
+    ]);
+  }
+
+  async hasURLContaining(pattern: RegExp) {
+    await expect(this.page).toHaveURL(pattern);
+  }
+
+  async hasTitleContaining(pattern: RegExp) {
+    await expect(this.page).toHaveTitle(pattern);
+  }
+
+  async hasToken(token: string) {
+    expect(token).not.toBe('');
+  }
+
+  async hasNetworkTab() {
+    const networkTab = this.page.locator('span:has-text("Network")').first();
+    expect(await networkTab.textContent()).toBe('Network');
+  }
+
+  async hasSecurityTab() {
+    const networkTab = this.page.locator('span:has-text("Security")').first();
+    expect(await networkTab.textContent()).toBe('Security');
+  }
+
+  async checkPageContent(text: string) {
+    const pageContent = await this.page.content();
+    expect(pageContent).toContain(text);
+  }
+}

--- a/e2e-tests/tests/securityPage.ts
+++ b/e2e-tests/tests/securityPage.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export class SecurityPage {
+  constructor(private page: Page) { }
+
+  async navigateToSecurity() {
+    // Click on the "Security" button
+    await this.page.click('span:has-text("Security")');
+    // Wait for the page to load
+    await this.page.waitForLoadState('load');
+  }
+
+  async clickOnServiceAccountsSection() {
+    // Wait for the Service Accounts tab to load
+    await this.page.waitForSelector('span:has-text("Service Accounts")');
+    // Click on the "Service Accounts" section
+    await this.page.click('span:has-text("Service Accounts")');
+    // Wait for the page to load
+    await this.page.waitForLoadState('load');
+  }
+}

--- a/e2e-tests/tests/servicesPage.ts
+++ b/e2e-tests/tests/servicesPage.ts
@@ -1,0 +1,30 @@
+import { Page } from '@playwright/test';
+
+export class ServicesPage {
+  constructor(private page: Page) { }
+
+  async navigateToServices() {
+    // Click on the "Network" button
+    await this.page.click('span:has-text("Network")');
+    // Wait for the page to load
+    await this.page.waitForLoadState('load');
+  }
+
+  async clickOnServicesSection() {
+    // Wait for the Services tab to load
+    await this.page.waitForSelector('span:has-text("Services")');
+    // Click on the "Services" section
+    await this.page.click('span:has-text("Services")');
+    // Wait for the page to load
+    await this.page.waitForLoadState('load');
+  } 
+
+  async goToParticularService(serviceName: string) {
+    // Click on the particular service
+    await this.page.click(`a:has-text("${serviceName}")`);
+    // Wait for the page to load
+    await this.page.waitForLoadState('load');
+    // Wait for section to load
+    await this.page.waitForSelector('h1:has-text("Service")');
+  }
+}


### PR DESCRIPTION
Streamline setup for e2e tests. We do not need to authenticate repetedly now. Added helpers for it.

CI did not ran e2e tests when changes were made to e2e folder, so updated it.