### PR TITLE
frontend: fix crash on service list page

### DIFF
--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -31,7 +31,7 @@ export default function ServiceList() {
         {
           id: 'ports',
           label: t('Ports'),
-          getValue: service => service.getPorts().join(', '),
+          getValue: service => service.getPorts()?.join(', '),
           render: service => <LabelListItem labels={service.getPorts()} />,
         },
         {


### PR DESCRIPTION
This fixes #2027 where the service list page crashes when there is at least one service without port.