### PR TITLE
e2e-tests headlampPage: Fix flaky test to wait for page to load

### DIFF
--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -6,6 +6,8 @@ export class HeadlampPage {
   async authenticate() {
     await this.page.goto('/');
 
+    await this.page.waitForSelector('h1:has-text("Authentication")');
+
     // Expects the URL to contain c/main/token
     this.hasURLContaining(/.*token/);
 


### PR DESCRIPTION
Sometimes the token would not be in the URL in time, and it would fail the tests. So we wait for the heading to be there.