### PR TITLE
Make Workload Circular Chart Names Clickable

### DIFF
--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -28,7 +28,7 @@ export interface PercentageCircleProps {
   size?: number;
   dataKey?: string;
   label?: string | null;
-  title?: string | null;
+  title?: string | JSX.Element | null;
   legend?: string | null;
   total?: number;
   totalProps?: {

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -13,6 +13,7 @@ import Pod from '../../lib/k8s/pod';
 import ReplicaSet from '../../lib/k8s/replicaSet';
 import StatefulSet from '../../lib/k8s/statefulSet';
 import { getReadyReplicas, getTotalReplicas } from '../../lib/util';
+import Link from '../common/Link';
 import { PageGrid, ResourceLink } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { SectionBox } from '../common/SectionBox';
@@ -93,16 +94,21 @@ export default function Overview() {
     );
   });
 
+  function ChartLink(workload: KubeObject) {
+    const linkName = workload.pluralName;
+    return <Link routeName={linkName}>{linkName}</Link>;
+  }
+
   return (
     <PageGrid>
       <SectionBox py={2} mt={1}>
         <Grid container justifyContent="flex-start" alignItems="flex-start" spacing={2}>
-          {workloads.map(({ className: name }) => (
-            <Grid item lg={3} md={4} xs={6} key={name}>
+          {workloads.map(workload => (
+            <Grid item lg={3} md={4} xs={6} key={workload.name}>
               <WorkloadCircleChart
-                workloadData={workloadsData[name] || null}
+                workloadData={workloadsData[workload.name] || null}
                 // @todo: Use a plural from from the class itself when we have it
-                title={name + 's'}
+                title={ChartLink(workload)}
                 partialLabel={t('translation|Failed')}
                 totalLabel={t('translation|Running')}
               />


### PR DESCRIPTION
Fixes issue #1792

## Description

This PR enhances the user interface by making the names on the workload circular charts clickable. This allows users to easily navigate to the corresponding workload list page, providing a more intuitive and efficient way to access detailed workload information directly from the charts.

## Changes

- [x] Updated the workload circular charts to make the names clickable.
- [x] Implemented navigation functionality to redirect users to the corresponding workload list page upon clicking a chart name.
- [x] Ensured that the clickable names are styled appropriately to indicate their interactive nature.

## Verification

- [x] Tested the clickable functionality to ensure that clicking on a workload chart name correctly navigates to the respective workload list page.
- [x] Verified that the navigation works consistently across different charts and workload types.
- [x] Ensured that the user experience is smooth and the clickable elements are visually distinct.

## Screenshots
![image](https://github.com/headlamp-k8s/headlamp/assets/78232183/70c12a1a-2161-4e48-96e2-5b50ece751a1)
