### PR TITLE
backend: Prevent OIDC errors when not in use

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -817,10 +817,7 @@ func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Hand
 		// skip if cluster is not using OIDC auth
 		oidcAuthConfig, err := kContext.OidcConfig()
 		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
-				err, "failed to get oidc config")
 			next.ServeHTTP(w, r)
-
 			return
 		}
 


### PR DESCRIPTION
This change prevents the spam of OIDC config errors in the logs when running the latest version of Headlamp without OIDC. Instead of logging an error when we check for the OIDC config, we simply return since we know we are not using OIDC auth.

Fixes: #1933 

### Testing
- [x] Build a custom headlamp image in minikube and point the `kubernetes-headlamp.yaml` to it
- [x] Apply the YAML (`kubectl apply -f kubernetes-headlamp.yaml`) and configure non-OIDC credentials
- [x] Run headlamp in-cluster and watch the logs for the new headlamp pod: `kubectl logs -n kube-system <pod-name> -f`
- [x] Open the app, click around, and ensure that the OIDC config errors do not appear