### PR TITLE
app: Fix external url opening in app

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -574,6 +574,7 @@ function startElecron() {
       if (url.startsWith(startUrl)) {
         return;
       }
+      event.preventDefault();
       shell.openExternal(url);
     });
 


### PR DESCRIPTION
This fix prevents external URLs from being opened within the Headlamp app.

Fixes: #1917 

### Testing
- [x] Create new cluster and apply an ingress with an external URL
- [x] Click the external URL to ensure that it only opens in the web browser