### PR TITLE
frontend: Disable auto reconnection of logs

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -1,4 +1,4 @@
-import { Box, DialogContent, Grid, InputBase, Paper } from '@mui/material';
+import { Box, Button, DialogContent, Grid, InputBase, Paper } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
@@ -67,6 +67,15 @@ export interface LogViewerProps extends DialogProps {
   topActions?: JSX.Element[];
   open: boolean;
   xtermRef?: React.MutableRefObject<XTerminal | null>;
+  /**
+   * @description This is a callback function that is called when the user clicks on the reconnect button.
+   * @returns void
+   */
+  handleReconnect?: () => void;
+  /**
+   * @description This is a boolean that determines whether the reconnect button should be shown or not.
+   */
+  showReconnectButton?: boolean;
 }
 
 export function LogViewer(props: LogViewerProps) {
@@ -77,6 +86,8 @@ export function LogViewer(props: LogViewerProps) {
     xtermRef: outXtermRef,
     onClose,
     topActions = [],
+    handleReconnect,
+    showReconnectButton = false,
     ...other
   } = props;
   const [isFullScreen, setIsFullScreen] = React.useState(false);
@@ -210,6 +221,11 @@ export function LogViewer(props: LogViewerProps) {
           </Grid>
         </Grid>
         <Box className={classes.logBox}>
+          {showReconnectButton && (
+            <Button onClick={handleReconnect} color="info" variant="contained">
+              Reconnect
+            </Button>
+          )}
           <div
             id="xterm-container"
             ref={ref => setTerminalContainerRef(ref)}


### PR DESCRIPTION
Adds a new enhancement where pods logs are not auto reconnected. This used to happen when pod's container was in retry state, which made logs to reconnect and it kept on flashing as if the page reloaded until the pod was in a Ready state.

This adds functionality if the pod is not Ready, it shows a button to reconnect the logs.

Fixes: #1480

## Testing

Run the following commands in your terminal, assuming you have a cluster up and running.

```bash
# Install nginx
kubectl run nginx --image nginx

# Go to Headlamp page and open logs for nginx

# In your terminal exec into nginx pod
kubectl exec -it nginx -- bash

# kill the root process to restart the pod
kill 1
```

You will see the Reconnect button as show below.

![Screenshot 2024-01-30 at 11 15 34 AM](https://github.com/headlamp-k8s/headlamp/assets/24803604/242a293b-f0c7-4863-bae2-02950b5a29f1)
