### PR TITLE
charts: Option to pass additional arg to container

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -67,13 +67,14 @@ See [MAINTAINERS.md](https://github.com/headlamp-k8s/headlamp/blob/main/MAINTAIN
 
 ### Headlamp Configuration
 
-| Key                       | Type   | Default               | Description                                |
-|---------------------------|--------|-----------------------|--------------------------------------------|
-| config.baseURL            | string | `""`                  | base url path at which headlamp should run |
-| config.oidc.clientID      | string | `""`                  | OIDC client ID                             |
-| config.oidc.clientSecret  | string | `""`                  | OIDC client secret                         |
-| config.oidc.issuerURL     | string | `""`                  | OIDC issuer URL                            |
-| config.oidc.scopes        | string | `""`                  | OIDC scopes to be used                     |
+| Key                       | Type   | Default               | Description                                                                                           |
+|---------------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------|
+| config.baseURL            | string | `""`                  | base url path at which headlamp should run                                                            |
+| config.extraArgs          | object | `{}`                  | Extra arguments that can be given to the headlamp container                                           |
+| config.oidc.clientID      | string | `""`                  | OIDC client ID                                                                                        |
+| config.oidc.clientSecret  | string | `""`                  | OIDC client secret                                                                                    |
+| config.oidc.issuerURL     | string | `""`                  | OIDC issuer URL                                                                                       |
+| config.oidc.scopes        | string | `""`                  | OIDC scopes to be used                                                                                |
 | config.oidc.secret.create | bool   | `true`                | Enable this option to have the chart automatically create the OIDC secret using the specified values. |
-| config.oidc.secret.name   | string | `oidc`                | Name of the OIDC secret used by headlamp   |
-| config.pluginsDir         | string | `"/headlamp/plugins"` | directory to look for plugins              |
+| config.oidc.secret.name   | string | `oidc`                | Name of the OIDC secret used by headlamp                                                              |
+| config.pluginsDir         | string | `"/headlamp/plugins"` | directory to look for plugins                                                                         |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -91,6 +91,9 @@ spec:
             {{- with .Values.config.baseURL }}
             - "-base-url={{ . }}"
             {{- end }}
+            {{- with .Values.config.extraArgs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -101,6 +101,7 @@ spec:
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
+            - -insecure-ssl
           ports:
             - name: http
               containerPort: 4466
@@ -115,6 +116,3 @@ spec:
               port: http
           resources:
             {}
-      volumes:
-        - emptyDir: {}
-          name: plugins

--- a/charts/headlamp/tests/test_cases/extra-args.yaml
+++ b/charts/headlamp/tests/test_cases/extra-args.yaml
@@ -1,0 +1,3 @@
+config:
+  extraArgs:
+  - -insecure-ssl

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -44,6 +44,8 @@ config:
     scopes: ""
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
+  # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.
+  extraArgs: {}
 
 # -- An optional list of environment variables
 # env:


### PR DESCRIPTION
User were unable to pass any additional arguments to the headlamp deployment, this adds enhancement for that.

Fixes: #1898