### PR TITLE
backend: Fix plugin paths when base-url is set

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -310,13 +310,13 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	logger.Log(logger.LevelInfo, nil, nil, "Helm support: "+fmt.Sprint(config.enableHelm))
 	logger.Log(logger.LevelInfo, nil, nil, "Proxy URLs: "+fmt.Sprint(config.proxyURLs))
 
-	plugins.PopulatePluginsCache(config.baseURL, config.staticPluginDir, config.pluginDir, config.cache)
+	plugins.PopulatePluginsCache(config.staticPluginDir, config.pluginDir, config.cache)
 
 	if !config.useInCluster {
 		// in-cluster mode is unlikely to want reloading plugins.
 		pluginEventChan := make(chan string)
 		go plugins.Watch(config.pluginDir, pluginEventChan)
-		go plugins.HandlePluginEvents(config.baseURL, config.staticPluginDir, config.pluginDir, pluginEventChan, config.cache)
+		go plugins.HandlePluginEvents(config.staticPluginDir, config.pluginDir, pluginEventChan, config.cache)
 		// in-cluster mode is unlikely to want reloading kubeconfig.
 		go kubeconfig.LoadAndWatchFiles(config.kubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig)
 	}

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -77,20 +77,20 @@ func periodicallyWatchSubfolders(watcher *fsnotify.Watcher, path string, interva
 	}
 }
 
