### PR TITLE
frontend cluster/Overview: Show only warnings by default

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -62,6 +62,7 @@ export default function Overview() {
 
 function EventsSection() {
   const EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY = 'EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY';
+  const EVENT_WARNING_SWITCH_DEFAULT = true;
   const { t } = useTranslation(['translation', 'glossary']);
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
@@ -69,7 +70,12 @@ function EventsSection() {
   const dispatch = useDispatch();
   const filterFunc = useFilterFunc(['.jsonData.involvedObject.kind']);
   const [isWarningEventSwitchChecked, setIsWarningEventSwitchChecked] = React.useState(
-    Boolean(JSON.parse(localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY) || 'false'))
+    Boolean(
+      JSON.parse(
+        localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY) ||
+          EVENT_WARNING_SWITCH_DEFAULT.toString()
+      )
+    )
   );
   const [events, eventsError] = Event.useList({ limit: Event.maxLimit });
 

--- a/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
@@ -485,9 +485,10 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                         class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                       >
                         <span
-                          class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-5xfy0x-MuiButtonBase-root-MuiSwitch-switchBase"
+                          class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-5xfy0x-MuiButtonBase-root-MuiSwitch-switchBase"
                         >
                           <input
+                            checked=""
                             class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
                             type="checkbox"
                           />
@@ -686,75 +687,6 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                   <tbody
                     class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
                   >
-                    <tr
-                      class="MuiTableRow-root css-73w7uv-MuiTableRow-root"
-                    >
-                      <td
-                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                      >
-                        Pod
-                      </td>
-                      <th
-                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                        scope="row"
-                      >
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
-                          href="/"
-                        >
-                          hello-123-123
-                        </a>
-                      </th>
-                      <td
-                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                      >
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
-                          href="/"
-                        >
-                          default
-                        </a>
-                      </td>
-                      <td
-                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                      >
-                        <span
-                          aria-label="Started"
-                          class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-19rs0eg-MuiTypography-root"
-                          data-mui-internal-clone-element="true"
-                          style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
-                        >
-                          Started
-                        </span>
-                      </td>
-                      <td
-                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                      >
-                        <div
-                          class="MuiBox-root css-k008qs"
-                        >
-                          <label
-                            class="makeStyles-fullText"
-                            id="a12345"
-                          >
-                            Started container hello
-                          </label>
-                        </div>
-                      </td>
-                      <td
-                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                        style="text-align: right;"
-                      >
-                        <p
-                          aria-label="2023-07-13T13:42:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 makeStyles-noWrap makeStyles-display css-1ezega9-MuiTypography-root"
-                          data-mui-internal-clone-element="true"
-                        >
-                          3mo
-                          <span />
-                        </p>
-                      </td>
-                    </tr>
                     <tr
                       class="MuiTableRow-root css-73w7uv-MuiTableRow-root"
                     >


### PR DESCRIPTION
By default we should show only warnings. This wrong default has been
around since we added the related switch.
