### PR TITLE
frontend plugins: Fix enable button disappearing

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -278,16 +278,17 @@ export async function fetchAndExecutePlugins(
 
   if (Object.keys(incompatiblePlugins).length > 0) {
     onIncompatible(incompatiblePlugins);
-    const packagesIncompatibleSet: PluginInfo[] = updatedSettingsPackages.map(
-      (plugin: PluginInfo) => {
-        return {
-          ...plugin,
-          isCompatible: !incompatiblePlugins[plugin.name],
-        };
-      }
-    );
-    onSettingsChange(packagesIncompatibleSet);
   }
+
+  const packagesIncompatibleSet: PluginInfo[] = updatedSettingsPackages.map(
+    (plugin: PluginInfo) => {
+      return {
+        ...plugin,
+        isCompatible: !incompatiblePlugins[plugin.name],
+      };
+    }
+  );
+  onSettingsChange(packagesIncompatibleSet);
 
   sourcesToExecute.forEach((source, index) => {
     // Execute plugins inside a context (not in global/window)


### PR DESCRIPTION
The enable button was not being shown for plugins unless there was at
least one incompatible plugin being processed. This happened because
the code that set the isCompatible part of each plugin info was not
being directly set unless there were incompatible plugins.

Signed-off-by: Joaquim Rocha <joaquim.rocha@microsoft.com>
