### PR TITLE
Fix links to helm chart and values in documentation

### DIFF
--- a/docs/installation/in-cluster/_index.md
+++ b/docs/installation/in-cluster/_index.md
@@ -6,7 +6,7 @@ weight: 10
 A common use-case for any Kubernetes web UI is to deploy it in-cluster and
 set up an ingress server for having it available to users.
 
-The easiest way to install headlamp in your existing cluster is to use our [helm chart](../../../charts/headlamp/).
+The easiest way to install headlamp in your existing cluster is to use our [helm chart](https://github.com/headlamp-k8s/headlamp/blob/main/charts/headlamp).
 
 ```bash
 # first add our custom repo to your local helm repositories
@@ -15,8 +15,8 @@ helm repo add headlamp https://headlamp-k8s.github.io/headlamp/
 # now you should be able to install headlamp via helm
 helm install my-headlamp headlamp/headlamp --namespace kube-system
 ```
-
-As usual it is possible to configure the helm release via the [values file](../../../charts/headlamp/values.yaml) or setting your preferred values directly.
+https://github.com/headlamp-k8s/headlamp/blob/main/charts/headlamp/values.yaml
+As usual it is possible to configure the helm release via the [values file](https://github.com/headlamp-k8s/headlamp/blob/main/charts/headlamp/values.yaml) or setting your preferred values directly.
 
 ```bash
 # install headlamp with your own values.yaml


### PR DESCRIPTION
These documents don't appear to be published to the documentation page, so I replaced the links to GitHub.