### PR TITLE
frontend ClusterChooser: Fix color (make it black again)

### DIFF
--- a/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
@@ -260,7 +260,7 @@ exports[`Storyshots TopBar Two Cluster 1`] = `
         class="makeStyles-clusterTitle"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge css-1cz0hnj-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge css-tsm8af-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >

--- a/frontend/src/components/cluster/ClusterChooser.tsx
+++ b/frontend/src/components/cluster/ClusterChooser.tsx
@@ -27,16 +27,16 @@ const ClusterChooser = React.forwardRef(function ClusterChooser(
       size="large"
       variant="contained"
       onClick={clickHandler}
-      sx={{
-        color: 'clusterChooser.button.color',
-        background: 'clusterChooser.button.background',
+      sx={theme => ({
+        color: theme.palette.clusterChooser.button.color,
+        background: theme.palette.clusterChooser.button.background,
         '&:hover': {
-          background: 'clusterChooser.button.hover.background',
+          background: theme.palette.clusterChooser.button.hover.background,
         },
         maxWidth: '20em',
         textTransform: 'none',
         padding: '6px 22px',
-      }}
+      })}
       ref={ref}
     >
       <SpanClusterName title={cluster}>


### PR DESCRIPTION
After 2bc3979e7c41f264226bfb44e01e03f679b3a370 , the cluster chooser button's color became blue as apparently the sx prop isn't picking up custom theme entries. This patch fixes that by accessing the theme directly in the sx prop.

cc/ @farodin91 This may be important if you add more style replacements (the sx prop doesn't seem to find custom props by string directly, so they need to be referred by theme).
