### PR TITLE
Small documentation improvements, helm link, and blog link

### DIFF
--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -150,6 +150,11 @@ make app-linux
 
 For more on how to extract files into there see "Shipping and Deploying Plugins" above.
 
+### More on making a headlamp container image including plugins
+
+See the blog post
+"[Get up to speed deploying Headlamp with plugins](https://headlamp.dev/blog/2022/10/get-up-to-speed-deploying-headlamp-with-plugins/)"
+for more information on building a container image with your plugins.
 
 ## Writing storybook stories
 

--- a/docs/installation/in-cluster/_index.md
+++ b/docs/installation/in-cluster/_index.md
@@ -6,7 +6,8 @@ weight: 10
 A common use-case for any Kubernetes web UI is to deploy it in-cluster and
 set up an ingress server for having it available to users.
 
-The easiest way to install headlamp in your existing cluster is to use our [helm chart](../../../charts/headlamp/).
+The easiest way to install headlamp in your existing cluster is to
+use [helm](https://helm.sh/docs/intro/quickstart/) with our [helm chart](../../../charts/headlamp/).
 
 ```bash
 # first add our custom repo to your local helm repositories


### PR DESCRIPTION
- docs: in-cluster: Add link to helm quickstart
- docs: building: Add a link to container plugins blog post
