### PR TITLE
Ship official plugins in image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ docker-ext:
 	-t $(DOCKER_EXT_REPO)/$(DOCKER_IMAGE_NAME)-docker-extension:${LATEST_TAG} \
 	-t $(DOCKER_EXT_REPO)/$(DOCKER_IMAGE_NAME)-docker-extension:latest -f \
 	./docker-extension/Dockerfile \
-	./docker-extension 
+	./docker-extension
 
 .PHONY: docs
 docs:

--- a/container/build-manifest.json
+++ b/container/build-manifest.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    {
+      "name": "prometheus",
+      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/v0.1.4/prometheus-0.0.1.tgz"
+    }
+  ]
+}

--- a/container/fetch-plugins.sh
+++ b/container/fetch-plugins.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -e
+
+DESTDIR=$1
+
+if [ -z "$DESTDIR" ]; then
+  echo "Usage: $0 <destdir>"
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+
+# Fetch plugins
+echo "Fetching plugins (wdir: $TMPDIR)..."
+
+manifest=$(cat ./build-manifest.json)
+
+plugins=$(echo $manifest | jq -r '.plugins[] | .name')
+for plugin in $plugins; do
+  echo "Fetching $plugin..."
+
+  url=$(echo $manifest | jq -r ".plugins[] | select(.name == \"$plugin\") | .archive")
+  curl -sL $url --output-dir $TMPDIR --output $plugin.tgz
+
+  archivedir=$TMPDIR/$plugin
+  mkdir -p $archivedir
+  tar -xzf $TMPDIR/$plugin.tgz -C $archivedir --wildcards '*/dist/main.js' '*/package.json'
+
+  ls -lr $archivedir
+
+  dir=$DESTDIR/$plugin
+  mkdir -p $dir
+  cp $archivedir/package/dist/main.js $archivedir/package/package.json $dir
+
+  echo " done"
+done
+
+rm -rf $TMPDIR


### PR DESCRIPTION
We want to ship plugins with the official container image as well, but these will be only plugins that are safe in a non-desktop environment, so for now this means the prometheus plugin.

## How to test

1. Build and run the image from this branch, make sure you can access a cluster, then go to a workload, like a deployment: verify that the prometheus charts are enabled in a workload's details view