### PR TITLE
frontend: MainInfoSection: Correctly handle null backLink

### DIFF
--- a/frontend/src/components/App/Notifications/__snapshots__/List.List.stories.storyshot
+++ b/frontend/src/components/App/Notifications/__snapshots__/List.List.stories.storyshot
@@ -1,22 +1,5 @@
 <div>
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
-    tabindex="0"
-    type="button"
-  >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
-    />
-    <p
-      class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
-      style="padding-top: 3px;"
-    >
-      Back
-    </p>
-    <span
-      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-    />
-  </button>
+  
   <div
     class="MuiBox-root css-j1fy4m"
   >

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -1,22 +1,5 @@
 <div>
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
-    tabindex="0"
-    type="button"
-  >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
-    />
-    <p
-      class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
-      style="padding-top: 3px;"
-    >
-      Back
-    </p>
-    <span
-      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-    />
-  </button>
+  
   <div
     class="MuiBox-root css-j1fy4m"
   >

--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSection.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSection.tsx
@@ -49,6 +49,10 @@ export function MainInfoSection(props: MainInfoSectionProps) {
   const header = typeof headerSection === 'function' ? headerSection(resource) : headerSection;
 
   function getBackLink() {
+    if (backLink === null) {
+      return false;
+    }
+
     if (!!backLink || backLink === '') {
       return backLink;
     }

--- a/frontend/src/components/common/SectionBox.tsx
+++ b/frontend/src/components/common/SectionBox.tsx
@@ -33,7 +33,7 @@ export function SectionBox(props: SectionBoxProps) {
 
   return (
     <>
-      {actualBackLink !== undefined && <BackLink to={actualBackLink} />}
+      {actualBackLink && <BackLink to={actualBackLink} />}
       <Box py={0} {...outterBoxProps}>
         {title && titleElem}
         <Box

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
@@ -8,24 +8,7 @@
       <div
         class="MuiBox-root css-p0cik4"
       >
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
-          />
-          <p
-            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
-            style="padding-top: 3px;"
-          >
-            Back
-          </p>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+        
         <div
           class="MuiBox-root css-j1fy4m"
         >


### PR DESCRIPTION
This fix explicitly handles the null case in `getBackLink()` to ensure that no back button will be shown, as defined in MainInfoSectionProps.

Fixes: #2033

### Testing
- [ ] Go to `frontend/src/components/crd/Details.tsx` and set backLink to null in the `MainInfoSection` component
- [ ] Open a cluster in Headlamp (`npm start`) and navigate to the Custom Resources page
- [ ] Click on a CRD and ensure that the back button does not appear on the CRD page