### PR TITLE
pod/List: Fix IPs being displayed as "undefined" when not set

### DIFF
--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.stories.storyshot
@@ -2424,7 +2424,7 @@ exports[`Storyshots Namespace/DetailsView Active 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-113h9jm-MuiTableCell-root"
                         data-index="4"
                       >
-                        0.0.0.2
+                        
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19qh9pa-MuiTableCell-root"

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -500,11 +500,11 @@ export default function PodDetails(props: PodDetailsProps) {
           },
           {
             name: t('Host IP'),
-            value: item.status.hostIP,
+            value: item.status.hostIP ?? '',
           },
           {
             name: t('Pod IP'),
-            value: item.status.podIP,
+            value: item.status.podIP ?? '',
           },
           {
             name: t('QoS Class'),

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -117,7 +117,7 @@ export function PodListRenderer(props: PodListProps) {
         {
           id: 'ip',
           label: t('glossary|IP'),
-          getValue: (pod: Pod) => String(pod.status.podIP),
+          getValue: (pod: Pod) => pod.status?.podIP ?? '',
         },
         {
           id: 'node',

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -5703,9 +5703,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
-                  >
-                    0.0.0.1
-                  </span>
+                  />
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
@@ -5717,9 +5715,7 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
-                  >
-                    0.0.0.2
-                  </span>
+                  />
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
@@ -1016,7 +1016,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-113h9jm-MuiTableCell-root"
                   data-index="5"
                 >
-                  0.0.0.2
+                  
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19qh9pa-MuiTableCell-root"

--- a/frontend/src/components/pod/storyHelper.ts
+++ b/frontend/src/components/pod/storyHelper.ts
@@ -150,7 +150,7 @@ const successful = {
     restartPolicy: 'Never',
   },
   status: {
-    ...basePod.status,
+    startTime: stateDate,
     phase: 'Succeeded',
     conditions: [
       {

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -35,7 +35,7 @@ export interface KubePod extends KubeObjectInterface {
     containerStatuses: KubeContainerStatus[];
     initContainerStatuses?: KubeContainerStatus[];
     ephemeralContainerStatuses?: KubeContainerStatus[];
-    hostIP: string;
+    hostIP?: string;
     message?: string;
     phase: string;
     qosClass?: string;


### PR DESCRIPTION
Just noticed that after the table changes we have pod IPs as being `undefined` (when there's no IP defined) in the pod list.

How to test:
- [ ] Go to a pod that has no IP set to them; check how it shows nothing in the IP column (as opposed to `undefined`)