### PR TITLE
charts: Add schema for values.yaml

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -79,3 +79,4 @@ See [MAINTAINERS.md](https://github.com/headlamp-k8s/headlamp/blob/main/MAINTAIN
 | config.oidc.externalSecret.enabled | bool   | `false`               | Enable this option if you want to use an external secret for OIDC configuration.                      |
 | config.oidc.externalSecret.name    | string | `""`                  | Name of the external OIDC secret to be used by headlamp.                                              |
 | config.pluginsDir                  | string | `"/headlamp/plugins"` | directory to look for plugins                                                                         |
+| config.extraArgs                   | array  | `[]`                  | Extra arguments that can be given to the container                                                    |

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -1,0 +1,407 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of replicas to deploy",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "title": "Image",
+      "description": "Image to deploy",
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Registry of the image"
+        },
+        "repository": {
+          "type": "string",
+          "description": "Repository of the image"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Pull policy of the image",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string",
+          "description": "Tag of the image"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets",
+      "items": {
+        "type": "string"
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the chart"
+    },
+    "initContainers": {
+      "type": "array",
+      "description": "Init containers",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the init container"
+          },
+          "image": {
+            "type": "string",
+            "description": "Image of the init container"
+          },
+          "imagePullPolicy": {
+            "type": "string",
+            "description": "Pull policy of the init container",
+            "enum": ["Always", "IfNotPresent", "Never"]
+          },
+          "command": {
+            "type": "array",
+            "description": "Command of the init container",
+            "items": {
+              "type": "string"
+            }
+          },
+          "args": {
+            "type": "array",
+            "description": "Arguments of the init container",
+            "items": {
+              "type": "string"
+            }
+          },
+          "resources": {
+            "type": "object",
+            "description": "Resources of the init container",
+            "properties": {
+              "limits": {
+                "type": "object",
+                "description": "Limits of the init container",
+                "properties": {
+                  "cpu": {
+                    "type": "string",
+                    "description": "CPU limit"
+                  },
+                  "memory": {
+                    "type": "string",
+                    "description": "Memory limit"
+                  }
+                }
+              },
+              "requests": {
+                "type": "object",
+                "description": "Requests of the init container",
+                "properties": {
+                  "cpu": {
+                    "type": "string",
+                    "description": "CPU request"
+                  },
+                  "memory": {
+                    "type": "string",
+                    "description": "Memory request"
+                  }
+                }
+              }
+            }
+          },
+          "env": {
+            "type": "array",
+            "description": "Environment variables of the init container",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the environment variable"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Value of the environment variable"
+                }
+              }
+            }
+          },
+          "volumeMounts": {
+            "type": "array",
+            "description": "Volume mounts of the init container",
+            "items":
+              {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the volume mount"
+                  },
+                  "mountPath": {
+                    "type": "string",
+                    "description": "Mount path of the volume mount"
+                  },
+                  "readOnly": {
+                    "type": "boolean",
+                    "description": "Read only of the volume mount"
+                  }
+                }
+              }
+          }
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "description": "Headlamp deployment configuration",
+      "properties": {
+        "baseURL": {
+          "type": "string",
+          "description": "Base URL of the application"
+        },
+        "oidc": {
+          "type": "object",
+          "description": "OIDC configuration",
+          "properties": {
+            "secret": {
+              "type": "object",
+              "description": "Secret created by Headlamp to authenticate with the OIDC provider",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the secret"
+                },
+                "create": {
+                  "type": "boolean",
+                  "description": "Create the secret"
+                }
+              }
+            },
+            "clientID": {
+              "type": "string",
+              "description": "Issuer of the OIDC provider"
+            },
+            "clientSecret": {
+              "type": "string",
+              "description": "Client ID of the OIDC provider"
+            },
+            "issuerURL": {
+              "type": "string",
+              "description": "Client secret of the OIDC provider"
+            },
+            "scopes": {
+              "type": "string",
+              "description": "Scopes of the OIDC provider"
+            },
+            "externalSecret": {
+              "type": "object",
+              "description": "External secret to use for OIDC configuration",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the external secret"
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable the external secret"
+                }
+              }
+            }
+          }
+        },
+        "pluginsDir": {
+          "type": "string",
+          "description": "Directory to load plugins from"
+        },
+        "extraArgs": {
+          "type": "array",
+          "description": "Extra arguments to pass to the application",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "description": "Environment variables to pass to the deployment",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the environment variable"
+          },
+          "value": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "description": "Value of the environment variable"
+          }
+        },
+        "required": ["name", "value"],
+        "additionalProperties": false
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use"
+        }
+      }
+    },
+    "clusterRoleBinding": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a cluster role binding should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the cluster role binding"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Kubernetes Service type",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "type": "integer",
+          "description": "Kubernetes Service port"
+        }
+      }
+    },
+    "persistentVolumeClaim": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Persistent Volume Claim"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the persistent volume claim (if enabled)"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "size": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "matchLabels": {
+              "type": "object"
+            },
+            "matchExpressions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "operator": {
+                    "type": "string"
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "volumeMode": {
+          "type": "string"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress controller resource"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for Ingress resource"
+        },
+        "ingressClassName": {
+          "type": "string",
+          "description": "Ingress class name"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -84,7 +84,7 @@ config:
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.
-  extraArgs: {}
+  extraArgs: []
 
 # -- An optional list of environment variables
 # env:


### PR DESCRIPTION
Charts did not have defined structure for Headlamp value configurations. Now we have defined schema for the same which will run while linting, installing, upgrading or templating the helm charts.

Fixes: #1926