### PR TITLE
Fix notifications infinite loop

### DIFF
--- a/frontend/src/components/App/Notifications/notificationsSlice.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.ts
@@ -176,6 +176,19 @@ export function loadNotifications(): NotificationIface[] {
   return notifications.map((n: any) => Notification.fromJSON(n).toJSON());
 }
 
+function mergeNotifications(
+  oldNotifications: NotificationIface[],
+  newNotifications: NotificationIface[]
+) {
+  let notifications = _.uniqBy([...newNotifications, ...oldNotifications], 'id');
+  notifications.sort((n1, n2) => new Date(n2.date).getTime() - new Date(n1.date).getTime());
+  // We limit the number of notifications here even though we also do it when storing them
+  // so we can check if the notifications are the same and avoid updating them in that case.
+  notifications = notifications.slice(0, defaultMaxNotificationsStored);
+
+  return notifications;
+}
+
 const notificationsSlice = createSlice({
   name: 'notifications',
   initialState,
@@ -197,11 +210,7 @@ const notificationsSlice = createSlice({
         };
       }
 
-      notifications = _.uniqBy([...notifications, ...state.notifications], 'id');
-      notifications.sort((n1, n2) => new Date(n2.date).getTime() - new Date(n1.date).getTime());
-      // We limit the number of notifications here even though we also do it when storing them
-      // so we can check if the notifications are the same and avoid updating them in that case.
-      notifications = notifications.slice(0, defaultMaxNotificationsStored);
+      notifications = mergeNotifications(state.notifications, notifications);
 
       // Check if the events are the same, if so, don't update the state unless
       // needed. This saves unnecessary re-renders and may also prevent infinite loops.
@@ -222,7 +231,7 @@ const notificationsSlice = createSlice({
         ? action.payload
         : [action.payload];
 
-      const updatedState = state.notifications.map(notification => {
+      let updatedState = state.notifications.map(notification => {
         const updatedNotification = dispatchedNotifications.find(n => n.id === notification.id);
         return updatedNotification
           ? Notification.fromJSON({ ...updatedNotification, seen: true })
@@ -232,7 +241,8 @@ const notificationsSlice = createSlice({
       const newNotifications = dispatchedNotifications.filter(
         n => !updatedState.some(s => s.id === n.id)
       );
-      updatedState.push(...newNotifications);
+
+      updatedState = mergeNotifications(updatedState, newNotifications);
 
       return {
         notifications: storeNotifications(updatedState),

--- a/frontend/src/components/App/Notifications/notificationsSlice.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.ts
@@ -199,6 +199,15 @@ const notificationsSlice = createSlice({
 
       notifications = _.uniqBy([...notifications, ...state.notifications], 'id');
       notifications.sort((n1, n2) => new Date(n2.date).getTime() - new Date(n1.date).getTime());
+      // We limit the number of notifications here even though we also do it when storing them
+      // so we can check if the notifications are the same and avoid updating them in that case.
+      notifications = notifications.slice(0, defaultMaxNotificationsStored);
+
+      // Check if the events are the same, if so, don't update the state unless
+      // needed. This saves unnecessary re-renders and may also prevent infinite loops.
+      if (_.isEqual(notifications, state.notifications)) {
+        return state;
+      }
 
       return {
         notifications: storeNotifications(notifications),


### PR DESCRIPTION
## How to test
 * Get 200 notifications stored in the local storage. Then go to a cluster with warnings and check the dev console logs to see if there are any indication/warnings about infinite loops.
 * Verify that the latest cluster warning events are shown in the notifications
 * Verify that marking notifications as read and deleting them does work

fixes #1664 