### PR TITLE
Cluster in hook api functions / Warnings in home view

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.stories.storyshot
@@ -224,6 +224,23 @@ exports[`Storyshots Home/Home Base 1`] = `
                       class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall makeStyles-headerCell makeStyles-sortCell css-1ciaiyl-MuiTableCell-root"
                       scope="col"
                     >
+                      Warnings
+                      <button
+                        aria-label="sort swap"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall makeStyles-headerCell makeStyles-sortCell css-1ciaiyl-MuiTableCell-root"
+                      scope="col"
+                    >
                       Kubernetes Version
                       <button
                         aria-label="sort swap"
@@ -279,6 +296,11 @@ exports[`Storyshots Home/Home Base 1`] = `
                           </p>
                         </div>
                       </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      ⋯
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
@@ -347,6 +369,11 @@ exports[`Storyshots Home/Home Base 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     >
+                      ⋯
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
                       <div
                         class="MuiBox-root css-s2uf1z"
                       >
@@ -397,6 +424,11 @@ exports[`Storyshots Home/Home Base 1`] = `
                           </p>
                         </div>
                       </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      ⋯
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -18,6 +18,7 @@
   "All Clusters": "Alle Cluster",
   "Name": "Name",
   "Status": "Status",
+  "Warnings": "",
   "Load cluster": "Cluster laden",
   "Something went wrong with cluster {{ cluster }}": "Mit dem Cluster ist etwas schief gelaufen {{ cluster }}",
   "Choose another cluster": "Wählen Sie einen anderen Cluster",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -18,6 +18,7 @@
   "All Clusters": "All Clusters",
   "Name": "Name",
   "Status": "Status",
+  "Warnings": "Warnings",
   "Load cluster": "Load cluster",
   "Something went wrong with cluster {{ cluster }}": "Something went wrong with cluster {{ cluster }}",
   "Choose another cluster": "Choose another cluster",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -18,6 +18,7 @@
   "All Clusters": "Todos los Clusters",
   "Name": "Nombre",
   "Status": "Estado",
+  "Warnings": "",
   "Load cluster": "Cargar cluster",
   "Something went wrong with cluster {{ cluster }}": "Algo ha fallado en el cluster {{ cluster }}",
   "Choose another cluster": "Elegir un otro cluster",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -18,6 +18,7 @@
   "All Clusters": "Tous les clusters",
   "Name": "Nom",
   "Status": "Statut",
+  "Warnings": "",
   "Load cluster": "Charger cluster",
   "Something went wrong with cluster {{ cluster }}": "Quelque chose s'est mal passé avec le cluster {{ cluster }}",
   "Choose another cluster": "Choisir un autre cluster",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -18,6 +18,7 @@
   "All Clusters": "Todos os Clusters",
   "Name": "Nome",
   "Status": "Estado",
+  "Warnings": "",
   "Load cluster": "Carregar cluster",
   "Something went wrong with cluster {{ cluster }}": "Algo falhou com o cluster {{ cluster }}",
   "Choose another cluster": "Escolha outro cluster",

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -440,9 +440,7 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
         args.unshift(opts?.namespace || null);
       }
 
-      if (onError) {
-        args.push(onError);
-      }
+      args.push(onError);
 
       const queryParams: QueryParameters = {};
       if (opts?.queryParams?.labelSelector) {


### PR DESCRIPTION
Allow useGet, useList, and apiGet/apiList functions to specify the cluster.
This is needed and it's possible now that we have a way to specify the cluster in apiProxy.

As part of testing whether this was working, I ended up adding the number of warnings for the clusters in the home view. Which is part of the new design when we implement the new multi-cluster view.

fixes #1747