### PR TITLE
charts: Provide 3 options for oidc configuration

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -67,14 +67,15 @@ See [MAINTAINERS.md](https://github.com/headlamp-k8s/headlamp/blob/main/MAINTAIN
 
 ### Headlamp Configuration
 
-| Key                       | Type   | Default               | Description                                                                                           |
-|---------------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------|
-| config.baseURL            | string | `""`                  | base url path at which headlamp should run                                                            |
-| config.extraArgs          | object | `{}`                  | Extra arguments that can be given to the headlamp container                                           |
-| config.oidc.clientID      | string | `""`                  | OIDC client ID                                                                                        |
-| config.oidc.clientSecret  | string | `""`                  | OIDC client secret                                                                                    |
-| config.oidc.issuerURL     | string | `""`                  | OIDC issuer URL                                                                                       |
-| config.oidc.scopes        | string | `""`                  | OIDC scopes to be used                                                                                |
-| config.oidc.secret.create | bool   | `true`                | Enable this option to have the chart automatically create the OIDC secret using the specified values. |
-| config.oidc.secret.name   | string | `oidc`                | Name of the OIDC secret used by headlamp                                                              |
-| config.pluginsDir         | string | `"/headlamp/plugins"` | directory to look for plugins                                                                         |
+| Key                                | Type   | Default               | Description                                                                                           |
+|------------------------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------|
+| config.baseURL                     | string | `""`                  | base url path at which headlamp should run                                                            |
+| config.oidc.clientID               | string | `""`                  | OIDC client ID                                                                                        |
+| config.oidc.clientSecret           | string | `""`                  | OIDC client secret                                                                                    |
+| config.oidc.issuerURL              | string | `""`                  | OIDC issuer URL                                                                                       |
+| config.oidc.scopes                 | string | `""`                  | OIDC scopes to be used                                                                                |
+| config.oidc.secret.create          | bool   | `true`                | Enable this option to have the chart automatically create the OIDC secret using the specified values. |
+| config.oidc.secret.name            | string | `oidc`                | Name of the OIDC secret used by headlamp                                                              |
+| config.oidc.externalSecret.enabled | bool   | `false`               | Enable this option if you want to use an external secret for OIDC configuration.                      |
+| config.oidc.externalSecret.name    | string | `""`                  | Name of the external OIDC secret to be used by headlamp.                                              |
+| config.pluginsDir                  | string | `"/headlamp/plugins"` | directory to look for plugins                                                                         |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -1,3 +1,28 @@
+{{- $oidc := .Values.config.oidc }}
+{{- $env := .Values.env }}
+
+{{- $clientID := "" }}
+{{- $clientSecret := "" }}
+{{- $issuerURL := "" }}
+{{- $scopes := "" }}
+
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+{{- range $env }}
+  {{- if eq .name "OIDC_CLIENT_ID" }}
+    {{- $clientID = .value }}
+  {{- end }}
+  {{- if eq .name "OIDC_CLIENT_SECRET" }}
+    {{- $clientSecret = .value }}
+  {{- end }}
+  {{- if eq .name "OIDC_ISSUER_URL" }}
+    {{- $issuerURL = .value }}
+  {{- end }}
+  {{- if eq .name "OIDC_SCOPES" }}
+    {{- $scopes = .value }}
+  {{- end }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,36 +60,58 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{ if or .Values.config.oidc .Values.env }}
+          {{ if or $oidc .Values.env }}
           env:
-            {{- with .Values.config.oidc }}
-            {{- if or .clientID (not .secret.create) }}
+            {{- if $oidc.secret.create }}
+            {{- if $oidc.clientID }}
             - name: OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .secret.name }}
+                  name: {{ $oidc.secret.name }}
                   key: clientID
             {{- end }}
-            {{- if or .clientSecret (not .secret.create) }}
+            {{- if $oidc.clientSecret }}
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .secret.name }}
+                  name: {{ $oidc.secret.name }}
                   key: clientSecret
             {{- end }}
