### PR TITLE
chocolatey: Update Headlamp to 0.22.0

### DIFF
--- a/app/windows/chocolatey/headlamp.nuspec
+++ b/app/windows/chocolatey/headlamp.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>headlamp</id>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
     <packageSourceUrl>https://github.com/headlamp-k8s/headlamp/tree/main/app/windows/chocolatey</packageSourceUrl>
     <title>Headlamp</title>
     <authors>Kinvolk</authors>

--- a/app/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/app/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$headlampVersion = '0.21.0'
+$headlampVersion = '0.22.0'
 $url = "https://github.com/headlamp-k8s/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
-$checksum = '841105457d5e877b15da0f2b6830283f0b1a5f52f443d4a349519386a2edb223'
+$checksum = '78a1548a79e2d2b3702b393c5095225c8847eafe853165f8c158dd4538003e14'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
Just for an extra check. I have tested locally and verified it installs the published 0.22.0 version. The new version is already sent to the Chocolatey registry.