### PR TITLE
add container exit code in details view

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -734,6 +734,11 @@ export function ContainerInfo(props: ContainerInfoProps) {
         hide: !status,
       },
       {
+        name: t('translation|Exit Code'),
+        value: status?.state?.terminated?.exitCode,
+        hide: !status?.state?.terminated,
+      },
+      {
         name: t('translation|Restart Count'),
         value: status?.restartCount,
         hide: !status,

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -675,8 +675,13 @@ export function ContainerInfo(props: ContainerInfoProps) {
       statusType = 'success';
       label = t('translation|Running');
     } else if (!!status.state.terminated) {
-      statusType = status.state.terminated.exitCode === 0 ? '' : 'error';
-      label = t('translation|Error');
+      if (status.state.terminated.exitCode === 0) {
+        statusType = '';
+        label = status.state.terminated.reason;
+      } else {
+        statusType = 'error';
+        label = t('translation|Error');
+      }
     }
 
     const tooltipID = 'container-state-message-' + container.name;

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -5852,7 +5852,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
                     style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
                   >
-                    Error
+                    Completed
                   </span>
                 </dd>
                 <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -724,6 +724,16 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
                 >
+                  Exit Code
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  1
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
                   Restart Count
                 </dt>
                 <dd
@@ -5854,6 +5864,16 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                   >
                     Completed
                   </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Exit Code
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  0
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -714,12 +714,20 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Error
-                  </span>
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
+                      >
+                        Error
+                      </span>
+                    </div>
+                  </div>
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
@@ -730,6 +738,34 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
                   1
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Started
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Finished
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
+                  </span>
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
@@ -1692,12 +1728,20 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Waiting (PodInitializing)
-                  </span>
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                      >
+                        Waiting (PodInitializing)
+                      </span>
+                    </div>
+                  </div>
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
@@ -1809,11 +1853,33 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Running
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                      >
+                        Running
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Started
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
                   </span>
                 </dd>
                 <dt
@@ -1915,12 +1981,20 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Waiting (PodInitializing)
-                  </span>
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                      >
+                        Waiting (PodInitializing)
+                      </span>
+                    </div>
+                  </div>
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
@@ -2873,21 +2947,29 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    aria-describedby="container-state-message-liveness"
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
-                  >
-                    Waiting (CrashLoopBackOff)
-                  </span>
                   <div
-                    aria-label="hidden"
-                    class="MuiBox-root css-a56neh"
-                    data-mui-internal-clone-element="true"
-                    role="tooltip"
-                    style="vertical-align: bottom;"
+                    class="MuiBox-root css-0"
                   >
-                    <span />
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        aria-describedby="container-state-message-liveness"
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                      >
+                        Waiting (CrashLoopBackOff)
+                      </span>
+                      <div
+                        aria-label="hidden"
+                        class="MuiBox-root css-a56neh"
+                        data-mui-internal-clone-element="true"
+                        role="tooltip"
+                        style="vertical-align: bottom;"
+                      >
+                        <span />
+                      </div>
+                    </div>
                   </div>
                 </dd>
                 <dt
@@ -3932,21 +4014,29 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    aria-describedby="container-state-message-imagepullbackoff"
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
-                  >
-                    Waiting (ImagePullBackOff)
-                  </span>
                   <div
-                    aria-label="hidden"
-                    class="MuiBox-root css-a56neh"
-                    data-mui-internal-clone-element="true"
-                    role="tooltip"
-                    style="vertical-align: bottom;"
+                    class="MuiBox-root css-0"
                   >
-                    <span />
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        aria-describedby="container-state-message-imagepullbackoff"
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                      >
+                        Waiting (ImagePullBackOff)
+                      </span>
+                      <div
+                        aria-label="hidden"
+                        class="MuiBox-root css-a56neh"
+                        data-mui-internal-clone-element="true"
+                        role="tooltip"
+                        style="vertical-align: bottom;"
+                      >
+                        <span />
+                      </div>
+                    </div>
                   </div>
                 </dd>
                 <dt
@@ -4865,11 +4955,33 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Running
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                      >
+                        Running
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Started
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
                   </span>
                 </dd>
                 <dt
@@ -5858,12 +5970,20 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Completed
-                  </span>
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                      >
+                        Completed
+                      </span>
+                    </div>
+                  </div>
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
@@ -5874,6 +5994,34 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
                   0
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Started
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Finished
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
+                  </span>
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -723,11 +723,33 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    class="MuiBox-root css-0"
                   >
-                    Running
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 makeStyles-statusLabel css-1ezega9-MuiTypography-root"
+                        style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                      >
+                        Running
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 makeStyles-metadataNameCell css-1r6indk-MuiGrid-root"
+                >
+                  Started
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 makeStyles-metadataCell css-r0umuq-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2022-01-01T00:05:00.000Z
                   </span>
                 </dd>
                 <dt

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -210,6 +210,7 @@
   "Waiting": "Warten",
   "Running": "Läuft",
   "Error": "Error",
+  "Exit Code": "",
   "Restart Count": "Anzahl der Neustarts",
   "No data to be shown.": "Es sind keine Daten zum Anzeigen vorhanden.",
   "Init Containers": "Init-Container",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -211,6 +211,8 @@
   "Running": "Läuft",
   "Error": "Error",
   "Exit Code": "",
+  "Started": "",
+  "Finished": "",
   "Restart Count": "Anzahl der Neustarts",
   "No data to be shown.": "Es sind keine Daten zum Anzeigen vorhanden.",
   "Init Containers": "Init-Container",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -210,6 +210,7 @@
   "Waiting": "Waiting",
   "Running": "Running",
   "Error": "Error",
+  "Exit Code": "Exit Code",
   "Restart Count": "Restart Count",
   "No data to be shown.": "No data to be shown.",
   "Init Containers": "Init Containers",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -211,6 +211,8 @@
   "Running": "Running",
   "Error": "Error",
   "Exit Code": "Exit Code",
+  "Started": "Started",
+  "Finished": "Finished",
   "Restart Count": "Restart Count",
   "No data to be shown.": "No data to be shown.",
   "Init Containers": "Init Containers",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -210,6 +210,7 @@
   "Waiting": "Esperando",
   "Running": "en ejecución",
   "Error": "Error",
+  "Exit Code": "",
   "Restart Count": "Núm. de reinicios",
   "No data to be shown.": "Sin datos para enseñar.",
   "Init Containers": "Contenedores de Inicialización",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -211,6 +211,8 @@
   "Running": "en ejecución",
   "Error": "Error",
   "Exit Code": "",
+  "Started": "",
+  "Finished": "",
   "Restart Count": "Núm. de reinicios",
   "No data to be shown.": "Sin datos para enseñar.",
   "Init Containers": "Contenedores de Inicialización",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -210,6 +210,7 @@
   "Waiting": "Attente",
   "Running": "En fonctionnement",
   "Error": "Error",
+  "Exit Code": "",
   "Restart Count": "Nombre de redémarrages",
   "No data to be shown.": "Aucune donnée à montrer.",
   "Init Containers": "Conteneurs d'initialisation",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -211,6 +211,8 @@
   "Running": "En fonctionnement",
   "Error": "Error",
   "Exit Code": "",
+  "Started": "",
+  "Finished": "",
   "Restart Count": "Nombre de redémarrages",
   "No data to be shown.": "Aucune donnée à montrer.",
   "Init Containers": "Conteneurs d'initialisation",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -211,6 +211,8 @@
   "Running": "em execução",
   "Error": "Erro",
   "Exit Code": "",
+  "Started": "",
+  "Finished": "",
   "Restart Count": "Núm. Reinícios",
   "No data to be shown.": "Sem dados para mostrar.",
   "Init Containers": "Containers de Inicialização",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -210,6 +210,7 @@
   "Waiting": "À espera",
   "Running": "em execução",
   "Error": "Erro",
+  "Exit Code": "",
   "Restart Count": "Núm. Reinícios",
   "No data to be shown.": "Sem dados para mostrar.",
   "Init Containers": "Containers de Inicialização",


### PR DESCRIPTION
This PR fixes the items mentioned for the container display in details view as described in #1971.

How to test. Use the storybook to see how this PR shows the exit code + dates for the places showing containers.

Also fixes how the "terminated" display is shown.