### PR TITLE
frontend: fix `repeatStreamFunc` for `list` requests

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -496,7 +496,7 @@ async function repeatStreamFunc(
   ) {
     const endpoint = apiEndpoints[endpointIndex];
     const fullArgs = [...args];
-    let errCbIndex = 2;
+    let errCbIndex = funcName === 'get' ? 2 : 1;
     if (endpoint.isNamespaced) {
       ++errCbIndex;
     }


### PR DESCRIPTION
`errCb` parameter is the 3rd argument of `get` function returned by `singleApiFactory`, whereas it's only the 2nd argument of `list`. This causes `repeatStreamFunc` to misbehave for `list` calls because the error callback index is hard-coded to `2`.
In my case I couldn't list custom resources with deprecated API versions.