### PR TITLE
plugins/examples/change-logo: Use sx prop in logo

### DIFF
--- a/plugins/examples/change-logo/src/index.tsx
+++ b/plugins/examples/change-logo/src/index.tsx
@@ -20,18 +20,19 @@ import Settings, { store } from './settings';
  * it's easier to make it look good with light and dark themes.
  */
 function SimpleLogo(props: AppLogoProps) {
-  const { logoType, className } = props;
+  const { logoType, className, sx } = props;
 
   const useConf = store.useConfig();
   const config = useConf();
 
   return config?.url ? (
-    <Avatar src={config?.url} alt="logo" className={className} />
+    <Avatar src={config?.url} alt="logo" className={className} sx={sx} />
   ) : (
     <SvgIcon
       className={className}
       component={logoType === 'large' ? LogoWithTextLight : LogoLight}
       viewBox="0 0 auto 32"
+      sx={sx}
     />
   );
 }


### PR DESCRIPTION
Since now we are using sx everywhere.

Fixes #1764