### PR TITLE
charts: add ingressClassName to ingress template

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -37,6 +37,7 @@ See [MAINTAINERS.md](https://github.com/headlamp-k8s/headlamp/blob/main/MAINTAIN
 | imagePullSecrets | list | `[]` | An optional list of references to secrets in the same namespace to use for pulling any of the images used |
 | ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | ingress.enabled | bool | `false` | Enable ingress controller resource |
+| ingress.ingressClassName | string | `""` | The ingress class name. Replacement for the deprecated "kubernetes.io/ingress.class" annotation |
 | ingress.hosts | list | `[]` | Hostname(s) for the Ingress resource |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | An optional list of init containers to be run before the main containers. |

--- a/charts/headlamp/templates/ingress.yaml
+++ b/charts/headlamp/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }} 
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -120,8 +120,11 @@ ingress:
   # -- Annotations for Ingress resource
   annotations:
     {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+  # -- Ingress class name. replacement for the deprecated "kubernetes.io/ingress.class" annotation
+  ingressClassName: ""
+
   # -- Hostname(s) for the Ingress resource
   hosts:
     []


### PR DESCRIPTION
## Description
This PR updates the existing ingress chart template and adds the field "ingress.ingressClassName". 
According to the kubernetes documentation, setting the ingressClassName in the annotations is deprecated: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

This fixes issue #1895 

## Changes
Added one line to the ingress chart template to template the field `Values.ingress.ingressClassName` if it exists

## Verification

I tested the change locally by defining a simple my-values.yaml file:

```
ingress:
  enabled: true
  ingressClassName: nginx
  hosts:
  - host: chart-example.local
  tls:
  - secretName: chart-example-tls
    hosts:
      - chart-example.local
```

Using `helm template` I confirmed that a correct Ingress was templated:

```
helm template headlamp --namespace headlamp --create-namespace -f my-values.yaml .
```

Results in:
```
# Source: headlamp/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: headlamp
  labels:
    helm.sh/chart: headlamp-0.20.0
    app.kubernetes.io/name: headlamp
    app.kubernetes.io/instance: headlamp
    app.kubernetes.io/version: "0.23.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - "chart-example.local"
      secretName: chart-example-tls
  rules:
    - host: "chart-example.local"
      http:
        paths:
```