-// GeneratePluginPaths takes the basePath, staticPluginDir and pluginDir and returns a list of plugin paths.
-func GeneratePluginPaths(basePath string, staticPluginDir string, pluginDir string) ([]string, error) {
+// GeneratePluginPaths takes the staticPluginDir and pluginDir and returns a list of plugin paths.
+func GeneratePluginPaths(staticPluginDir string, pluginDir string) ([]string, error) {
 	var pluginListURLStatic []string
 
 	if staticPluginDir != "" {
 		var err error
 
-		pluginListURLStatic, err = pluginBasePathListForDir(staticPluginDir, filepath.Join(basePath, "static-plugins"))
+		pluginListURLStatic, err = pluginBasePathListForDir(staticPluginDir, "static-plugins")
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	pluginListURL, err := pluginBasePathListForDir(pluginDir, filepath.Join(basePath, "plugins"))
+	pluginListURL, err := pluginBasePathListForDir(pluginDir, "plugins")
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func pluginBasePathListForDir(pluginDir string, baseURL string) ([]string, error
 
 // HandlePluginEvents handles the plugin events by updating the plugin list
 // and plugin refresh key in the cache.
-func HandlePluginEvents(basePath, staticPluginDir, pluginDir string,
+func HandlePluginEvents(staticPluginDir, pluginDir string,
 	notify <-chan string, cache cache.Cache[interface{}],
 ) {
 	for range notify {
@@ -163,7 +163,7 @@ func HandlePluginEvents(basePath, staticPluginDir, pluginDir string,
 		}
 
 		// generate the plugin list
-		pluginList, err := GeneratePluginPaths(basePath, staticPluginDir, pluginDir)
+		pluginList, err := GeneratePluginPaths(staticPluginDir, pluginDir)
 		if err != nil && !os.IsNotExist(err) {
 			logger.Log(logger.LevelError, nil, err, "generating plugins path")
 		}
@@ -176,7 +176,7 @@ func HandlePluginEvents(basePath, staticPluginDir, pluginDir string,
 }
 
 // PopulatePluginsCache populates the plugin list and plugin refresh key in the cache.
-func PopulatePluginsCache(basePath, staticPluginDir, pluginDir string, cache cache.Cache[interface{}]) {
+func PopulatePluginsCache(staticPluginDir, pluginDir string, cache cache.Cache[interface{}]) {
 	// set the plugin refresh key to false
 	err := cache.Set(context.Background(), PluginRefreshKey, false)
 	if err != nil {
@@ -185,10 +185,10 @@ func PopulatePluginsCache(basePath, staticPluginDir, pluginDir string, cache cac
 	}
 
 	// generate the plugin list
-	pluginList, err := GeneratePluginPaths(basePath, staticPluginDir, pluginDir)
+	pluginList, err := GeneratePluginPaths(staticPluginDir, pluginDir)
 	if err != nil && !os.IsNotExist(err) {
 		logger.Log(logger.LevelError,
-			map[string]string{"basePath": basePath, "staticPluginDir": staticPluginDir, "pluginDir": pluginDir},
+			map[string]string{"staticPluginDir": staticPluginDir, "pluginDir": pluginDir},
 			err, "generating plugins path")
 	}
 

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -111,22 +111,16 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 		_, err = os.Create(packageJSONPath)
 		require.NoError(t, err)
 
-		// test without basePath
-		pathList, err := plugins.GeneratePluginPaths("", "", testDirName)
+		pathList, err := plugins.GeneratePluginPaths("", testDirName)
 		require.NoError(t, err)
 		require.Contains(t, pathList, "plugins/"+subDirName)
-
-		// test with basePath
-		pathList, err = plugins.GeneratePluginPaths("/test", "", testDirName)
-		require.NoError(t, err)
-		require.Contains(t, pathList, "/test/plugins/"+subDirName)
 
 		// delete the sub directory
 		err = os.RemoveAll(subDir)
 		require.NoError(t, err)
 
 		// test without any valid plugin
-		pathList, err = plugins.GeneratePluginPaths("", "", testDirName)
+		pathList, err = plugins.GeneratePluginPaths("", testDirName)
 		require.NoError(t, err)
 		require.Empty(t, pathList)
 	})
@@ -147,22 +141,16 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 		_, err = os.Create(packageJSONPath)
 		require.NoError(t, err)
 
-		// test without basePath
-		pathList, err := plugins.GeneratePluginPaths("", testDirName, "")
+		pathList, err := plugins.GeneratePluginPaths(testDirName, "")
 		require.NoError(t, err)
 		require.Contains(t, pathList, "static-plugins/"+subDirName)
-
-		// test with basePath
-		pathList, err = plugins.GeneratePluginPaths("/test", testDirName, "")
-		require.NoError(t, err)
-		require.Contains(t, pathList, "/test/static-plugins/"+subDirName)
 
 		// delete the sub directory
 		err = os.RemoveAll(subDir)
 		require.NoError(t, err)
 
 		// test without any valid plugin
-		pathList, err = plugins.GeneratePluginPaths("", testDirName, "")
+		pathList, err = plugins.GeneratePluginPaths(testDirName, "")
 		require.NoError(t, err)
 		require.Empty(t, pathList)
 	})
@@ -180,7 +168,7 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 		require.NoError(t, err)
 
 		// test with file as plugin Dir
-		pathList, err := plugins.GeneratePluginPaths("", fileName, "")
+		pathList, err := plugins.GeneratePluginPaths(fileName, "")
 		assert.Error(t, err)
 		assert.Nil(t, pathList)
 	})
@@ -225,7 +213,7 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	// create cache
 	ch := cache.New[interface{}]()
 
-	go plugins.HandlePluginEvents("", "", testDirPath, events, ch)
+	go plugins.HandlePluginEvents("", testDirPath, events, ch)
 
 	// plugin list key should be empty
 	pluginList, err := ch.Get(context.Background(), plugins.PluginListKey)
@@ -301,7 +289,7 @@ func TestPopulatePluginsCache(t *testing.T) {
 	ch := cache.New[interface{}]()
 
 	// call PopulatePluginsCache
-	plugins.PopulatePluginsCache("", "", "", ch)
+	plugins.PopulatePluginsCache("", "", ch)
 
 	// check if the plugin refresh key is set to false
 	pluginRefresh, err := ch.Get(context.Background(), plugins.PluginRefreshKey)


### PR DESCRIPTION
this patch removes the base-url that was appended
to the /plugins response as the base path is
added automatically by the frontend