### PR TITLE
frontend: Fix success state when adding kubeconfig

### DIFF
--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   headlamp:
     image: ghcr.io/headlamp-k8s/headlamp:v0.20.0
-    command: ["--kubeconfig","/headlamp/config/config", "--port","64446"]
+    command: ["--kubeconfig","/headlamp/config/config", "--port","64446", "--enable-dynamic-clusters"]
     restart: unless-stopped
     volumes:
       - ~/.kube/:/headlamp/config:ro

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { setCluster } from '../../lib/k8s/apiProxy';
-import { setConfig } from '../../redux/configSlice';
+import { setStatelessConfig } from '../../redux/configSlice';
 import { DialogTitle } from '../common/Dialog';
 import Loader from '../common/Loader';
 import { ClusterDialog } from './Chooser';
@@ -145,10 +145,10 @@ function KubeConfigLoader() {
         const selectedClusterConfig = configWithSelectedClusters(fileContent, selectedClusters);
         setCluster({ kubeconfig: btoa(yaml.dump(selectedClusterConfig)) })
           .then(res => {
-            if (res.clusters.length > 0) {
-              dispatch(setConfig(res));
-              setState(Step.Success);
+            if (res?.clusters?.length > 0) {
+              dispatch(setStatelessConfig(res));
             }
+            setState(Step.Success);
           })
           .catch(e => {
             console.debug('Error setting up clusters from kubeconfig:', e);

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1600,7 +1600,19 @@ export async function setCluster(clusterReq: ClusterRequest) {
 
   if (kubeconfig) {
     await storeStatelessClusterKubeconfig(kubeconfig);
-    return;
+    // We just send parsed kubeconfig from the backend to the frontend.
+    return request(
+      '/parseKubeConfig',
+      {
+        method: 'POST',
+        body: JSON.stringify(clusterReq),
+        headers: {
+          ...JSON_HEADERS,
+        },
+      },
+      false,
+      false
+    );
   }
 
   return request(


### PR DESCRIPTION
The way we were adding clusters previously (before the stateless
clusters) meant we received the configuration when we added a
cluster. After stateless clusters, that same call to add a cluster
in the frontend doesn't return a response. This triggered an
exception which meant the UI assumed there was an issue with setting
up the cluster but that was false.

fixes #1831
