### PR TITLE
headlamp-plugin: Do not exit process when watching for changes

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -292,19 +292,19 @@ function start() {
   config.mode = 'development';
   process.env['BABEL_ENV'] = 'development';
   copyToPluginsFolder(config);
+  let exitCode = 0;
   webpack(config, (err, stats) => {
     // We are checking the exit code of the compileMessages function.
     // It should be 0 if there are no errors, and 1 if there are errors.
-    const exitCode = compileMessages(err, stats);
+    exitCode = compileMessages(err, stats);
     if (exitCode !== 0) {
       console.error('Failed to start watching for changes.');
     } else {
       console.log('Watching for changes to plugin...');
     }
-    process.exit(exitCode);
   });
 
-  return 0;
+  return exitCode;
 }
 
 /**


### PR DESCRIPTION
Due to a recent change, after webpack compiled or had an error
compiling a plugin's code, the process was being exited, meaning that
the functionality of watching for changes was broken.

fixes #1855 

## How to test
1. Set up a version of headlamp-plugin with these changes (create a package using `npm pack`);
2. Go to an example plugin and install that package from the tarball (`npm i /path/to/your/kinvolk-headlamp-...tgz`);
3. Build the plugin for changes: `npm run start` -> Realize that the command does not quit after copying the files to the plugins folder, and instead it keeps watching for changes in the plugin files.