### PR TITLE
backend: Fix empty X-Forwared-Host header

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1007,7 +1007,7 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 		}
 
 		r.Host = clusterURL.Host
-		r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
+		r.Header.Set("X-Forwarded-Host", r.Host)
 		r.URL.Host = clusterURL.Host
 		r.URL.Path = mux.Vars(r)["api"]
 		r.URL.Scheme = clusterURL.Scheme


### PR DESCRIPTION
The header was not getting set correctly and returning an empty string

Fixes: #1968