### PR TITLE
frontend: Add dialog for Drain

### DIFF
--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -94,6 +94,8 @@
   "Drained node {{name}}.": "Node {{name}} wurde entleert.",
   "Failed to drain node {{name}}.": "Fehler beim Entleeren des Knotens {{name}}.",
   "Draining node {{name}} cancelled.": "Entleerung des Knotens {{name}} abgebrochen.",
+  "Drain Node": "",
+  "Are you sure you want to drain the node {{name}}?": "",
   "Uncordon": "Planungssperre aufheben",
   "Cordon": "Planungssperre setzen",
   "Drain": "Entleeren",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -94,6 +94,8 @@
   "Drained node {{name}}.": "Drained node {{name}}.",
   "Failed to drain node {{name}}.": "Failed to drain node {{name}}.",
   "Draining node {{name}} cancelled.": "Draining node {{name}} cancelled.",
+  "Drain Node": "Drain Node",
+  "Are you sure you want to drain the node {{name}}?": "Are you sure you want to drain the node {{name}}?",
   "Uncordon": "Uncordon",
   "Cordon": "Cordon",
   "Drain": "Drain",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -94,6 +94,8 @@
   "Drained node {{name}}.": "Nodo {{name}} drenado.",
   "Failed to drain node {{name}}.": "Error al drenar nodo {{name}}.",
   "Draining node {{name}} cancelled.": "Drenado de nodo {{name}} cancelado.",
+  "Drain Node": "",
+  "Are you sure you want to drain the node {{name}}?": "",
   "Uncordon": "Desbloquear",
   "Cordon": "Bloquear",
   "Drain": "Drenar",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -94,6 +94,8 @@
   "Drained node {{name}}.": "Nœud {{name}} vidé.",
   "Failed to drain node {{name}}.": "Échec de la vidange du nœud {{name}}.",
   "Draining node {{name}} cancelled.": "Vidange du nœud {{name}} annulée.",
+  "Drain Node": "",
+  "Are you sure you want to drain the node {{name}}?": "",
   "Uncordon": "Débloquer",
   "Cordon": "Bloquer",
   "Drain": "Vider",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -94,6 +94,8 @@
   "Drained node {{name}}.": "Node {{name}} esvaziado.",
   "Failed to drain node {{name}}.": "Falha ao esvaziar o node {{name}}.",
   "Draining node {{name}} cancelled.": "Esvaziamento do node {{name}} cancelado.",
+  "Drain Node": "",
+  "Are you sure you want to drain the node {{name}}?": "",
   "Uncordon": "Desbloquear",
   "Cordon": "Bloquear",
   "Drain": "Esvaziar",


### PR DESCRIPTION
# Add Confirm Dialog Box for Node Actions in UI

Fixes issue #1316 

## Description
This PR introduces a confirmation dialog box in the Node UI for Drain actions, aimed at enhancing user experience by providing a clear, interactive confirmation step before these critical actions are executed. However, there's a known bug where the dialog box re-renders every couple of seconds if left open for an extended period. This issue has been traced back to the `apiProxy.ts` file, specifically lines 415 and 376.

## Changes
- [x] Added a confirmation dialog box for Drain actions in the Node UI.
- [x] Identified a re-rendering bug in the confirmation dialog box.

## Known Issues
- The confirmation dialog box for node actions re-renders every few seconds if it remains open. This behavior has been traced to the `apiProxy.ts` file, lines 415 and 376. May need to be solved in a different PR.

![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/f865f4e9-ef53-47c8-9ea8-173721489b02)


## Verification
- [x] Tested the implementation of the confirmation dialog box for Drain actions.
- [x] Confirmed the dialog box appears as expected and requires user interaction to proceed with the actions.
- [x] Identified and located the source of the dialog box re-rendering issue.

## Next Steps
- Investigate and resolve the re-rendering issue in the `apiProxy.ts` file to ensure the dialog box remains stable and does not refresh unnecessarily.

## Screenshots

![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/aa28f7a0-4ef5-4471-8639-75012ffe3e24)

