### PR TITLE
frontend: Fix fullscreen icon bypassing tests and add missing icon

### DIFF
--- a/frontend/src/components/App/icons.ts
+++ b/frontend/src/components/App/icons.ts
@@ -173,6 +173,9 @@ const mdiIcons = {
     fullscreen: {
       body: '<path fill="currentColor" d="M5 5h5v2H7v3H5V5m9 0h5v5h-2V7h-3V5m3 9h2v5h-5v-2h3v-3m-7 3v2H5v-5h2v3h3Z"/>',
     },
+    'fullscreen-exit': {
+      body: '<path fill="currentColor" d="M14 14h5v2h-3v3h-2zm-9 0h5v5H8v-3H5zm3-9h2v5H5V8h3zm11 3v2h-5V5h2v3z"/>',
+    },
     calendar: {
       body: '<path fill="currentColor" d="M19 19H5V8h14m-3-7v2H8V1H6v2H5c-1.11 0-2 .89-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-1V1m-1 11h-5v5h5v-5Z"/>',
     },

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -117,7 +117,7 @@ export function Dialog(props: DialogProps) {
       <ActionButton
         description={t('Toggle fullscreen')}
         onClick={handleFullScreen}
-        icon={`mdi:${fullScreen ? 'fullscreen-exit' : 'fullscreen'}`}
+        icon={fullScreen ? 'mdi:fullscreen-exit' : 'mdi:fullscreen'}
       />
     );
   }


### PR DESCRIPTION
The logic around setting the icon for the fullscreen toggle in the
mentioned component was done by appending the icon name to the "mdi:"
prefix depending on the state. Therefore, this prevented the icon test
from scanning this file correctly, since it looks for a string that
started by "mdi:".

As a cause for this, the fullscreen-exit icon was not added to the
icon list for offline use, which this patch also adds.

Signed-off-by: Joaquim Rocha <joaquim.rocha@microsoft.com>

fixes #1644 