### PR TITLE
frontend: Fix lint-staged linting/formatting for e2e-tests

### DIFF
--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -2,37 +2,40 @@ import { test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { podsPage } from './podsPage';
 
-test('multi tab create delete pod', async ({ browser, }) => {
+test('multi tab create delete pod', async ({ browser }) => {
+  // This test may be slow to create and delete a pod
+  test.setTimeout(60000);
+  const name = 'examplepodlol';
 
-    // This test may be slow to create and delete a pod
-    test.setTimeout(60000);
-    const name = 'examplepodlol';
+  const instance1 = await browser.newContext();
+  const page1 = await instance1.newPage();
+  const window1 = new HeadlampPage(page1);
+  await window1.authenticate();
 
-    const instance1 = await browser.newContext();
-    const page1 = await instance1.newPage();
-    const window1 = new HeadlampPage(page1);
-    await window1.authenticate();
+  const page2 = await instance1.newPage();
+  const window2 = new HeadlampPage(page2);
+  await window2.navigateTopage('/c/main/pods', /Pods/);
 
-    const page2 = await instance1.newPage();
-    const window2 = new HeadlampPage(page2);
-    await window2.navigateTopage('/c/main/pods', /Pods/);
+  // if no pod permission, return
+  const content1 = await page1.content();
+  const content2 = await page2.content();
+  if (
+    !content1.includes('Pods') ||
+    !content1.includes('href="/c/main/pods') ||
+    !content2.includes('Pods') ||
+    !content2.includes('href="/c/main/pods')
+  ) {
+    return;
+  }
 
-    // if no pod permission, return
-    const content1 = await page1.content();
-    const content2 = await page2.content();
-    if (!content1.includes('Pods') || !content1.includes('href="/c/main/pods') || !content2.includes('Pods') || !content2.includes('href="/c/main/pods')) {
-        return;
-    }
+  const realtimeUpdate1 = new podsPage(page1);
+  const realtimeUpdate2 = new podsPage(page2);
 
-    const realtimeUpdate1 = new podsPage(page1);
-    const realtimeUpdate2 = new podsPage(page2);
+  await realtimeUpdate1.navigateToPods();
 
-    await realtimeUpdate1.navigateToPods();
+  await realtimeUpdate1.createPod(name);
+  await realtimeUpdate2.confirmPodCreation(name);
 
-    await realtimeUpdate1.createPod(name);
-    await realtimeUpdate2.confirmPodCreation(name);
-
-    await realtimeUpdate1.deletePod(name);
-    await realtimeUpdate2.confirmPodDeletion(name);
-
+  await realtimeUpdate1.deletePod(name);
+  await realtimeUpdate2.confirmPodDeletion(name);
 });

--- a/e2e-tests/tests/podsPage.ts
+++ b/e2e-tests/tests/podsPage.ts
@@ -1,21 +1,20 @@
-import { expect,Page,  } from "@playwright/test";
+import { expect, Page } from '@playwright/test';
 
 export class podsPage {
-    constructor(private page: Page) { }
+  constructor(private page: Page) {}
 
-    async navigateToPods() {
+  async navigateToPods() {
+    await this.page.click('span:has-text("Workloads")');
+    await this.page.waitForLoadState('load');
+    await this.page.waitForSelector('span:has-text("Pods")');
+    await this.page.waitForLoadState('load');
+    await this.page.click('span:has-text("Pods")');
 
-        await this.page.click('span:has-text("Workloads")');
-        await this.page.waitForLoadState("load");
-        await this.page.waitForSelector('span:has-text("Pods")');
-        await this.page.waitForLoadState("load");
-        await this.page.click('span:has-text("Pods")');
+    console.log('Now on the pods page');
+  }
 
-        console.log('Now on the pods page')
-    }
-
-    async createPod(name) {
-        const yaml = `
+  async createPod(name) {
+    const yaml = `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -27,70 +26,69 @@ spec:
     ports:
     - containerPort: 80
     `;
-        const page = this.page;
+    const page = this.page;
 
-        // If the pod already exists, return.
-        // This makes it a bit more resilient to flakiness.
-        const pageContent = await this.page.content();
-        if (pageContent.includes(name)) {
-            return;
-        }
-
-        await expect(page.getByRole('button', { name: "Create" })).toBeVisible()
-        await page.getByRole('button', { name: "Create" }).click()
-
-        await page.waitForLoadState("load");
-
-        await expect(page.getByText("Use minimal editor")).toBeVisible()
-        await page.getByText("Use minimal editor").click()
-
-        await page.waitForLoadState("load");
-        await page.fill('textarea[aria-label="yaml Code"]', yaml);
-
-        await expect(page.getByRole('button', { name: "Apply" })).toBeVisible()
-        await page.getByRole('button', { name: "Apply" }).click()
-
-        await page.waitForSelector(`text=Applied ${name}`);
-        await expect(page.getByRole('link', { name: name })).toBeVisible()
-
-        console.log(`Created pod ${name}`)
-
+    // If the pod already exists, return.
+    // This makes it a bit more resilient to flakiness.
+    const pageContent = await this.page.content();
+    if (pageContent.includes(name)) {
+      return;
     }
 
-    async deletePod(name) {
-        const page = this.page;
+    await expect(page.getByRole('button', { name: 'Create' })).toBeVisible();
+    await page.getByRole('button', { name: 'Create' }).click();
 
-        await page.click('span:has-text("Pods")');
-        await page.waitForLoadState("load");
-        await page.waitForSelector(`a:has-text("${name}")`);
+    await page.waitForLoadState('load');
 
-        await expect(page.getByRole('link', { name: name })).toBeVisible()
-        await page.getByRole('link', { name: name }).click()
+    await expect(page.getByText('Use minimal editor')).toBeVisible();
+    await page.getByText('Use minimal editor').click();
 
-        await expect(page.getByRole('button', { name: "Delete" })).toBeVisible()
-        await page.getByRole('button', { name: "Delete" }).click()
+    await page.waitForLoadState('load');
+    await page.fill('textarea[aria-label="yaml Code"]', yaml);
 
-        await page.waitForSelector('text=Are you sure you want to delete this item?');
+    await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
+    await page.getByRole('button', { name: 'Apply' }).click();
 
-        await expect(page.getByRole('button', { name: "Yes" })).toBeVisible()
-        await page.getByRole('button', { name: "Yes" }).click()
+    await page.waitForSelector(`text=Applied ${name}`);
+    await expect(page.getByRole('link', { name: name })).toBeVisible();
 
-        await page.waitForSelector(`text=Deleted item ${name}`);
+    console.log(`Created pod ${name}`);
+  }
 
-        console.log(`Deleted pod ${name}`)
-    }
+  async deletePod(name) {
+    const page = this.page;
 
-    async confirmPodCreation(name) {
-        await this.page.waitForSelector(`a:has-text("${name}")`);
-        await expect(this.page.locator(`a:has-text("${name}")`)).toBeVisible();
+    await page.click('span:has-text("Pods")');
+    await page.waitForLoadState('load');
+    await page.waitForSelector(`a:has-text("${name}")`);
 
-        console.log(`Pod ${name} is running`)
-    }
+    await expect(page.getByRole('link', { name: name })).toBeVisible();
+    await page.getByRole('link', { name: name }).click();
 
-    async confirmPodDeletion(name) {
-        await this.page.waitForSelector(`a:has-text("${name}")`);
-        await expect(this.page.locator(`a:has-text("${name}")`)).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+    await page.getByRole('button', { name: 'Delete' }).click();
 
-        console.log(`Pod ${name} is deleted`)
-    }
+    await page.waitForSelector('text=Are you sure you want to delete this item?');
+
+    await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
+    await page.getByRole('button', { name: 'Yes' }).click();
+
+    await page.waitForSelector(`text=Deleted item ${name}`);
+
+    console.log(`Deleted pod ${name}`);
+  }
+
+  async confirmPodCreation(name) {
+    await this.page.waitForSelector(`a:has-text("${name}")`);
+    await expect(this.page.locator(`a:has-text("${name}")`)).toBeVisible();
+
+    console.log(`Pod ${name} is running`);
+  }
+
+  async confirmPodDeletion(name) {
+    await this.page.waitForSelector(`a:has-text("${name}")`);
+    await expect(this.page.locator(`a:has-text("${name}")`)).not.toBeVisible();
+
+    console.log(`Pod ${name} is deleted`);
+  }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -153,6 +153,12 @@
     ],
     "../plugins/examples/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
       "prettier --config package.json --write"
+    ],
+    "../e2e-tests/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier --config package.json --write"
+    ],
+    "../e2e-tests/**/*.{ts,tsx}": [
+      "eslint -c package.json --fix --resolve-plugins-relative-to ."
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
The e2e-tests folder was not included in the "lint-staged" pre-commit hook for formatting or linting.

### How to test

Make a change in the e2e-tests/tests/ folder which would trigger a lint issue (resort imports to something wrong) or a formatting issue (add some incorrect indentation). These should be fixed for you when you try committing the same as happens in frontend/ or app/.