### PR TITLE
frontend sts/List: the containers field broken

### DIFF
--- a/frontend/src/components/statefulset/List.tsx
+++ b/frontend/src/components/statefulset/List.tsx
@@ -35,7 +35,7 @@ export default function StatefulSetList() {
         {
           id: 'containers',
           label: t('Containers'),
-          getValue: statefulSet => statefulSet.containerNames.join(', '),
+          getValue: statefulSet => statefulSet.getContainers().map(c => c.name).join(', '),
           render: statefulSet => {
             const containerNames = statefulSet.getContainers().map((c: KubeContainer) => c.name);
             const containerTooltip = containerNames.join('\n');


### PR DESCRIPTION
I found there is a error that will crash the StateFulSet/List 
`
          label: t('Containers'),
          getValue: statefulSet => statefulSet.containerNames.join(', '),
          render: statefulSet => {

`
seem like statefulSet object has no property named 'containerNames'

So I change the code to 
`
getValue: statefulSet => statefulSet.getContainers().map(it => it.name).join(', '),
`