### PR TITLE
frontend: Notifications: Disable Notifications

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -35,7 +35,6 @@ import { drawerWidth } from '../Sidebar';
 import HeadlampButton from '../Sidebar/HeadlampButton';
 import { setWhetherSidebarOpen } from '../Sidebar/sidebarSlice';
 import { AppLogo } from './AppLogo';
-import Notifications from './Notifications';
 
 export interface TopBarProps {}
 
@@ -328,11 +327,7 @@ export function PureTopBar({
     ...appBarActions,
     {
       id: DefaultAppBarAction.NOTIFICATION,
-      action: (
-        <MenuItem onClick={handleMenuClose}>
-          <Notifications />
-        </MenuItem>
-      ),
+      action: null,
     },
     {
       id: DefaultAppBarAction.SETTINGS,
@@ -391,7 +386,7 @@ export function PureTopBar({
     ...appBarActions,
     {
       id: DefaultAppBarAction.NOTIFICATION,
-      action: <Notifications />,
+      action: null,
     },
     {
       id: DefaultAppBarAction.SETTINGS,

--- a/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
@@ -23,33 +23,6 @@ exports[`Storyshots TopBar No Token 1`] = `
       <div
         class="makeStyles-clusterTitle"
       />
-      <button
-        aria-controls=""
-        aria-haspopup="true"
-        aria-label="Show notifications"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          height="1em"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <path
-            d="M21 19v1H3v-1l2-2v-6c0-3.1 2.03-5.83 5-6.71V4a2 2 0 0 1 2-2a2 2 0 0 1 2 2v.29c2.97.88 5 3.61 5 6.71v6l2 2m-7 2a2 2 0 0 1-2 2a2 2 0 0 1-2-2"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
     </div>
   </nav>
 </div>
@@ -78,33 +51,6 @@ exports[`Storyshots TopBar One Cluster 1`] = `
       <div
         class="makeStyles-clusterTitle"
       />
-      <button
-        aria-controls=""
-        aria-haspopup="true"
-        aria-label="Show notifications"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          height="1em"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <path
-            d="M21 19v1H3v-1l2-2v-6c0-3.1 2.03-5.83 5-6.71V4a2 2 0 0 1 2-2a2 2 0 0 1 2 2v.29c2.97.88 5 3.61 5 6.71v6l2 2m-7 2a2 2 0 0 1-2 2a2 2 0 0 1-2-2"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
       <button
         aria-controls="primary-user-menu"
         aria-haspopup="true"
@@ -149,33 +95,6 @@ exports[`Storyshots TopBar Processor Action 1`] = `
       <p>
         meow
       </p>
-      <button
-        aria-controls=""
-        aria-haspopup="true"
-        aria-label="Show notifications"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          height="1em"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <path
-            d="M21 19v1H3v-1l2-2v-6c0-3.1 2.03-5.83 5-6.71V4a2 2 0 0 1 2-2a2 2 0 0 1 2 2v.29c2.97.88 5 3.61 5 6.71v6l2 2m-7 2a2 2 0 0 1-2 2a2 2 0 0 1-2-2"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
     </div>
   </nav>
 </div>
@@ -204,33 +123,6 @@ exports[`Storyshots TopBar Token 1`] = `
       <div
         class="makeStyles-clusterTitle"
       />
-      <button
-        aria-controls=""
-        aria-haspopup="true"
-        aria-label="Show notifications"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          height="1em"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <path
-            d="M21 19v1H3v-1l2-2v-6c0-3.1 2.03-5.83 5-6.71V4a2 2 0 0 1 2-2a2 2 0 0 1 2 2v.29c2.97.88 5 3.61 5 6.71v6l2 2m-7 2a2 2 0 0 1-2 2a2 2 0 0 1-2-2"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
     </div>
   </nav>
 </div>
@@ -275,33 +167,6 @@ exports[`Storyshots TopBar Two Cluster 1`] = `
           />
         </button>
       </div>
-      <button
-        aria-controls=""
-        aria-haspopup="true"
-        aria-label="Show notifications"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          height="1em"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <path
-            d="M21 19v1H3v-1l2-2v-6c0-3.1 2.03-5.83 5-6.71V4a2 2 0 0 1 2-2a2 2 0 0 1 2 2v.29c2.97.88 5 3.61 5 6.71v6l2 2m-7 2a2 2 0 0 1-2 2a2 2 0 0 1-2-2"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
       <button
         aria-controls="primary-user-menu"
         aria-haspopup="true"


### PR DESCRIPTION
There's a number of problems with Notifications. With some clusters the number of warnings makes it not useful. Because they keep showing new notifications over and over again.

The idea is to disable it for now, and revisit it again once we can prove that it is working well.

Related to this issue:
- https://github.com/headlamp-k8s/headlamp/issues/1807
- https://github.com/headlamp-k8s/headlamp/issues/1853

