### PR TITLE
frontend: Add live update e2e test

### DIFF
--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -12,7 +12,8 @@
         "yaml": "^2.3.4"
       },
       "devDependencies": {
-        "@playwright/test": "^1.42"
+        "@playwright/test": "^1.42.1",
+        "@types/node": "^20.12.2"
       }
     },
     "node_modules/@playwright/test": {
@@ -28,6 +29,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
+      "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/fsevents": {
@@ -74,6 +84,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/yaml": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
@@ -91,6 +107,15 @@
       "dev": true,
       "requires": {
         "playwright": "1.42.1"
+      }
+    },
+    "@types/node": {
+      "version": "20.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
+      "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
       }
     },
     "fsevents": {
@@ -114,6 +139,12 @@
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
       "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "yaml": {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -8,7 +8,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.42"
+    "@playwright/test": "^1.42.1",
+    "@types/node": "^20.12.2"
   },
   "dependencies": {
     "yaml": "^2.3.4"

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -1,0 +1,38 @@
+import { test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+import { podsPage } from './podsPage';
+
+test('multi tab create delete pod', async ({ browser, }) => {
+
+    // This test may be slow to create and delete a pod
+    test.setTimeout(60000);
+    const name = 'examplepodlol';
+
+    const instance1 = await browser.newContext();
+    const page1 = await instance1.newPage();
+    const window1 = new HeadlampPage(page1);
+    await window1.authenticate();
+
+    const page2 = await instance1.newPage();
+    const window2 = new HeadlampPage(page2);
+    await window2.navigateTopage('/c/main/pods', /Pods/);
+
+    // if no pod permission, return
+    const content1 = await page1.content();
+    const content2 = await page2.content();
+    if (!content1.includes('Pods') || !content1.includes('href="/c/main/pods') || !content2.includes('Pods') || !content2.includes('href="/c/main/pods')) {
+        return;
+    }
+
+    const realtimeUpdate1 = new podsPage(page1);
+    const realtimeUpdate2 = new podsPage(page2);
+
+    await realtimeUpdate1.navigateToPods();
+
+    await realtimeUpdate1.createPod(name);
+    await realtimeUpdate2.confirmPodCreation(name);
+
+    await realtimeUpdate1.deletePod(name);
+    await realtimeUpdate2.confirmPodDeletion(name);
+
+});

--- a/e2e-tests/tests/podsPage.ts
+++ b/e2e-tests/tests/podsPage.ts
@@ -1,0 +1,96 @@
+import { Page, expect, } from "@playwright/test";
+
+export class podsPage {
+    constructor(private page: Page) { }
+
+    async navigateToPods(baseURL?: string) {
+
+        await this.page.click('span:has-text("Workloads")');
+        await this.page.waitForLoadState("load");
+        await this.page.waitForSelector('span:has-text("Pods")');
+        await this.page.waitForLoadState("load");
+        await this.page.click('span:has-text("Pods")');
+
+        console.log('Now on the pods page')
+    }
+
+    async createPod(name) {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+    `;
+        const page = this.page;
+
+        // If the pod already exists, return.
+        // This makes it a bit more resilient to flakiness.
+        const pageContent = await this.page.content();
+        if (pageContent.includes(name)) {
+            return;
+        }
+
+        await expect(page.getByRole('button', { name: "Create" })).toBeVisible()
+        await page.getByRole('button', { name: "Create" }).click()
+
+        await page.waitForLoadState("load");
+
+        await expect(page.getByText("Use minimal editor")).toBeVisible()
+        await page.getByText("Use minimal editor").click()
+
+        await page.waitForLoadState("load");
+        await page.fill('textarea[aria-label="yaml Code"]', yaml);
+
+        await expect(page.getByRole('button', { name: "Apply" })).toBeVisible()
+        await page.getByRole('button', { name: "Apply" }).click()
+
+        await page.waitForSelector(`text=Applied ${name}`);
+        await expect(page.getByRole('link', { name: name })).toBeVisible()
+
+        console.log(`Created pod ${name}`)
+
+    }
+
+    async deletePod(name) {
+        const page = this.page;
+
+        await page.click('span:has-text("Pods")');
+        await page.waitForLoadState("load");
+        await page.waitForSelector(`a:has-text("${name}")`);
+
+        await expect(page.getByRole('link', { name: name })).toBeVisible()
+        await page.getByRole('link', { name: name }).click()
+
+        await expect(page.getByRole('button', { name: "Delete" })).toBeVisible()
+        await page.getByRole('button', { name: "Delete" }).click()
+
+        await page.waitForSelector('text=Are you sure you want to delete this item?');
+
+        await expect(page.getByRole('button', { name: "Yes" })).toBeVisible()
+        await page.getByRole('button', { name: "Yes" }).click()
+
+        await page.waitForSelector(`text=Deleted item ${name}`);
+
+        console.log(`Deleted pod ${name}`)
+    }
+
+    async confirmPodCreation(name) {
+        await this.page.waitForSelector(`a:has-text("${name}")`);
+        await expect(this.page.locator(`a:has-text("${name}")`)).toBeVisible();
+
+        console.log(`Pod ${name} is running`)
+    }
+
+    async confirmPodDeletion(name) {
+        await this.page.waitForSelector(`a:has-text("${name}")`);
+        await expect(this.page.locator(`a:has-text("${name}")`)).not.toBeVisible();
+
+        console.log(`Pod ${name} is deleted`)
+    }
+}


### PR DESCRIPTION
## Description

fixes #1836

This PR introduces a new Playwright test that validates the functionality of live updates within the application. Specifically, it tests creating a pod and deleting it in the same browser tab, while confirming that these changes are reflected in real-time on new tab. This test ensures that live updates work seamlessly, providing users with accurate and up-to-date information without the need for manual refreshes.

## Changes

- [x] Implemented a new Playwright test script named `realtime update` which opens two instances of the application in separate tabs.
- [x] In the first tab, the script creates a new Kubernetes pod and confirms its presence in the list of pods.
- [x] The script then confirms the new pod's presence the second tab, where it is demonstrating the live update feature.
- [x] Subsequently, the script deletes the pod from the first tab and then confirms that the pod has been removed from the list, again confirming the live update capability.
- [x] Added assertions to ensure that actions performed in one tab are reflected in the other tab in real time.

## Verification

- [x] Conducted multiple runs of the new Playwright test to ensure consistency and reliability of the live update feature across different environments.
- [x] Verified that the test accurately detects the presence and absence of pods in real-time across browser tabs without manual refresh.
- [x] Ensured that the test script handles tab switching, pod creation, and deletion efficiently, providing clear feedback in case of failures.
