### PR TITLE
Fix event time displaying in certain k8s flavors

### DIFF
--- a/frontend/src/components/cluster/Overview.stories.tsx
+++ b/frontend/src/components/cluster/Overview.stories.tsx
@@ -70,6 +70,66 @@ Event.useList = () => {
       },
       type: 'Warning',
     },
+    {
+      apiVersion: 'v1',
+      kind: 'Event',
+      metadata: {
+        name: 'nginx-deployment-12345',
+        namespace: 'default',
+        creationTimestamp: '2024-02-12T20:07:10Z',
+        uid: 'b123456',
+        resourceVersion: '1',
+      },
+      involvedObject: {
+        kind: 'Pod',
+        name: 'nginx-deployment-1234567890-abcde',
+        namespace: 'default',
+        uid: 'b1234',
+      },
+      reason: 'FailedGetResourceMetric',
+      message: 'failed to get cpu utilization: missing request for cpu',
+      source: {
+        component: 'horizontal-pod-autoscaler',
+      },
+      firstTimestamp: '2024-02-13T14:42:17Z',
+      lastTimestamp: '2024-02-13T14:42:17Z',
+      type: 'Warning',
+      series: {
+        count: 10,
+        lastObservedTime: '2024-02-13T14:42:17Z',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Event',
+      metadata: {
+        name: 'nginx-deployment-12346',
+        namespace: 'default',
+        creationTimestamp: '2024-02-12T20:07:10Z',
+        uid: 'abc123456',
+        resourceVersion: '1',
+      },
+      involvedObject: {
+        kind: 'Pod',
+        name: 'nginx-deployment-abcd-1234567890',
+        namespace: 'default',
+        uid: 'b1234',
+      },
+      reason: 'FailedGetResourceMetric',
+      message: 'failed to get cpu utilization: missing request for cpu',
+      source: {
+        component: 'horizontal-pod-autoscaler',
+      },
+      firstTimestamp: null,
+      lastTimestamp: null,
+      type: 'Warning',
+      series: {
+        count: 10,
+        lastObservedTime: '2024-02-13T15:42:17Z',
+      },
+      reportingComponent: '',
+      reportingInstance: '',
+    },
   ].map((data: any) => new Event(data));
   return [objList, null, () => {}, () => {}] as any;
 };

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -185,12 +185,7 @@ function EventsSection() {
         },
         {
           label: t('Last Seen'),
-          getter: event => (
-            <DateLabel
-              date={event.lastTimestamp || event.metadata.creationTimestamp}
-              format="mini"
-            />
-          ),
+          getter: event => <DateLabel date={event.lastOccurrence} format="mini" />,
           cellProps: { style: { textAlign: 'right' } },
           gridTemplate: 'minmax(150px, 0.5fr)',
           sort: (e1: Event, e2: Event) => {

--- a/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
@@ -506,7 +506,7 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                       <span
                         class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
                       >
-                        Only warnings (1)
+                        Only warnings (3)
                       </span>
                     </label>
                   </div>
@@ -687,6 +687,144 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                   <tbody
                     class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
                   >
+                    <tr
+                      class="MuiTableRow-root css-73w7uv-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        Pod
+                      </td>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                        scope="row"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          nginx-deployment-1234567890-abcde
+                        </a>
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          default
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        <span
+                          aria-label="FailedGetResourceMetric"
+                          class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-19rs0eg-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                          style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                        >
+                          FailedGetResourceMetric
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-k008qs"
+                        >
+                          <label
+                            class="makeStyles-fullText"
+                            id="b123456"
+                          >
+                            failed to get cpu utilization: missing request for cpu
+                          </label>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                        style="text-align: right;"
+                      >
+                        <p
+                          aria-label="2024-02-13T14:42:17.000Z"
+                          class="MuiTypography-root MuiTypography-body1 makeStyles-noWrap makeStyles-display css-1ezega9-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          3mo
+                          <span />
+                        </p>
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-73w7uv-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        Pod
+                      </td>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                        scope="row"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          nginx-deployment-abcd-1234567890
+                        </a>
+                      </th>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          default
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        <span
+                          aria-label="FailedGetResourceMetric"
+                          class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-19rs0eg-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                          style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                        >
+                          FailedGetResourceMetric
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-k008qs"
+                        >
+                          <label
+                            class="makeStyles-fullText"
+                            id="abc123456"
+                          >
+                            failed to get cpu utilization: missing request for cpu
+                          </label>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                        style="text-align: right;"
+                      >
+                        <p
+                          aria-label="2024-02-13T15:42:17.000Z"
+                          class="MuiTypography-root MuiTypography-body1 makeStyles-noWrap makeStyles-display css-1ezega9-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          3mo
+                          <span />
+                        </p>
+                      </td>
+                    </tr>
                     <tr
                       class="MuiTableRow-root css-73w7uv-MuiTableRow-root"
                     >

--- a/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.stories.storyshot
@@ -747,7 +747,7 @@ exports[`Storyshots cluster/Overview Events 1`] = `
                         style="text-align: right;"
                       >
                         <p
-                          aria-label="2023-07-12T20:07:10.000Z"
+                          aria-label="2023-07-13T14:42:17.000Z"
                           class="MuiTypography-root MuiTypography-body1 makeStyles-noWrap makeStyles-display css-1ezega9-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -23,7 +23,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
 
   async function fetchEvents() {
     const events = await Event.objectEvents(props.object);
-    setEvents(events);
+    setEvents(events.map((e: KubeEvent) => new Event(e)));
   }
   const { t } = useTranslation(['translation', 'glossary']);
 
@@ -69,17 +69,17 @@ export default function ObjectEventList(props: ObjectEventListProps) {
             label: t('Age'),
             getter: item => {
               if (item.count > 1) {
-                return `${timeAgo(item.lastTimestamp)} (${item.count} times over ${timeAgo(
-                  item.firstTimestamp
+                return `${timeAgo(item.lastOccurrence)} (${item.count} times over ${timeAgo(
+                  item.firstOccurrence
                 )})`;
               }
-              const eventDate = timeAgo(item.lastTimestamp, { format: 'mini' });
+              const eventDate = timeAgo(item.lastOccurrence, { format: 'mini' });
               let label: string;
               if (item.count > 1) {
                 label = t('{{ eventDate }} ({{ count }} times since {{ firstEventDate }})', {
                   eventDate,
                   count: item.count,
-                  firstEventDate: timeAgo(item.firstTimestamp),
+                  firstEventDate: timeAgo(item.firstOccurrence),
                 });
               } else {
                 label = eventDate;
@@ -88,7 +88,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
               return (
                 <HoverInfoLabel
                   label={label}
-                  hoverInfo={localeDate(item.lastTimestamp)}
+                  hoverInfo={localeDate(item.lastOccurrence)}
                   icon="mdi:calendar"
                 />
               );

--- a/frontend/src/components/pod/PodDetails.stories.tsx
+++ b/frontend/src/components/pod/PodDetails.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, Story } from '@storybook/react';
 import { KubeObjectClass } from '../../lib/k8s/cluster';
+import Event from '../../lib/k8s/event';
 import Pod, { KubePod } from '../../lib/k8s/pod';
 import { TestContext } from '../../test';
 import PodDetails from './Details';
@@ -32,11 +33,12 @@ export default {
 interface MockerStory {
   useGet?: KubeObjectClass['useGet'];
   useList?: KubeObjectClass['useList'];
+  objectEventsFunc?: typeof Event.objectEvents;
   podName: string;
 }
 
 const Template: Story<MockerStory> = args => {
-  const { useGet, useList, podName } = args;
+  const { useGet, useList, podName, objectEventsFunc } = args;
 
   if (!!useGet) {
     Pod.useGet = args.useGet!;
@@ -44,9 +46,15 @@ const Template: Story<MockerStory> = args => {
   if (!!useList) {
     Pod.useList = args.useList!;
   }
+  if (!!objectEventsFunc) {
+    Event.objectEvents = objectEventsFunc!;
+  }
 
   return (
-    <TestContext routerMap={{ namespace: 'default', name: podName }}>
+    <TestContext
+      routerMap={{ namespace: 'default', name: podName }}
+      withObjectEvents={!objectEventsFunc}
+    >
       <PodDetails />;
     </TestContext>
   );
@@ -68,6 +76,40 @@ export const Error = Template.bind({});
 Error.args = {
   useGet: usePhonyGet,
   podName: 'terminated',
+  objectEventsFunc: () =>
+    Promise.resolve([
+      {
+        apiVersion: 'v1',
+        kind: 'Event',
+        metadata: {
+          name: 'nginx-deployment-12346',
+          namespace: 'default',
+          creationTimestamp: '2024-02-12T20:07:10Z',
+          uid: 'abc123456',
+          resourceVersion: '1',
+        },
+        involvedObject: {
+          kind: 'Pod',
+          name: 'nginx-deployment-abcd-1234567890',
+          namespace: 'default',
+          uid: 'b1234',
+        },
+        reason: 'FailedGetResourceMetric',
+        message: 'failed to get cpu utilization: missing request for cpu',
+        source: {
+          component: 'horizontal-pod-autoscaler',
+        },
+        firstTimestamp: null,
+        lastTimestamp: null,
+        type: 'Warning',
+        series: {
+          count: 10,
+          lastObservedTime: '2024-02-13T15:42:17Z',
+        },
+        reportingComponent: '',
+        reportingInstance: '',
+      },
+    ]),
 };
 
 export const LivenessFailed = Template.bind({});

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -922,17 +922,17 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     >
-                      Normal
+                      Warning
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     >
-                      Created
+                      FailedGetResourceMetric
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     >
-                      kubelet
+                      horizontal-pod-autoscaler
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
@@ -942,23 +942,16 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                       >
                         <label
                           class="makeStyles-fullText"
-                          id=""
+                          id="abc123456"
                         >
-                          Created
+                          failed to get cpu utilization: missing request for cpu
                         </label>
                       </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     >
-                      <p
-                        aria-label="2021-03-01T00:00:00.000Z"
-                        class="MuiTypography-root MuiTypography-body1 makeStyles-noWrap makeStyles-display css-1ezega9-MuiTypography-root"
-                        data-mui-internal-clone-element="true"
-                      >
-                        3mo
-                        <span />
-                      </p>
+                      3 months (10 times over 3 months)
                     </td>
                   </tr>
                 </tbody>

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -61,6 +61,31 @@ class Event extends makeKubeObject<KubeEvent>('Event') {
     return this.getValue('message');
   }
 
+  get lastOccurrence() {
+    const series = this.getValue('series');
+    if (!!series) {
+      return series.lastObservedTime;
+    }
+
+    const lastTimestamp = this.getValue('lastTimestamp');
+    if (!!lastTimestamp) {
+      return lastTimestamp;
+    }
+
+    const eventTime = this.getValue('eventTime');
+    if (!!eventTime) {
+      return eventTime;
+    }
+
+    const firstTimestamp = this.getValue('firstTimestamp');
+    if (!!firstTimestamp) {
+      return firstTimestamp;
+    }
+
+    const creationTimestamp = this.metadata.creationTimestamp;
+    return creationTimestamp;
+  }
+
   static async objectEvents(object: KubeObject) {
     const namespace = object.metadata.namespace;
     const name = object.metadata.name;

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -61,6 +61,19 @@ class Event extends makeKubeObject<KubeEvent>('Event') {
     return this.getValue('message');
   }
 
+  get source() {
+    return this.getValue('source');
+  }
+
+  get count() {
+    const series = this.getValue('series');
+    if (!!series) {
+      return series.count;
+    }
+
+    return this.getValue('count');
+  }
+
   get lastOccurrence() {
     const series = this.getValue('series');
     if (!!series) {
@@ -78,6 +91,21 @@ class Event extends makeKubeObject<KubeEvent>('Event') {
     }
 
     const firstTimestamp = this.getValue('firstTimestamp');
+    if (!!firstTimestamp) {
+      return firstTimestamp;
+    }
+
+    const creationTimestamp = this.metadata.creationTimestamp;
+    return creationTimestamp;
+  }
+
+  get firstOccurrence() {
+    const eventTime = this.getValue('eventTime');
+    if (!!eventTime) {
+      return eventTime;
+    }
+
+    const firstTimestamp = this.firstTimestamp;
     if (!!firstTimestamp) {
       return firstTimestamp;
     }

--- a/frontend/src/test/index.tsx
+++ b/frontend/src/test/index.tsx
@@ -10,13 +10,21 @@ export type TestContextProps = PropsWithChildren<{
   store?: ReturnType<typeof configureStore>;
   routerMap?: Record<string, string>;
   urlPrefix?: string;
+  withObjectEvents?: boolean;
   urlSearchParams?: {
     [key: string]: string;
   };
 }>;
 
 export function TestContext(props: TestContextProps) {
-  const { store, routerMap, urlPrefix = '', urlSearchParams, children } = props;
+  const {
+    store,
+    routerMap,
+    urlPrefix = '',
+    urlSearchParams,
+    withObjectEvents = true,
+    children,
+  } = props;
   let url = '';
   let routePath = '';
 
@@ -36,21 +44,23 @@ export function TestContext(props: TestContextProps) {
     url += '?' + new URLSearchParams(urlSearchParams).toString();
   }
 
-  // override Event.objectEvents to return phony events array
-  Event.objectEvents = () =>
-    Promise.resolve([
-      {
-        type: 'Normal',
-        reason: 'Created',
-        message: 'Created',
-        source: {
-          component: 'kubelet',
+  if (withObjectEvents) {
+    // override Event.objectEvents to return phony events array
+    Event.objectEvents = () =>
+      Promise.resolve([
+        {
+          type: 'Normal',
+          reason: 'Created',
+          message: 'Created',
+          source: {
+            component: 'kubelet',
+          },
+          firstTimestamp: '2021-03-01T00:00:00Z',
+          lastTimestamp: '2021-03-01T00:00:00Z',
+          count: 1,
         },
-        firstTimestamp: '2021-03-01T00:00:00Z',
-        lastTimestamp: '2021-03-01T00:00:00Z',
-        count: 1,
-      },
-    ]);
+      ]);
+  }
 
   return (
     <Provider store={store || defaultStore}>


### PR DESCRIPTION
fixes #1787 

This PR takes into consideration the kube Event's eventTime and series before checking the lastTimestamp/firstTimestamp, as some kubernetes flavors apparently don't use the latter.

@lijianzhi01 , can you test if this fixes your issues?