### PR TITLE
backend: format backend logs to use zlog

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -1,19 +1,20 @@
 package main
 
 import (
-	"log"
 	"os"
 	"strings"
 
 	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
 	"github.com/headlamp-k8s/headlamp/backend/pkg/config"
 	"github.com/headlamp-k8s/headlamp/backend/pkg/kubeconfig"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/logger"
 )
 
 func main() {
 	conf, err := config.Parse(os.Args)
 	if err != nil {
-		log.Fatalf("Error fetching config:%v", err)
+		logger.Log(logger.LevelError, nil, err, "fetching config:%v")
+		os.Exit(1)
 	}
 
 	cache := cache.New[interface{}]()

--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/schema"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/logger"
 
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
@@ -118,7 +119,8 @@ func (h *Handler) ListRelease(w http.ResponseWriter, r *http.Request) {
 
 	err := decoder.Decode(&req, r.URL.Query())
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "list_releases").Msg("parsing request")
+		logger.Log(logger.LevelError, map[string]string{"request": "list_releases"},
+			err, "parsing request")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -126,7 +128,8 @@ func (h *Handler) ListRelease(w http.ResponseWriter, r *http.Request) {
 
 	releases, err := getReleases(req, h.Configuration)
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "list_releases").Msg("fetching releases")
+		logger.Log(logger.LevelError, map[string]string{"request": "list_releases"},
+			err, "fetching releases")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -139,7 +142,8 @@ func (h *Handler) ListRelease(w http.ResponseWriter, r *http.Request) {
 	err = json.NewEncoder(w).Encode(res)
 
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "list_releases").Msg("encoding response")
+		logger.Log(logger.LevelError, map[string]string{"request": "list_releases"},
+			err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -161,7 +165,8 @@ func (h *Handler) GetRelease(w http.ResponseWriter, r *http.Request) {
 
 	err := decoder.Decode(&req, r.URL.Query())
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "get_release").Msg("parsing request")
+		logger.Log(logger.LevelError, map[string]string{"request": "get_release"},
+			err, "parsing request")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -170,8 +175,8 @@ func (h *Handler) GetRelease(w http.ResponseWriter, r *http.Request) {
 	// check if release exists
 	_, err = h.Configuration.Releases.Deployed(req.Name)
 	if err == driver.ErrReleaseNotFound {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("request", "get_release").Msg("release not found")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "request": "get_release"},
+			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
 
 		return
@@ -181,7 +186,8 @@ func (h *Handler) GetRelease(w http.ResponseWriter, r *http.Request) {
 
 	result, err := getClient.Run(req.Name)
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "get_release").Str("releaseName", req.Name).Msg("getting release")
+		logger.Log(logger.LevelError, map[string]string{"request": "get_release", "releaseName": req.Name},
+			err, "getting release")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -191,7 +197,8 @@ func (h *Handler) GetRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewEncoder(w).Encode(result)
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "get_release").Str("releaseName", req.Name).Msg("encoding response")
+		logger.Log(logger.LevelError, map[string]string{"request": "get_release", "releaseName": req.Name},
+			err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -217,7 +224,8 @@ func (h *Handler) GetReleaseHistory(w http.ResponseWriter, r *http.Request) {
 
 	err := decoder.Decode(&req, r.URL.Query())
 	if err != nil {
-		zlog.Error().Err(err).Str("request", "get_release_history").Msg("error decoding request")
+		logger.Log(logger.LevelError, map[string]string{"request": "get_release_history"},
+			err, "decoding request")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -226,8 +234,8 @@ func (h *Handler) GetReleaseHistory(w http.ResponseWriter, r *http.Request) {
 	// check if release exists
 	_, err = h.Configuration.Releases.Deployed(req.Name)
 	if err == driver.ErrReleaseNotFound {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("request", "get_release_history").Msg("release not found")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "request": "get_release_history"},
+			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
 
 		return
@@ -237,12 +245,8 @@ func (h *Handler) GetReleaseHistory(w http.ResponseWriter, r *http.Request) {
 
 	result, err := getClient.Run(req.Name)
 	if err != nil {
-		zlog.
-			Error().
-			Err(err).
-			Str("request", "get_release_history").
-			Str("releaseName", req.Name).
-			Msg("getting release history")
+		logger.Log(logger.LevelError, map[string]string{"request": "get_release_history", "releaseName": req.Name},
+			err, "getting release history")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -257,12 +261,8 @@ func (h *Handler) GetReleaseHistory(w http.ResponseWriter, r *http.Request) {
 	err = json.NewEncoder(w).Encode(resp)
 
 	if err != nil {
-		zlog.
-			Error().
-			Err(err).
-			Str("request", "get_release_history").
-			Str("releaseName", req.Name).
-			Msg("encoding response")
+		logger.Log(logger.LevelError, map[string]string{"request": "get_release_history", "releaseName": req.Name},
+			err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -284,7 +284,8 @@ func (h *Handler) UninstallRelease(w http.ResponseWriter, r *http.Request) {
 
 	err := decoder.Decode(&req, r.URL.Query())
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "uninstall").Msg("parsing request")
+		logger.Log(logger.LevelError, map[string]string{"request": "uninstall_release"},
+			err, "decoding request")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -293,8 +294,8 @@ func (h *Handler) UninstallRelease(w http.ResponseWriter, r *http.Request) {
 	// check if release exists
 	_, err = h.Configuration.Releases.Deployed(req.Name)
 	if err == driver.ErrReleaseNotFound {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "uninstall").Msg("release not found")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "request": "uninstall_release"},
+			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
 
 		return
@@ -302,8 +303,11 @@ func (h *Handler) UninstallRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = h.setReleaseStatus("uninstall", req.Name, processing, nil)
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "uninstall").Msg("setting status")
+		logger.Log(logger.LevelError, map[string]string{"request": "uninstall_release", "releaseName": req.Name},
+			err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
 	}
 
 	go func(h *Handler) {
@@ -319,7 +323,8 @@ func (h *Handler) UninstallRelease(w http.ResponseWriter, r *http.Request) {
 	err = json.NewEncoder(w).Encode(response)
 
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "uninstall").Msg("encoding response")
+		logger.Log(logger.LevelError, map[string]string{"request": "uninstall_release", "releaseName": req.Name},
+			err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -336,7 +341,8 @@ func (h *Handler) uninstallRelease(req UninstallReleaseRequest) {
 
 	_, err := uninstallClient.Run(req.Name)
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).Str("namespace", req.Namespace).Msg("uninstalling release")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "namespace": req.Namespace},
+			err, "uninstalling release")
 
 		status = failed
 	}
@@ -361,7 +367,7 @@ func (h *Handler) RollbackRelease(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "rollback").Msg("parsing request body")
+		logger.Log(logger.LevelError, nil, err, "parsing request for rollback")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -369,7 +375,7 @@ func (h *Handler) RollbackRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = req.Validate()
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "rollback").Msg("validating request body")
+		logger.Log(logger.LevelError, nil, err, "validating request for rollback")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -378,8 +384,8 @@ func (h *Handler) RollbackRelease(w http.ResponseWriter, r *http.Request) {
 	// check if release exists
 	_, err = h.Configuration.Releases.Deployed(req.Name)
 	if err == driver.ErrReleaseNotFound {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "rollback").Msg("release not found")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name},
+			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
 
 		return
@@ -387,8 +393,10 @@ func (h *Handler) RollbackRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = h.setReleaseStatus("rollback", req.Name, processing, nil)
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "rollback").Msg("setting status")
+		logger.Log(logger.LevelError, nil, err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
 	}
 
 	go func(h *Handler) {
@@ -403,7 +411,7 @@ func (h *Handler) RollbackRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "rollback").Msg("encoding response")
+		logger.Log(logger.LevelError, nil, err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -420,7 +428,8 @@ func (h *Handler) rollbackRelease(req RollbackReleaseRequest) {
 
 	err := rollbackClient.Run(req.Name)
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).Msg("rollback release")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name},
+			err, "rolling back release")
 
 		status = failed
 	}
@@ -454,7 +463,7 @@ func (h *Handler) InstallRelease(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "install").Msg("parsing request body")
+		logger.Log(logger.LevelError, nil, err, "parsing request for install")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -462,7 +471,7 @@ func (h *Handler) InstallRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = req.Validate()
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "install").Msg("validating request body")
+		logger.Log(logger.LevelError, nil, err, "validating request for install")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -470,7 +479,7 @@ func (h *Handler) InstallRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = h.setReleaseStatus("install", req.Name, processing, nil)
 	if err != nil {
-		zlog.Error().Err(err).Str("action", "install").Msg("setting status")
+		logger.Log(logger.LevelError, nil, err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -487,8 +496,8 @@ func (h *Handler) InstallRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "install").Str("chart", req.Chart).Str("action", "install").Msg("encoding response")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "chart": req.Chart},
+			err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -562,9 +571,8 @@ func (h *Handler) installRelease(req InstallRequest) {
 	chart, err := h.getChart("install", req.Chart, req.Name,
 		installClient.ChartPathOptions, req.DependencyUpdate, h.EnvSettings)
 	if err != nil {
-		zlog.Error().Err(err).Str("chart", req.Chart).
-			Str("action", "install").Str("releaseName", req.Name).
-			Msg("getting chart")
+		logger.Log(logger.LevelError, map[string]string{"chart": req.Chart, "releaseName": req.Name},
+			err, "getting chart")
 
 		return
 	}
@@ -573,9 +581,8 @@ func (h *Handler) installRelease(req InstallRequest) {
 
 	decodedBytes, err := base64.StdEncoding.DecodeString(req.Values)
 	if err != nil {
-		zlog.Error().Err(err).Str("chart", req.Chart).
-			Str("action", "install").Str("releaseName", req.Name).
-			Msg("decoding values")
+		logger.Log(logger.LevelError, map[string]string{"chart": req.Chart, "releaseName": req.Name},
+			err, "decoding values")
 		h.setReleaseStatusSilent("install", req.Name, failed, err)
 
 		return
@@ -584,9 +591,8 @@ func (h *Handler) installRelease(req InstallRequest) {
 	err = yaml.Unmarshal(decodedBytes, &values)
 
 	if err != nil {
-		zlog.Error().Err(err).Str("chart", req.Chart).
-			Str("action", "install").Str("releaseName", req.Name).
-			Msg("unmarshalling values")
+		logger.Log(logger.LevelError, map[string]string{"chart": req.Chart, "releaseName": req.Name},
+			err, "unmarshalling values")
 		h.setReleaseStatusSilent("install", req.Name, failed, err)
 
 		return
@@ -595,16 +601,15 @@ func (h *Handler) installRelease(req InstallRequest) {
 	// Install chart
 	_, err = installClient.Run(chart, values)
 	if err != nil {
-		zlog.Error().Err(err).Str("chart", req.Chart).
-			Str("action", "install").Str("releaseName", req.Name).
-			Msg("installing chart")
+		logger.Log(logger.LevelError, map[string]string{"chart": req.Chart, "releaseName": req.Name},
+			err, "installing chart")
 		h.setReleaseStatusSilent("install", req.Name, failed, err)
 
 		return
 	}
 
-	zlog.Info().Str("chart", req.Chart).Str("action", "install").
-		Str("releaseName", req.Name).Msg("chart installed successfully")
+	logger.Log(logger.LevelInfo, map[string]string{"chart": req.Chart, "releaseName": req.Name},
+		nil, "chart installed successfully")
 
 	h.setReleaseStatusSilent("install", req.Name, success, nil)
 }
@@ -619,14 +624,15 @@ func (req *UpgradeReleaseRequest) Validate() error {
 	return validate.Struct(req)
 }
 
+//nolint:funlen
 func (h *Handler) UpgradeRelease(w http.ResponseWriter, r *http.Request) {
 	// Parse request and validate
 	var req UpgradeReleaseRequest
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "upgrade").Msg("parsing request for upgrade release")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name},
+			err, "parsing request for upgrade release")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -634,8 +640,8 @@ func (h *Handler) UpgradeRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = req.Validate()
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "upgrade").Msg("validating request for upgrade release")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name},
+			err, "validating request for upgrade release")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -644,8 +650,8 @@ func (h *Handler) UpgradeRelease(w http.ResponseWriter, r *http.Request) {
 	// check if release exists
 	_, err = h.Configuration.Releases.Deployed(req.Name)
 	if err == driver.ErrReleaseNotFound {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "upgrade").Str("chart", req.Chart).Msg("release not found")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "chart": req.Chart},
+			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
 
 		return
@@ -653,8 +659,11 @@ func (h *Handler) UpgradeRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = h.setReleaseStatus("upgrade", req.Name, processing, nil)
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).Str("action", "upgrade").Msg("setting status")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name},
+			err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
 	}
 
 	go func(h *Handler) {
@@ -670,8 +679,8 @@ func (h *Handler) UpgradeRelease(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
-		zlog.Error().Err(err).Str("releaseName", req.Name).
-			Str("action", "upgrade").Str("chart", req.Chart).Msg("encoding response")
+		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "chart": req.Chart},
+			err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -680,7 +689,7 @@ func (h *Handler) UpgradeRelease(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 }
 
-func (h *Handler) logActionState(log *zerolog.Event,
+func (h *Handler) logActionState(zlog *zerolog.Event,
 	err error,
 	action string,
 	chart string,
@@ -689,11 +698,13 @@ func (h *Handler) logActionState(log *zerolog.Event,
 	message string,
 ) {
 	if err != nil {
-		log = log.Err(err)
+		zlog = zlog.Err(err)
 	}
 
-	log.Str("chart", chart).
-		Str("action", action).Str("releaseName", releaseName).Str("status", status).
+	zlog.Str("chart", chart).
+		Str("action", action).
+		Str("releaseName", releaseName).
+		Str("status", status).
 		Msg(message)
 
 	h.setReleaseStatusSilent(action, releaseName, status, err)
@@ -708,6 +719,9 @@ func (h *Handler) upgradeRelease(req UpgradeReleaseRequest) {
 
 	chart, err := h.getChart("upgrade", req.Chart, req.Name, upgradeClient.ChartPathOptions, true, h.EnvSettings)
 	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"chart": req.Chart, "releaseName": req.Name},
+			err, "getting chart")
+
 		return
 	}
 
@@ -745,6 +759,9 @@ func (a *ActionStatusRequest) Validate() error {
 
 	err := validate.Struct(a)
 	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"action": a.Action, "releaseName": a.Name},
+			err, "validating request for status")
+
 		return err
 	}
 
@@ -760,7 +777,7 @@ func (h *Handler) GetActionStatus(w http.ResponseWriter, r *http.Request) {
 
 	err := schema.NewDecoder().Decode(&request, r.URL.Query())
 	if err != nil {
-		zlog.Error().Err(err).Msg("parsing request for status")
+		logger.Log(logger.LevelError, nil, err, "parsing request for status")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -768,7 +785,7 @@ func (h *Handler) GetActionStatus(w http.ResponseWriter, r *http.Request) {
 
 	err = request.Validate()
 	if err != nil {
-		zlog.Error().Err(err).Msg("validating request for status")
+		logger.Log(logger.LevelError, nil, err, "validating request for status")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -776,7 +793,7 @@ func (h *Handler) GetActionStatus(w http.ResponseWriter, r *http.Request) {
 
 	stat, err := h.getReleaseStatus(request.Action, request.Name)
 	if err != nil {
-		zlog.Error().Err(err).Msg("getting status")
+		logger.Log(logger.LevelError, nil, err, "getting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -798,7 +815,7 @@ func (h *Handler) GetActionStatus(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
-		zlog.Error().Err(err).Msg("encoding response")
+		logger.Log(logger.LevelError, nil, err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"strings"
 
-	zlog "github.com/rs/zerolog/log"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/logger"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -169,7 +169,8 @@ func (c *Context) SetupProxy() error {
 
 	c.proxy = proxy
 
-	zlog.Info().Msgf("Proxy setup for context %q to cluster url %q", c.Name, c.Cluster.Server)
+	logger.Log(logger.LevelInfo, map[string]string{"context": c.Name, "clusterURL": c.Cluster.Server},
+		nil, "Proxy setup")
 
 	return nil
 }

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const kubeConfigFilePath = "./test_data/kubeconfig1"
+
 func TestLoadAndStoreKubeConfigs(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
 
 	t.Run("valid_file", func(t *testing.T) {
-		kubeConfigFile := "./test_data/kubeconfig1"
+		kubeConfigFile := kubeConfigFilePath
 
 		err := kubeconfig.LoadAndStoreKubeConfigs(contextStore, kubeConfigFile, kubeconfig.KubeConfig)
 		require.NoError(t, err)
@@ -44,7 +46,7 @@ func TestLoadAndStoreKubeConfigs(t *testing.T) {
 
 func TestLoadContextsFromKubeConfigFile(t *testing.T) {
 	t.Run("valid_file", func(t *testing.T) {
-		kubeConfigFile := "./test_data/kubeconfig1"
+		kubeConfigFile := kubeConfigFilePath
 
 		contexts, err := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
 		require.NoError(t, err)
@@ -98,7 +100,7 @@ func TestContext(t *testing.T) {
 func TestLoadContextsFromBase64String(t *testing.T) {
 	t.Run("valid_base64", func(t *testing.T) {
 		// Read the content of the kubeconfig file
-		kubeConfigFile := config.GetDefaultKubeConfigPath()
+		kubeConfigFile := kubeConfigFilePath
 		kubeConfigContent, err := os.ReadFile(kubeConfigFile)
 		require.NoError(t, err)
 
@@ -108,7 +110,7 @@ func TestLoadContextsFromBase64String(t *testing.T) {
 		contexts, err := kubeconfig.LoadContextsFromBase64String(base64String, kubeconfig.DynamicCluster)
 		require.NoError(t, err)
 
-		require.Equal(t, 1, len(contexts))
+		require.Equal(t, 2, len(contexts))
 		assert.Equal(t, kubeconfig.DynamicCluster, contexts[0].Source)
 	})
 

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -1,0 +1,81 @@
+package logger
+
+import (
+	"runtime"
+
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+)
+
+const (
+	// LevelInfo is the info level.
+	LevelInfo = iota
+	// LevelWarn is the warn level.
+	LevelWarn
+	// LevelError is the error level.
+	LevelError
+)
+
+// LogFunc is a function signature for logging.
+type LogFunc func(level uint, str map[string]string, err interface{}, msg string)
+
+// logFunc holds the actual logging function.
+var logFunc LogFunc = log
+
+// Log logs the message, source file, and line number at the specified level.
+func Log(level uint, str map[string]string, err interface{}, msg string) {
+	logFunc(level, str, err, msg)
+}
+
+// Log is a wrapper function for logging. It uses zlog package and logs to stdout.
+// It logs the message, source file and line number.
+// It logs the message at the level specified.
+func log(level uint, str map[string]string, err interface{}, msg string) {
+	var event *zerolog.Event
+
+	switch level {
+	case LevelInfo:
+		event = zlog.Info()
+	case LevelWarn:
+		event = zlog.Warn()
+	case LevelError:
+		event = zlog.Error()
+	default:
+		event = zlog.Info()
+	}
+
+	for k, v := range str {
+		event.Str(k, v)
+	}
+
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		event.Str("source", file)
+		event.Int("line", line)
+	}
+
+	// Handle errors
+	if err != nil {
+		switch e := err.(type) {
+		case error:
+			event.Err(e).Msg(msg)
+		case []error:
+			event.Errs("error", e).Msg(msg)
+		case int:
+			event.Int("error", e).Msg(msg)
+		case string:
+			event.Str("error", e).Msg(msg)
+		default:
+			event.Interface("error", e).Msg(msg)
+		}
+	} else {
+		event.Msg(msg)
+	}
+}
+
+// SetLogFunc sets the logging function.
+func SetLogFunc(lf LogFunc) LogFunc {
+	logFunc = lf
+
+	return logFunc
+}

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -1,0 +1,70 @@
+package logger_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/headlamp-k8s/headlamp/backend/pkg/logger"
+)
+
+var capturedLogs []string
+
+// MockLog is a mock logging function for testing.
+func MockLog(level uint, str map[string]string, err interface{}, msg string) {
+	logMessage := fmt.Sprintf(`{"level":%d, "message":"%s"}`, level, msg)
+	capturedLogs = append(capturedLogs, logMessage)
+}
+
+func TestLog(t *testing.T) {
+	t.Parallel()
+
+	// Replace the actual logging function with the mock one
+	originalLogFunc := logger.SetLogFunc(MockLog)
+	defer logger.SetLogFunc(originalLogFunc)
+
+	tests := []struct {
+		name  string
+		level uint
+		str   map[string]string
+		err   interface{}
+		msg   string
+	}{
+		{
+			name:  "TestInfoLog",
+			level: logger.LevelInfo,
+			str:   map[string]string{"key": "value"},
+			err:   nil,
+			msg:   "Test Info Log",
+		},
+		{
+			name:  "TestWarnLog",
+			level: logger.LevelWarn,
+			str:   map[string]string{"key": "value"},
+			err:   nil,
+			msg:   "Test Warn Log",
+		},
+		{
+			name:  "TestErrorLog",
+			level: logger.LevelError,
+			str:   map[string]string{"key": "value"},
+			err:   nil,
+			msg:   "Test Error Log",
+		},
+	}
+
+	// Call the Log function
+	for _, test := range tests {
+		test := test // Assign test to a local variable
+		t.Run(test.name, func(t *testing.T) {
+			logger.Log(test.level, test.str, test.err, test.msg)
+
+			expectedLog := fmt.Sprintf(`{"level":%d, "message":"%s"}`, test.level, test.msg)
+			if len(capturedLogs) != 1 || capturedLogs[0] != expectedLog {
+				t.Errorf("unexpected log output:\n\texpected: %s\n\tgot: %s", expectedLog, capturedLogs)
+			}
+		})
+
+		// Reset capturedLogs for the next test case
+		capturedLogs = nil
+	}
+}

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -3,10 +3,10 @@ package portforward
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/logger"
 )
 
 const storeKeyPrefix = "PORT_FORWARD_"
@@ -35,7 +35,7 @@ func portforwardstore(cache cache.Cache[interface{}], p portForward) {
 
 	err := cache.Set(context.Background(), key, p)
 	if err != nil {
-		log.Printf("Error storing portforward %s", err)
+		logger.Log(logger.LevelError, nil, err, "storing portforward")
 	}
 }
 
@@ -46,6 +46,9 @@ func portforwardstore(cache cache.Cache[interface{}], p portForward) {
 func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id string, isStopRequest bool) error {
 	portforward, err := getPortForwardByID(cache, cluster, id)
 	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster, "id": id},
+			err, "getting portforward")
+
 		return err
 	}
 
@@ -57,6 +60,9 @@ func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id 
 	} else {
 		err := cache.Delete(context.Background(), portforwardKeyGenerator(portforward))
 		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": cluster, "id": id},
+				err, "deleting portforward")
+
 			return err
 		}
 	}
@@ -70,6 +76,9 @@ func getPortForwardList(cache cache.Cache[interface{}], cluster string) []portFo
 		return strings.HasPrefix(key, storeKeyPrefix+cluster)
 	})
 	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+			err, "getting portforward list")
+
 		return nil
 	}
 


### PR DESCRIPTION
Earlier we were not using zlog everywhere due to which some logs were not correctly parsed by log platforms. They were all parsed as errors. This fixes that and adds correct format of all logs in headlamp. They are now shown as json which can be parsed by any log platform.

This also adds a wrapper function for zlog which increases code readability and cleanliness.

Fixes: #1645