### PR TITLE
Remove broken format version from the helm repository

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -106,50 +106,6 @@ entries:
         - title: Terminal
           url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/terminal.png
     apiVersion: v2
-    appVersion: v0.21.0
-    created: "2023-11-08T12:25:45.539060782Z"
-    description: Headlamp is an easy-to-use and extensible Kubernetes web UI.
-    digest: f459665fa6e464cb952a89e2f9f695655da4387cdfaeb9179eee00484467736f
-    home: https://headlamp.dev/
-    icon: https://raw.githubusercontent.com/headlamp-k8s/headlamp/main/docs/headlamp_light.svg
-    keywords:
-    - kubernetes
-    - plugins
-    - kinvolk
-    - headlamp
-    - dashboard
-    - ui
-    - web
-    - monitoring
-    - logging
-    maintainers:
-    - name: kinvolk
-      url: https://kinvolk.io/
-    name: headlamp
-    sources:
-    - https://github.com/headlamp-k8s/headlamp/tree/main/charts/headlamp
-    - https://github.com/headlamp-k8s/headlamp
-    type: application
-    urls:
-    - https://github.com/headlamp-k8s/headlamp/releases/download/headlamp-helm-0.17.0/headlamp-0.17.0.tgz
-    version: 0.17.0
-  - annotations:
-      artifacthub.io/category: monitoring-logging
-      artifacthub.io/license: Apache-2.0
-      artifacthub.io/screenshots: |
-        - title: Cluster Overview
-          url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_overview.png
-        - title: Cluster Chooser
-          url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/cluster_chooser.png
-        - title: Nodes
-          url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/nodes.png
-        - title: Resource edition
-          url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/resource_edition.png
-        - title: Editor Documentation
-          url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/editor_documentation.png
-        - title: Terminal
-          url: https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/screenshots/terminal.png
-    apiVersion: v2
     appVersion: 0.20.1
     created: "2023-10-09T10:52:33.277151796Z"
     description: Headlamp is an easy-to-use and extensible Kubernetes web UI.


### PR DESCRIPTION
By mistake, in version 0.21.0 (Helm version 0.17.0) we pushed the Helm config as having an appVersion of v0.21.0 but this config requires the tag version without the `v`. Since then, ArtifactHub has been giving us alerts that it cannot find the mentioned image.

Since we readily pushed a Helm 0.17.1 version with the right config, I think we should rather just remove the 0.17.0 from the registry to avoid anyone picking it up + fixing the warnings.

Once we merge this, we should remove the Helm 0.17.0 tag/release from the repo.