### PR TITLE
github: Dockerfile: Fix .plugins copying and usage with test

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -28,6 +28,18 @@ jobs:
       # now you can run kubectl to see the pods in the cluster
     - name: Try the cluster!
       run: kubectl get pods -A
+    - name: Make a .plugins folder for testing later
+      run: |
+        echo "Extract pod-counter plugin into .plugins folder, which will be copied into image later by 'make image'."
+        cd plugins/examples/pod-counter
+        npm install
+        npm run build
+        cd ../../../
+        cd plugins/headlamp-plugin
+        npm install
+        node bin/headlamp-plugin.js extract ../examples/pod-counter ../../.plugins/
+        cd ../../
+        ls -laR .plugins
     - name: Build image
       run: |
         export SHELL=/bin/bash
@@ -36,6 +48,12 @@ jobs:
         DOCKER_IMAGE_VERSION=latest DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-test make build-plugins-container
         echo -n "verifying images:"
         docker images
+        echo "----------------------------"
+        echo "Test .plugins folder is copied to the right place in the image by 'make image'"
+        echo "--- Files in the image /headlamp/ folder: ---"
+        docker run --rm --entrypoint=/bin/sh ghcr.io/headlamp-k8s/headlamp:latest -c "cd /headlamp/ && find ."
+        echo "----- Checking if the .plugins/ are copied to the right place in the image -----"
+        docker run --rm --entrypoint=/bin/sh ghcr.io/headlamp-k8s/headlamp:latest -c "set -e; (cd /headlamp/plugins && [ -e pod-counter/package.json ] && [ -e pod-counter/main.js ]) || exit 1"
     - name: Deploy to cluster
       run:
         kubectl apply -f e2e-tests/kubernetes-headlamp-ci.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,15 @@ RUN cat ./frontend/.env
 # Backwards compatibility, move plugin folder to only copy matching plugins.
 RUN mv plugins plugins-old || true
 
+# Copy a .plugins folder if it is there to ./plugins, otherwise create an empty one.
+# This is a Dockerfile quirky way to copy a folder if it exists, but also not fail if it is empty.
+COPY ./.plugi*s ./plugins
 RUN mkdir -p ./plugins
 
 # Backwards compatibility, copy any matching plugins found inside "./plugins-old" into "./plugins".
 # They should match plugins-old/MyFolder/main.js, otherwise they are not copied.
 RUN for i in $(find ./plugins-old/*/main.js); do plugin_name=$(echo $i|cut -d'/' -f3); mkdir -p plugins/$plugin_name; cp $i plugins/$plugin_name; done
-
-RUN for i in $(find ./.plugins/*/main.js); do plugin_name=$(echo $i|cut -d'/' -f3); mkdir -p plugins/$plugin_name; cp $i plugins/$plugin_name; done
+RUN for i in $(find ./plugins-old/*/package.json); do plugin_name=$(echo $i|cut -d'/' -f3); mkdir -p plugins/$plugin_name; cp $i plugins/$plugin_name; done
 
 # Static (officially shipped) plugins
 FROM --platform=${BUILDPLATFORM} frontend-build as static-plugins
@@ -93,4 +95,4 @@ USER headlamp
 EXPOSE 4466
 
 ENV HEADLAMP_STATIC_PLUGINS_DIR=/headlamp/static-plugins
-ENTRYPOINT ["/headlamp/headlamp-server", "-html-static-dir", "/headlamp/frontend"]
+ENTRYPOINT ["/headlamp/headlamp-server", "-html-static-dir", "/headlamp/frontend", "-plugins-dir", "/headlamp/plugins"]


### PR DESCRIPTION
At some point the .plugin package copying stopped working. 
It's documented that a .plugins folder will be copied and used by the container.

There's a test included proving that the files are copied properly now.
Fixes #1687