### PR TITLE
Fix Dimming Issue in Release Notes on Headlamp App Mode

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -1,6 +1,6 @@
 import 'github-markdown-css';
 import { Icon } from '@iconify/react';
-import { Backdrop, Box, Button, Link, Modal, Paper, Typography } from '@mui/material';
+import { Box, Button, Link, Modal, Paper, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -32,7 +32,7 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
   };
 
   return (
-    <Modal open={showReleaseNotes} BackdropComponent={Backdrop} style={modalStyle}>
+    <Modal open={showReleaseNotes} style={modalStyle}>
       <Paper style={releaseNotesStyle} variant="outlined">
         <Box display="flex" justifyContent="center">
           <Box flexGrow={2}>


### PR DESCRIPTION
# Fix Dimming Issue in Release Notes on Headlamp App Mode

Fixes issue #1584 

## Description
This PR addresses the issue where the release notes were dimmed across the entire screen in Headlamp's app mode. The root cause was identified as a deprecated attribute "BackdropComponent", which has now been removed to resolve the dimming problem.

![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/d3622c5c-4e8a-4713-8e1c-c4e4431e1788)


## Changes
- [x] Removed the deprecated "BackdropComponent" attribute from the release notes modal implementation.

## Verification
- Verified that the release notes are no longer dimmed on the entire screen in app mode.
- Conducted tests in different app modes to ensure the removal of the attribute does not affect other functionalities.

## Screenshots

![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/bc64c86a-12f7-408b-8d0a-e93123367470)
