### PR TITLE
Remove unnecessary fields from the editor

### DIFF
--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -108,7 +108,7 @@ export default function EditButton(props: EditButtonProps) {
       />
       {openDialog && (
         <EditorDialog
-          item={item.jsonData}
+          item={item.getEditableObject()}
           open={openDialog}
           onClose={() => setOpenDialog(false)}
           onSave={handleSave}

--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -52,6 +52,7 @@ class CustomResourceDefinition extends makeKubeObject<KubeCRD>('crd') {
     ['apiextensions.k8s.io', 'v1', 'customresourcedefinitions'],
     ['apiextensions.k8s.io', 'v1beta1', 'customresourcedefinitions']
   );
+  static readOnlyFields = ['metadata.managedFields'];
 
   static get className(): string {
     return 'CustomResourceDefinition';


### PR DESCRIPTION
A first draft to resolve #2032. I believe there might be a better way to do this.

I've removed the Status and ManagedFields fields from the code when making the editor dialog.

Fixes: #2032
Signed-off-by: guilhane <guilhane.bourgoin@orange.com>