### PR TITLE
github: Switch azure login to OIDC connect

### DIFF
--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -60,6 +60,9 @@ jobs:
         if-no-files-found: error
         retention-days: 1
   notarize:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: windows-latest
     needs: build-mac
     if: ${{ inputs.signBinaries }}
@@ -80,11 +83,17 @@ jobs:
       with:
         name: dmgs
         path: ./dmgs
+    - name: Azure login
+      if: ${{ inputs.signBinaries }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.WINDOWS_CLIENT_ID }}
+        tenant-id: ${{ secrets. AZ_TENANT_ID }}
+        subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
     - name: Fetch certificates
       if: ${{ inputs.signBinaries }}
       shell: pwsh
       run: |
-        az login --service-principal -u ${{ secrets.WINDOWS_CLIENT_ID }} -p ${{ secrets.AZ_LOGIN_PASS }}  --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47
         az keyvault secret download --subscription ${{ secrets.AZ_SUBSCRIPTION_ID }} --vault-name headlamp --name HeadlampAuthCert --file c:\HeadlampAuthCert.pfx --encoding base64
         az keyvault secret download --subscription ${{ secrets.AZ_SUBSCRIPTION_ID }} --vault-name headlamp --name ESRPHeadlampReqCert --file c:\HeadlampReqCert.pfx --encoding base64
     - name: Set up certificates

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   build-windows:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
@@ -41,11 +44,17 @@ jobs:
       uses: crazy-max/ghaction-chocolatey@v1
       with:
         args: install make
+    - name: Azure login
+      if: ${{ inputs.signBinaries }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.WINDOWS_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZ_TENANT_ID }}
+        subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
     - name: Fetch certificates
       if: ${{ inputs.signBinaries }}
       shell: pwsh
       run: |
-        az login --service-principal -u ${{ secrets.WINDOWS_CLIENT_ID }} -p ${{ secrets.AZ_LOGIN_PASS }}  --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47
         az keyvault secret download --subscription ${{ secrets.AZ_SUBSCRIPTION_ID }} --vault-name headlamp --name HeadlampAuthCert --file c:\HeadlampAuthCert.pfx --encoding base64
         az keyvault secret download --subscription ${{ secrets.AZ_SUBSCRIPTION_ID }} --vault-name headlamp --name ESRPHeadlampReqCert --file c:\HeadlampReqCert.pfx --encoding base64
     - name: Set up certificates


### PR DESCRIPTION
From @jepio:
Github issues every job a token, and a service principal in Azure can be configured to trust that token. This is called "federated credentials" or OpenID Connect. Switch to using the azure/login action and enable write access on the id-token for the jobs that need it.

Preserve the default `contents: read` permission and move the tenant id to a secret.