### PR TITLE
charts: fix oidc external secret loading

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -61,6 +61,12 @@ spec:
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{ if or $oidc .Values.env }}
+          {{- if $oidc.externalSecret.enabled }}
+          # Check if externalSecret is enabled
+          envFrom:
+          - secretRef:
+              name: {{ $oidc.externalSecret.name }}
+          {{- else }}
           env:
             {{- if $oidc.secret.create }}
             {{- if $oidc.clientID }}
@@ -91,11 +97,6 @@ spec:
                   name: {{ $oidc.secret.name }}
                   key: scopes
             {{- end }}
-            {{- else if $oidc.externalSecret.enabled }}
-            # Check if externalSecret is enabled
-            envFrom:
-            - secretRef:
-                name: {{ $oidc.externalSecret.name }}
             {{- else }}
             {{- if $oidc.clientID }}
             - name: OIDC_CLIENT_ID
@@ -117,6 +118,7 @@ spec:
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
             {{- end }}
+          {{- end }}
           {{- end }}
           args:
             - "-in-cluster"

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -92,11 +92,10 @@ spec:
           image: "ghcr.io/headlamp-k8s/headlamp:v0.24.0"
           imagePullPolicy: IfNotPresent
           
-          env:
-            # Check if externalSecret is enabled
-            envFrom:
-            - secretRef:
-                name: oidc
+          # Check if externalSecret is enabled
+          envFrom:
+          - secretRef:
+              name: oidc
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"


### PR DESCRIPTION
There was a wrong k8s config written for envFrom for external secret.

Fixes: #2022