-            {{- if or .issuerURL (not .secret.create) }}
+            {{- if $oidc.issuerURL }}
             - name: OIDC_ISSUER_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .secret.name }}
+                  name: {{ $oidc.secret.name }}
                   key: issuerURL
             {{- end }}
-            {{- if or .scopes (not .secret.create) }}
+            {{- if $oidc.scopes }}
             - name: OIDC_SCOPES
               valueFrom:
                 secretKeyRef:
-                  name: {{ .secret.name }}
+                  name: {{ $oidc.secret.name }}
                   key: scopes
+            {{- end }}
+            {{- else if $oidc.externalSecret.enabled }}
+            # Check if externalSecret is enabled
+            envFrom:
+            - secretRef:
+                name: {{ $oidc.externalSecret.name }}
+            {{- else }}
+            {{- if $oidc.clientID }}
+            - name: OIDC_CLIENT_ID
+              value: {{ $oidc.clientID }}
+            {{- end }}
+            {{- if $oidc.clientSecret }}
+            - name: OIDC_CLIENT_SECRET
+              value: {{ $oidc.clientSecret }}
+            {{- end }}
+            {{- if $oidc.issuerURL }}
+            - name: OIDC_ISSUER_URL
+              value: {{ $oidc.issuerURL }}
+            {{- end }}
+            {{- if $oidc.scopes }}
+            - name: OIDC_SCOPES
+              value: {{ $oidc.scopes }}
             {{- end }}
             {{- end }}
             {{- if .Values.env }}
@@ -76,16 +123,28 @@ spec:
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}
-            {{- if or .Values.config.oidc.clientID (not .Values.config.oidc.secret.create) }}
+            {{- if not $oidc.externalSecret.enabled}}
+            # Check if externalSecret is disabled
+            {{- if or (ne $oidc.clientID "") (ne $clientID "") }}
+            # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             {{- end }}
-            {{- if or .Values.config.oidc.clientSecret (not .Values.config.oidc.secret.create) }}
+            {{- if or (ne $oidc.clientSecret "") (ne $clientSecret "") }}
+            # Check if clientSecret is non empty either from env or oidc.config
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             {{- end }}
-            {{- if or .Values.config.oidc.issuerURL (not .Values.config.oidc.secret.create) }}
+            {{- if or (ne $oidc.issuerURL "") (ne $issuerURL "") }}
+            # Check if issuerURL is non empty either from env or oidc.config
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             {{- end }}
-            {{- if or .Values.config.oidc.scopes (not .Values.config.oidc.secret.create) }}
+            {{- if or (ne $oidc.scopes "") (ne $scopes "") }}
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
+            {{- end }}
+            {{- else }}
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             - "-oidc-scopes=$(OIDC_SCOPES)"
             {{- end }}
             {{- with .Values.config.baseURL }}

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -18,6 +18,10 @@ metadata:
   name: oidc
 type: Opaque
 data:
+  clientID: "dGVzdENsaWVudElk"
+  clientSecret: "dGVzdENsaWVudFNlY3JldA=="
+  issuerURL: "dGVzdElzc3VlclVSTA=="
+  scopes: "dGVzdFNjb3Bl"
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -101,11 +105,38 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: clientID
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: clientSecret
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: issuerURL
+            - name: OIDC_SCOPES
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: scopes
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
             # Check if externalSecret is disabled
-            - -insecure-ssl
+            # Check if clientID is non empty either from env or oidc.config
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            # Check if clientSecret is non empty either from env or oidc.config
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            # Check if issuerURL is non empty either from env or oidc.config
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -101,11 +101,26 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            - name: OIDC_CLIENT_ID
+              value: testClientId
+            - name: OIDC_CLIENT_SECRET
+              value: testClientSecret
+            - name: OIDC_ISSUER_URL
+              value: testIssuerURL
+            - name: OIDC_SCOPES
+              value: testScope
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
             # Check if externalSecret is disabled
