### PR TITLE
frontend: Add option to download all logs

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -219,6 +219,7 @@ function PodLogViewer(props: PodLogViewerProps) {
                 {i}
               </MenuItem>
             ))}
+            <MenuItem value={-1}>All</MenuItem>
           </Select>
         </FormControl>,
         <LightTooltip

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -120,8 +120,15 @@ class Pod extends makeKubeObject<KubePod>('Pod') {
       showTimestamps = false,
       follow = true,
     } = logsOptions;
+
     let logs: string[] = [];
-    const url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/log?container=${container}&previous=${showPrevious}&tailLines=${tailLines}&timestamps=${showTimestamps}&follow=${follow}`;
+    let url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/log?container=${container}&previous=${showPrevious}&timestamps=${showTimestamps}&follow=${follow}`;
+
+    // Negative tailLines parameter fetches all logs. If it's non negative it fetches
+    // the tailLines number of logs.
+    if (tailLines !== -1) {
+      url += `&tailLines=${tailLines}`;
+    }
 
     function onResults(item: string) {
       if (!item) {


### PR DESCRIPTION
User can now download all logs, there is an option in the dropdown menu of pod's log page.

Fixes: #1481

<img width="1258" alt="Screenshot 2024-01-15 at 9 58 46 AM" src="https://github.com/headlamp-k8s/headlamp/assets/24803604/a863eed8-3458-4172-96eb-3cdda31a02a9">
