### PR TITLE
Dockerfile: Fix issue with copying git folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ FROM --platform=${BUILDPLATFORM} node:18 as frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.
-COPY ./.git /headlamp/.git
+COPY .git/ ./headlamp/.git/
+
 COPY app/package.json /headlamp/app/package.json
 
 # Keep npm install separated so source changes don't trigger install


### PR DESCRIPTION
This was the error that was coming up:

```
ERROR: failed to solve: source can't be a git ref for COPY
```

It was causing the container image CI job to fail, and `make image` to fail.

Fixes #1903