### PR TITLE
frontend: plugins: mui fixes

### DIFF
--- a/docs/development/api/modules/plugin_registry.md
+++ b/docs/development/api/modules/plugin_registry.md
@@ -160,7 +160,7 @@ Add a component into the app bar (at the top of the app).
 
 ```tsx
 import { registerAppBarAction } from '@kinvolk/headlamp-plugin/lib';
-import { Button } from '@material-ui/core';
+import { Button } from '@mui/material';
 
 function ConsoleLogger() {
   return (

--- a/docs/development/plugins/how-to.md
+++ b/docs/development/plugins/how-to.md
@@ -32,8 +32,8 @@ displays that information in the top bar (i.e. registers an "app bar action").
 
 ```tsx
 import { K8s, registerAppBarAction } from '@kinvolk/headlamp-plugin/lib';
-import { Typography } from '@material-ui/core';
-import { makeStyles } from '@material-ui/styles';
+import { Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyle = makeStyles(() => ({
   pods: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -78,6 +78,7 @@
         "react-jwt": "^1.1.6",
         "react-markdown": "^8.0.0",
         "react-redux": "^7.2.5",
+        "react-router": "^5.3.0",
         "react-router-dom": "^5.3.0",
         "react-scripts": "5.0.0",
         "react-window": "^1.8.7",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,7 +64,7 @@
         "lodash": "^4.17.21",
         "monaco-editor": "^0.25.2",
         "monaco-editor-webpack-plugin": "^4.2.0",
-        "notistack": "^1.0.10",
+        "notistack": "^2.0.8",
         "openapi-types": "^9.3.0",
         "patch-package": "^6.4.7",
         "postcss": "^8.4.5",
@@ -2737,7 +2737,8 @@
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "dev": true
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -3678,145 +3679,6 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@material-ui/core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.5",
-        "@material-ui/system": "^4.12.2",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/styles": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/system": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.3",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/utils": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@mdx-js/loader": {
@@ -19047,7 +18909,8 @@
     "node_modules/csstype": {
       "version": "2.6.20",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+      "dev": true
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -28916,9 +28779,9 @@
       }
     },
     "node_modules/notistack": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.10.tgz",
-      "integrity": "sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
       "dependencies": {
         "clsx": "^1.1.0",
         "hoist-non-react-statics": "^3.3.0"
@@ -28928,9 +28791,19 @@
         "url": "https://opencollective.com/notistack"
       },
       "peerDependencies": {
-        "@material-ui/core": "^4.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
     "node_modules/now-and-later": {
@@ -30308,12 +30181,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==",
-      "peer": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -41363,7 +41230,8 @@
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "dev": true
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -42134,80 +42002,6 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
-      }
-    },
-    "@material-ui/core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.5",
-        "@material-ui/system": "^4.12.2",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      }
-    },
-    "@material-ui/styles": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@material-ui/system": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.3",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@material-ui/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "peer": true,
-      "requires": {}
-    },
-    "@material-ui/utils": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@mdx-js/loader": {
@@ -53861,7 +53655,8 @@
     "csstype": {
       "version": "2.6.20",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
@@ -61400,9 +61195,9 @@
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
     "notistack": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.10.tgz",
-      "integrity": "sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
       "requires": {
         "clsx": "^1.1.0",
         "hoist-non-react-statics": "^3.3.0"
@@ -62473,12 +62268,6 @@
       "requires": {
         "@babel/runtime": "^7.17.8"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==",
-      "peer": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "react-jwt": "^1.1.6",
     "react-markdown": "^8.0.0",
     "react-redux": "^7.2.5",
+    "react-router": "^5.3.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "5.0.0",
     "react-window": "^1.8.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "lodash": "^4.17.21",
     "monaco-editor": "^0.25.2",
     "monaco-editor-webpack-plugin": "^4.2.0",
-    "notistack": "^1.0.10",
+    "notistack": "^2.0.8",
     "openapi-types": "^9.3.0",
     "patch-package": "^6.4.7",
     "postcss": "^8.4.5",

--- a/frontend/src/components/common/__snapshots__/ActionsNotifier.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ActionsNotifier.stories.storyshot
@@ -5,35 +5,35 @@ exports[`Storyshots ActionsNotifier None 1`] = `<div />`;
 exports[`Storyshots ActionsNotifier Some 1`] = `
 <div>
   <div
-    class="makeStyles-bottom-4 makeStyles-left-5 makeStyles-root-1"
+    class="SnackbarContainer-bottom SnackbarContainer-left SnackbarContainer-root css-uwcd5u"
   >
     <div
-      class="MuiCollapse-root MuiCollapse-entered"
+      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
       style="min-height: 0px;"
     >
       <div
-        class="MuiCollapse-wrapper"
+        class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
       >
         <div
-          class="MuiCollapse-wrapperInner"
+          class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
         >
           <div
-            class="SnackbarItem-root-8 SnackbarItem-wrappedRoot-23 SnackbarItem-anchorOriginBottomLeft-14"
+            class="SnackbarItem-wrappedRoot css-1erfie"
           >
             <div
               aria-describedby="notistack-snackbar"
-              class="ForwardRef-root-24 SnackbarItem-contentRoot-15"
+              class="SnackbarContent-root SnackbarItem-contentRoot css-hped4j"
               role="alert"
               style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
             >
               <div
-                class="SnackbarItem-message-21"
+                class="SnackbarItem-message"
                 id="notistack-snackbar"
               >
                 Some message
               </div>
               <div
-                class="SnackbarItem-action-22"
+                class="SnackbarItem-action"
               >
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeSmall MuiButton-textSizeSmall css-u3zvl7-MuiButtonBase-root-MuiButton-root"

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -20,7 +20,7 @@ window.pluginLib = {
   // avoid circular dependencies' issues.
   Crd: require('../lib/k8s/crd'),
   CommonComponents: require('../components/common'),
-  MuiCore: require('@mui/material'),
+  MuiMaterial: require('@mui/material'),
   MuiStyles: require('@mui/styles'),
   MuiLab: require('@mui/lab'),
   React: require('react'),
@@ -39,6 +39,9 @@ window.pluginLib = {
   Plugin,
   ...registryToExport,
 };
+
+// backwards compat.
+window.pluginLib.MuiCore = window.pluginLib.MuiMaterial;
 
 // @todo: should window.plugins be private?
 // @todo: Should all the plugin objects be in a single window.Headlamp object?

--- a/plugins/headlamp-plugin/config/.storybook/preview.tsx
+++ b/plugins/headlamp-plugin/config/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import themesConf from '@kinvolk/headlamp-plugin/lib/lib/themes';
-import { ThemeProvider, StylesProvider } from '@material-ui/core/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import StylesProvider from '@mui/styles/StylesProvider';
 
 const darkTheme = themesConf['dark'];
 const lightTheme = themesConf['light'];

--- a/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
+++ b/plugins/headlamp-plugin/config/storyshots/storyshots-test.ts
@@ -1,11 +1,17 @@
 import initStoryshots, { Stories2SnapsConverter } from '@storybook/addon-storyshots';
 import * as rtl from '@testing-library/react';
 import path from 'path';
+import ResizeObserver from 'resize-observer-polyfill';
 // jsdom used by react-scripts test doesn't include TextEncoder/TextDecoder polyfills
 import { TextDecoder, TextEncoder } from 'util';
 global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder;
+
+if (!global.ResizeObserver) {
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+}
 
 /**
  * The storyshot addon has some bug where the path is src/

--- a/plugins/headlamp-plugin/config/webpack.config.js
+++ b/plugins/headlamp-plugin/config/webpack.config.js
@@ -1,5 +1,5 @@
 const externalModules = {
-  '@mui/material': 'pluginLib.MuiCore',
+  '@mui/material': 'pluginLib.MuiMaterial',
   '@monaco-editor/react': 'pluginLib.ReactMonacoEditor',
   'monaco-editor': 'pluginLib.MonacoEditor',
   '@mui/lab': 'pluginLib.MuiLab',
@@ -40,13 +40,13 @@ module.exports = {
   },
   externals: function ({ request }, callback) {
     const pluginLib = externalModules[request];
-    // For cases like: import { Grid } from '@material-ui/core'
+    // For cases like: import { Grid } from '@mui/material'
     if (!!pluginLib) {
       return callback(null, pluginLib);
     }
 
     // For cases like:
-    // import Grid from '@material-ui/core/Grid' -> const Grid = pluginLib.MuiCore["Grid"];
+    // import Grid from '@mui/material/Grid' -> const Grid = pluginLib.MuiMaterial["Grid"];
     for (const importModule of Object.keys(externalModules)) {
       const modulePrefix = importModule + '/';
       if (request.startsWith(modulePrefix)) {

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -102,7 +102,7 @@
         "monaco-editor-webpack-plugin": "^4.2.0",
         "msw": "^0.47.4",
         "msw-storybook-addon": "^1.6.3",
-        "notistack": "^1.0.10",
+        "notistack": "^2.0.8",
         "openapi-types": "^9.3.0",
         "patch-package": "^6.4.7",
         "postcss": "^8.4.5",
@@ -4491,145 +4491,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-    },
-    "node_modules/@material-ui/core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.5",
-        "@material-ui/system": "^4.12.2",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/styles": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/system": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.3",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/utils": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
     },
     "node_modules/@mdx-js/loader": {
       "version": "1.6.22",
@@ -31630,9 +31491,9 @@
       }
     },
     "node_modules/notistack": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.10.tgz",
-      "integrity": "sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
       "dependencies": {
         "clsx": "^1.1.0",
         "hoist-non-react-statics": "^3.3.0"
@@ -31642,9 +31503,19 @@
         "url": "https://opencollective.com/notistack"
       },
       "peerDependencies": {
-        "@material-ui/core": "^4.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
     "node_modules/now-and-later": {
@@ -32949,12 +32820,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==",
-      "peer": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -45581,80 +45446,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-    },
-    "@material-ui/core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.5",
-        "@material-ui/system": "^4.12.2",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      }
-    },
-    "@material-ui/styles": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@material-ui/system": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.3",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@material-ui/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "peer": true,
-      "requires": {}
-    },
-    "@material-ui/utils": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      }
     },
     "@mdx-js/loader": {
       "version": "1.6.22",
@@ -65977,9 +65768,9 @@
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
     "notistack": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.10.tgz",
-      "integrity": "sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
       "requires": {
         "clsx": "^1.1.0",
         "hoist-non-react-statics": "^3.3.0"
@@ -66985,12 +66776,6 @@
       "requires": {
         "@babel/runtime": "^7.17.8"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==",
-      "peer": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -117,6 +117,7 @@
         "react-jwt": "^1.1.6",
         "react-markdown": "^8.0.0",
         "react-redux": "^7.2.5",
+        "react-router": "^5.3.0",
         "react-router-dom": "^5.3.0",
         "react-scripts": "5.0.0",
         "react-window": "^1.8.7",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.8.0-alpha.5",
+      "version": "0.8.0-alpha.13",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.8.0-alpha.5",
+  "version": "0.8.0-alpha.13",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "main": "lib/index.js",
   "types": "./lib/additional.d.ts",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -121,6 +121,7 @@
     "react-jwt": "^1.1.6",
     "react-markdown": "^8.0.0",
     "react-redux": "^7.2.5",
+    "react-router": "^5.3.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "5.0.0",
     "react-window": "^1.8.7",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -106,7 +106,7 @@
     "monaco-editor-webpack-plugin": "^4.2.0",
     "msw": "^0.47.4",
     "msw-storybook-addon": "^1.6.3",
-    "notistack": "^1.0.10",
+    "notistack": "^2.0.8",
     "openapi-types": "^9.3.0",
     "patch-package": "^6.4.7",
     "postcss": "^8.4.5",

--- a/plugins/headlamp-plugin/template/src/headlamp-plugin.d.ts
+++ b/plugins/headlamp-plugin/template/src/headlamp-plugin.d.ts
@@ -4,3 +4,38 @@ declare module '*.svg' {
   const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;
 }
+
+declare module '*.avif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.bmp' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp' {
+  const src: string;
+  export default src;
+}

--- a/plugins/headlamp-plugin/template/src/index.tsx
+++ b/plugins/headlamp-plugin/template/src/index.tsx
@@ -4,6 +4,6 @@ import { registerAppBarAction } from '@kinvolk/headlamp-plugin/lib';
 //   See README.md for links to plugin development documentation.
 // import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 // import { K8s } from '@kinvolk/headlamp-plugin/lib/K8s';
-// import { Typography } from '@material-ui/core';
+// import { Typography } from '@mui/material';
 
 registerAppBarAction(<span>Hello</span>);


### PR DESCRIPTION
I'm finishing off upgrading the plugins/ (app-catalog, and prometheus) and came across some issues.

- plugins: frontend: docs: Update mentions of `@material-ui` to `@mui`
- frontend: Update notistack@2.0.8 which uses mui 5
- frontend: headlamp-plugin: Add direct react-router dependency
- headlamp-plugin: Add image types into config file
- headlamp-plugin: Add ResizeObserver polyfill for tests

See
- app-catalog plugin upgrade PR: https://github.com/headlamp-k8s/plugins/pull/26
- prometheus plugin upgrade PR: https://github.com/headlamp-k8s/plugins/pull/27