-            - -insecure-ssl
+            # Check if clientID is non empty either from env or oidc.config
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            # Check if clientSecret is non empty either from env or oidc.config
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            # Check if issuerURL is non empty either from env or oidc.config
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -11,14 +11,6 @@ metadata:
     app.kubernetes.io/version: "0.23.2"
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: headlamp/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: oidc
-type: Opaque
-data:
----
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -101,11 +93,26 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            - name: OIDC_CLIENT_ID
+              value: testClientId
+            - name: OIDC_CLIENT_SECRET
+              value: testClientSecret
+            - name: OIDC_ISSUER_URL
+              value: testIssuerURL
+            - name: OIDC_SCOPES
+              value: testScope
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
             # Check if externalSecret is disabled
-            - -insecure-ssl
+            # Check if clientID is non empty either from env or oidc.config
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            # Check if clientSecret is non empty either from env or oidc.config
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            # Check if issuerURL is non empty either from env or oidc.config
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -11,14 +11,6 @@ metadata:
     app.kubernetes.io/version: "0.23.2"
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: headlamp/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: oidc
-type: Opaque
-data:
----
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -101,11 +93,17 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            # Check if externalSecret is enabled
+            envFrom:
+            - secretRef:
+                name: oidc
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
-            # Check if externalSecret is disabled
-            - -insecure-ssl
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -62,6 +62,9 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -101,6 +104,7 @@ spec:
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/test_cases/extra-args.yaml
+++ b/charts/headlamp/tests/test_cases/extra-args.yaml
@@ -1,3 +1,5 @@
+# This is a test case for extraArgs in the Headlamp deployment.
+# Each test case is a dictionary with the following keys:
 config:
   extraArgs:
   - -insecure-ssl

--- a/charts/headlamp/tests/test_cases/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-create-secret.yaml
@@ -1,0 +1,16 @@
+# This is a test case for the oidc.secret.create field in the Headlamp deployment.
+# The oidc.secret.create field is a boolean that determines whether to create a secret for OIDC.
+# The oidc.secret.name field is a string that specifies the name of the OIDC secret.
+# The oidc.clientID field is a string that specifies the client ID for OIDC.
+# The oidc.clientSecret field is a string that specifies the client secret for OIDC.
+# The oidc.issuerURL field is a string that specifies the issuer URL for OIDC.
+# The oidc.scopes field is a string that specifies the scopes for OIDC.
+config:
+  oidc:
+    secret:
+      create: true
+      name: oidc
+    clientID: "testClientId"
+    clientSecret: "testClientSecret"
+    issuerURL: "testIssuerURL"
+    scopes: "testScope"

--- a/charts/headlamp/tests/test_cases/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-directly-env.yaml
@@ -1,0 +1,10 @@
+# This is a test case where user can set env values directly for OIDC configuration.
+env:
+  - name: OIDC_CLIENT_ID
+    value: testClientId
+  - name: OIDC_CLIENT_SECRET
+    value: testClientSecret
+  - name: OIDC_ISSUER_URL
+    value: testIssuerURL
+  - name: OIDC_SCOPES
+    value: testScope

--- a/charts/headlamp/tests/test_cases/oidc-directly.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-directly.yaml
@@ -1,0 +1,14 @@
+# This is a test case for the direct OIDC configuration in the Headlamp deployment.
+# The oidc.secret.create field is false to avoid creating a secret for OIDC.
+# The oidc.clientID field is a string that specifies the client ID for OIDC.
+# The oidc.clientSecret field is a string that specifies the client secret for OIDC.
+# The oidc.issuerURL field is a string that specifies the issuer URL for OIDC.
+# The oidc.scopes field is a string that specifies the scopes for OIDC.
+config:
+  oidc:
+    secret:
+      create: false
+    clientID: "testClientId"
+    clientSecret: "testClientSecret"
+    issuerURL: "testIssuerURL"
+    scopes: "testScope"

