### PR TITLE
backend: Fix log file source

### DIFF
--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -16,6 +16,9 @@ const (
 	LevelError
 )
 
+// callerDepth is the depth of the caller in the stack.
+const callerDepth = 2
+
 // LogFunc is a function signature for logging.
 type LogFunc func(level uint, str map[string]string, err interface{}, msg string)
 
@@ -48,7 +51,7 @@ func log(level uint, str map[string]string, err interface{}, msg string) {
 		event.Str(k, v)
 	}
 
-	_, file, line, ok := runtime.Caller(1)
+	_, file, line, ok := runtime.Caller(callerDepth)
 	if ok {
 		event.Str("source", file)
 		event.Int("line", line)


### PR DESCRIPTION
This fixes the log source file. Earlier the runtime.Caller function was 1 in the log function. This change ensures that we retrieve the source file from the caller of the Log function, rather than the log function itself.

Fixes: #1755
Signed-off-by: Kautilya Tripathi <ktripathi@microsoft.com>