### PR TITLE
frontend: fix calling /parseKubeConfig

### DIFF
--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -145,12 +145,18 @@ export default function Layout({}: LayoutProps) {
             dispatch(setConfig(configToStore));
           }
         }
+
+        /**
+         * Fetches the stateless cluster config from the indexDB and then sends the backend to parse it
+         * only if the stateless cluster config is enabled in the backend.
+         */
+        if (config?.isDynamicClusterEnabled) {
+          fetchStatelessClusterKubeConfigs(dispatch);
+        }
       })
       .catch(err => {
         console.error('Error getting config:', err);
       });
-
-    fetchStatelessClusterKubeConfigs(dispatch);
   };
 
   return (


### PR DESCRIPTION
This endpoint is used only for parsing stateless clusters kubeconfig. So, it should only be called when dynamic clusters are enabled. When the flag was disabled, the endpoint was unavailable. This fix calling the endpoint unnecessarily when dynamic cluster is disabled.

Signed-off-by: Kautilya Tripathi <ktripathi@microsoft.com>