### PR TITLE
app: Fix electron opening browser on page reload

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -506,7 +506,7 @@ function startElecron() {
       frontendPath = path.join(process.resourcesPath, 'frontend', 'index.html');
     }
 
-    const startUrl =
+    const startUrl = (
       process.env.ELECTRON_START_URL ||
       url.format({
         pathname: frontendPath,
@@ -515,7 +515,13 @@ function startElecron() {
         query: {
           backendToken: backendToken,
         },
-      });
+      })
+    )
+      // Windows paths use backslashes and for consistency we want to use forward slashes.
+      // For example: when application triggers refresh it requests a URL with forward slashes and
+      // we use startUrl to determine if it's an internal or external URL. So it's easier to
+      // convert everything to forward slashes.
+      .replace(/\\/g, '/');
 
     // WSL has a problem with full size window placement, so make it smaller.
     const withMargin = isWSL();

--- a/app/package.json
+++ b/app/package.json
@@ -142,6 +142,7 @@
     "name": "Kinvolk",
     "email": "hello@kinvolk.io"
   },
+  "prettier": "@kinvolk/eslint-config/prettier-config",
   "devDependencies": {
     "@babel/cli": "^7.15.7",
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
Currently in the app on windows when application triggers page reload it opens a browser.

The reason is difference in forward and back slashes in the url. 
in main.ts startUrl has forward slashes
but when page reloads, it requests a link with backward slashes. 

Since windows handles forward slashes just fine, I added a replacement that changes to forward slashes.

Fixes https://github.com/headlamp-k8s/headlamp/issues/1990