### PR TITLE
docs: Fix the link in building plugin page

### DIFF
--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -19,7 +19,7 @@ npm run start
 There's some basic code inside src/index.tsx.
 
 Now run Headlamp (the desktop app or the
-[development version](../index.md##run-the-code)),
+[development version](../_index.md#run-the-code)),
 and your plugin should be loaded.
 
 Using the above commands means that Headlamp will **automatically reload**


### PR DESCRIPTION
The original intent of that link was to point to the "run the code" section of the development page, but index.md wasn't resolving and currently it shows 404. Also extra # is unnecessary. Verified the fix locally  