### PR TITLE
app: Add checkCommandConsent dialog for checking az/minikube/etc

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1219,6 +1219,80 @@ function startElecron() {
     }
 
     /**
+     * Ask the user with an electron dialog if they want to allow the command
+     * to be executed.
+     * @param command - The command to show in the dialog.
+     * @returns true if the user allows the command to be executed, false otherwise.
+     */
+    function confirmCommandDialog(command: string): boolean {
+      if (mainWindow === null) {
+        return false;
+      }
+      const resp = dialog.showMessageBoxSync(mainWindow, {
+        title: i18n.t('Consent to command being run'),
+        message: i18n.t('Allow this local command to be executed? Your choice will be saved.'),
+        detail: command,
+        type: 'question',
+        buttons: [i18n.t('Allow'), i18n.t('Deny')],
+      });
+
+      return resp === 0;
+    }
+
+    const SETTINGS_PATH = path.join(app.getPath('userData'), 'settings.json');
+
+    /**
+     * Loads the user settings.
+     * If the settings file does not exist, an empty object is returned.
+     * @returns The settings object.
+     */
+    function loadSettings() {
+      try {
+        const data = fs.readFileSync(SETTINGS_PATH, 'utf-8');
+        return JSON.parse(data);
+      } catch (error) {
+        return {};
+      }
+    }
+
+    /**
+     * Saves the user settings.
+     * @param settings - The settings object to save.
+     */
+    function saveSettings(settings) {
+      fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings), 'utf-8');
+    }
+
+    /**
+     * Checks if the user has already consented to running the command.
+     *
+     * If the user has not consented, a dialog is shown to ask for consent.
+     *
+     * @param command - The command to check.
+     * @returns true if the user has consented to running the command, false otherwise.
+     */
+    function checkCommandConsent(command: string): boolean {
+      const settings = loadSettings();
+      const confirmedCommands = settings?.confirmedCommands;
+      const savedCommand: boolean | undefined = confirmedCommands
+        ? confirmedCommands[command]
+        : undefined;
+
+      if (savedCommand === false) {
+        console.error(`Invalid command: ${command}, command not allowed by users choice`);
+        return false;
+      } else if (savedCommand === undefined) {
+        const commandChoice = confirmCommandDialog(command);
+        if (settings?.confirmedCommands === undefined) {
+          settings.confirmedCommands = {};
+        }
+        settings.confirmedCommands[command] = commandChoice;
+        saveSettings(settings);
+      }
+      return true;
+    }
+
+    /**
      * Handles 'run-command' events from the renderer process.
      *
      * Spawns the requested command and sends 'command-stdout',
@@ -1233,12 +1307,16 @@ function startElecron() {
 
       // Only allow "minikube", and "az" commands
       const validCommands = ['minikube', 'az'];
+
       if (!validCommands.includes(eventData.command)) {
         console.error(
           `Invalid command: ${eventData.command}, only valid commands are: ${JSON.stringify(
             validCommands
           )}`
         );
+        return;
+      }
+      if (!checkCommandConsent(eventData.command)) {
         return;
       }
 


### PR DESCRIPTION
- Pops up a dialog asking the user if they consent to running the command.
- Saves the choice and uses that choice in the future.

![image](https://github.com/headlamp-k8s/headlamp/assets/9541/14fe15db-9857-47ee-b531-2076ed496d02)

Related to
-  #1824
- #1744

The General Settings part of issue #1744 is out of scope for this PR. That will be done in a future PR.

---

From a security standpoint, this adds an extra layer of protection for the user.

Now:
- an attacker would need to change a plugin, AND the user settings to be able to run commands. 

Before this PR:
- they would just need to add something into a plugin.

---

Note: the running of commands is still disabled in main for now. Because we are not using that functionality yet. This PR does NOT enable the running of commands.