--- a/charts/headlamp/tests/test_cases/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-external-secret.yaml
@@ -1,0 +1,10 @@
+# This is a test case for OIDC external secret.
+# The oidc.externalSecret.enabled field is a boolean that determines whether to use an external secret for OIDC.
+# The oidc.externalSecret.name field is a string that specifies the name of the external OIDC secret.
+config:
+  oidc:
+    secret:
+      create: false
+    externalSecret:
+      enabled: true
+      name: oidc

--- a/charts/headlamp/tests/test_cases/volumes-added.yaml
+++ b/charts/headlamp/tests/test_cases/volumes-added.yaml
@@ -1,8 +1,5 @@
-# custom values for headlamp with volume added.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-# -- Headlamp pod's volumes
+# This is a test case for volumes in the Headlamp deployment.
+# The volumes field is a list of dictionaries that specify the volumes to add to the Headlamp deployment.
 volumes:
   - name: plugins
     emptyDir: {}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -29,11 +29,34 @@ config:
   # -- base url path at which headlamp should run
   baseURL: ""
   oidc:
+    # Option 1:
+    # @param config.oidc.secret - OIDC secret configuration
+    # If you want to use an existing secret, set create to false and provide the name of the secret.
+    # If you want to create a new secret, set create to true and provide the name of the secret.
+    # Also provide the values for clientID, clientSecret, issuerURL, and scopes.
+    # Example:
+    # config:
+    #   oidc:
+    #     secret:
+    #       create: true
+    #       name: oidc
     secret:
       # -- Generate OIDC secret. If true, will generate a secret using .config.oidc.
       create: true
       # -- Name of the OIDC secret.
       name: oidc
+
+    # Option 2:
+    # @param config.oidc - OIDC env configuration
+    # If you want to set the OIDC configuration directly, set the following values.
+    # Example:
+    # config:
+    #   oidc:
+    #     clientID: "clientID"
+    #     clientSecret: "clientSecret"
+    #     issuerURL: "issuerURL"
+    #     scopes: "scopes"
+
     # -- OIDC client ID
     clientID: ""
     # -- OIDC client secret
@@ -42,6 +65,22 @@ config:
     issuerURL: ""
     # -- OIDC scopes to be used
     scopes: ""
+
+    # Option 3:
+    # @param config.oidc - External OIDC secret configuration
+    # If you want to use an external secret for OIDC configuration, enable this option.
+    # Provide the name of the secret to use.
+    # Example:
+    # config:
+    #   oidc:
+    #     secret:
+    #       create: false
+    #     externalSecret:
+    #       enabled: true
+    #       name: oidc
+    externalSecret:
+      enabled: false
+      name: ""
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.


### PR DESCRIPTION
Now users have 3 different way they can set oidc configuration

- Directly set values of respective config.oidc.clientID and others which inject them into ENV variable, to be used by args.
- Use external i.e. already created secret with the same keys as args.
- Use config.oidc.secret.create functionality to create secret and have them dynamically loaded into the headlamp deployment.

Fixes: #1897


## Testing

### Scenario 1
This is when user just want to use ENV variables directly. 

- Set values of `config.oidc.`  `clientID, clientSecret, issuerURL, scopes` in `values.yaml` and set `config.oidc.secret` as `false`
- Run `helm template charts/headlamp`


### Scenario 2
This is when user wants to use external secret created by them

- Create a new secret with above config.oidc values. For reference check `template/secret.yaml`. Then create it in your k8s cluster using kubectl command.
- Set `config.oidc.secret` as `false` and set `config.oidc.externalSecret` as `true` and also the name of secret.
- Run `helm template charts/headlamp`

### Scenario 3
This is when user want to use the secret created by headlamp

- Set values of `config.oidc.`  `clientID, clientSecret, issuerURL, scopes` in `values.yaml` and set `config.oidc.secret` as `true`
- Run `helm template charts/headlamp`


