### PR TITLE
frontend: Add node/npm version requirements to package.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -134,6 +134,10 @@
         "typedoc-plugin-rename-defaults": "0.4.0",
         "vm-browserify": "^1.1.2",
         "ws": "^8.16.0"
+      },
+      "engines": {
+        "node": ">=20.9.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "productName": "Headlamp",
+  "engines" : {
+    "npm" : ">=10.0.0",
+    "node" : ">=20.9.0"
+  },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@apidevtools/swagger-parser": "^10.0.3",


### PR DESCRIPTION
So people will get a hint when they install that they have older versions of node/npm than is required.


![image](https://github.com/headlamp-k8s/headlamp/assets/9541/f42fcf8e-8ce8-47cb-818f-c0078796b5a5)


### How to test

- Use node 18.
- Run `cd frontend && npm install`
- See warning message in screenshot about node version being wrong.
