### PR TITLE
github: Fix permissions so they are minimal

### DIFF
--- a/.github/workflows/app-artifacts-linux.yml
+++ b/.github/workflows/app-artifacts-linux.yml
@@ -8,9 +8,15 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # needed to upload artifacts
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -11,9 +11,17 @@ on:
         description: Notarize app
         default: true
         type: boolean
+
+permissions:
+  contents: read
+
 jobs:
   build-mac:
     runs-on: macos-latest
+    permissions:
+      contents: read
+      secrets: read
+      actions: write # needed to upload artifacts
     steps:
     - uses: actions/checkout@v4
       with:
@@ -61,8 +69,9 @@ jobs:
         retention-days: 1
   notarize:
     permissions:
-      id-token: write
+      id-token: write # For fetching an OpenID Connect (OIDC) token
       contents: read
+      secrets: read
     runs-on: windows-latest
     needs: build-mac
     if: ${{ inputs.signBinaries }}
@@ -135,6 +144,9 @@ jobs:
   stapler:
     runs-on: macos-latest
     needs: notarize
+    permissions:
+      actions: write # for downloading and uploading artifacts
+      contents: read
     if: ${{ inputs.signBinaries }}
     steps:
     - name: Download artifact

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -12,11 +12,15 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     permissions:
-      id-token: write
+      id-token: write # For fetching an OpenID Connect (OIDC) token
       contents: read
+      actions: write # needed to upload artifacts
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -18,6 +18,9 @@ on:
     - 'app/**'
     - 'backend/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  # We need to write a comment for the coverage change message.
-  issues: write
 
 env:
   HEADLAMP_RUN_INTEGRATION_TESTS: true
@@ -16,7 +14,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      issues: write # needed for commenting on PRs for coverage changes
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,15 +23,15 @@ jobs:
     
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.0
-    
+          go-version: '1.22.*'
+
       - name: Install dependencies
         run: |
           cd backend
           go mod download
     
       - name: Start cluster
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@latest
 
       - name: Check cluster status and enable headlamp addon
         run: |
@@ -103,4 +102,4 @@ jobs:
             echo "Pull request raised from a fork. Skipping comment."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -13,6 +13,9 @@ on:
     - Makefile
     - '.github/**'
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -15,17 +15,22 @@ on:
     - Dockerfile.plugins
     - 'e2e-tests/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: build discover and deploy
+    permissions:
+      actions: write # needed to upload artifacts
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
         node-version: 20.x
     - name: Start cluster
-      uses: medyagh/setup-minikube@master
+      uses: medyagh/setup-minikube@latest
       # now you can run kubectl to see the pods in the cluster
     - name: Try the cluster!
       run: kubectl get pods -A

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -13,6 +13,9 @@ on:
         description: 'Container tags (separated by a comma)'
         type: string
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: headlamp-k8s/headlamp
@@ -21,8 +24,7 @@ jobs:
     name: Test building container image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      packages: write # needed for publishing the container image
     steps:
     - name: Check out the repo
       uses: actions/checkout@v4
@@ -71,7 +73,7 @@ jobs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ github.token }}
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/docker-extension-release.yml
+++ b/.github/workflows/docker-extension-release.yml
@@ -6,6 +6,9 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: headlamp/headlamp-docker-extension
@@ -13,6 +16,8 @@ jobs:
   build_and_push_docker_extension:
     name: Build docker extension
     runs-on: ubuntu-latest
+    permissions:
+      secrets: read # needed to fetch docker hub creds
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'X.Y.Z'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     permissions:
@@ -18,7 +21,7 @@ jobs:
       - name: Create Release Draft
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           draft: true
           name: ${{ github.event.inputs.releaseName }}
           body: |

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,6 +18,9 @@ on:
     - 'app/**'
     - 'plugins/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/helm-chart-lint-test.yml
+++ b/.github/workflows/helm-chart-lint-test.yml
@@ -6,6 +6,9 @@ on:
       - charts/**
       - '!charts/**/README.md'
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-22.04
@@ -39,7 +42,7 @@ jobs:
         run: ct lint --config .github/ct.yaml
 
       - name: Setup Minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@latest
 
       - name: Build image & Run chart-testing (install)
         run: |

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,5 +1,7 @@
 name: Release Charts
 
+# See https://github.com/helm/chart-releaser-action
+
 on:
   push:
     branches:
@@ -9,10 +11,14 @@ on:
       - '!charts/**/README.md'
   # For manual dispatch
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   release:
     permissions:
-      contents: write
+      contents: write # need to write a commit to the repo
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -26,14 +32,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
-          
+        uses: azure/setup-helm@v3
+
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.6.0
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ github.token }}"
         with:
           config: .github/cr.yaml
-
+          mark_as_latest: false # only headlamp is set to latest

--- a/.github/workflows/pr-to-update-chart.yml
+++ b/.github/workflows/pr-to-update-chart.yml
@@ -8,12 +8,18 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   LATEST_HEADLAMP_TAG: latest
 jobs:
   create_pr_to_upgrade_chart:
     name: Create PR to update Headlamp's version in the Helm Chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push a branch
+      pull-requests: write # needed to open a pull request
     steps:
       - name: Checkout headlamp repo
         uses: actions/checkout@v4

--- a/.github/workflows/pr-to-update-homebrew.yml
+++ b/.github/workflows/pr-to-update-homebrew.yml
@@ -13,6 +13,11 @@ jobs:
   create_pr_to_upgrade_homebrew:
     name: Create PR to upgrade homebrew
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push a branch
+      pull-requests: write # needed to open a pull request
+      secrets: read
+
     steps:
       - name: Checkout headlamp repo
         uses: actions/checkout@v4

--- a/.github/workflows/pr-to-update-minikube.yml
+++ b/.github/workflows/pr-to-update-minikube.yml
@@ -9,12 +9,18 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   LATEST_HEADLAMP_TAG: latest
 jobs:
   create_pr_to_upgrade_minikube:
     name: Create PR to upgrade minikube
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push a branch
+      pull-requests: write # needed to open a pull request
     steps:
       - name: Checkout headlamp repo
         uses: actions/checkout@v4

--- a/.github/workflows/trigger-flatpak-update.yml
+++ b/.github/workflows/trigger-flatpak-update.yml
@@ -7,10 +7,17 @@ on:
     - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trigger_flatpak_update:
     name: Trigger Flatpak Headlamp version update
     runs-on: ubuntu-latest
+
+    permissions:
+      secrets: read # needed to fetch gh token
+
     steps:
       - name: Trigger via gh
         env:


### PR DESCRIPTION
See 
- https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

Note: `contents: read` at the top turns off all other permissions. It's best practice to do that and specify in each job any extra permissions they have. This is so that it's easier to tell which permission is for which job, and also so that the other permissions are turned off or not.