### PR TITLE
frontend: fix stream function for websocket conn

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -137,8 +137,8 @@ export default function Terminal(props: TerminalProps) {
     fitAddon.fit();
   }
 
-  function send(channel: number, data: string) {
-    const socket = execOrAttachRef.current!.getSocket();
+  async function send(channel: number, data: string) {
+    const socket = await execOrAttachRef.current!.getSocket();
 
     // We should only send data if the socket is ready.
     if (!socket || socket.readyState !== 1) {


### PR DESCRIPTION
When called stream function was calling connect function synchronously and returning cancel and getSocket which were always null. This converts the function to a async function and returns a promise which resolves to the desired values for both getSocket and cancel function.