### PR TITLE
frontend: Improve snapshot tests to be more deterministic

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.MoreThanThreeClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.MoreThanThreeClusters.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -85,4 +85,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.NoClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.NoClusters.stories.storyshot
@@ -1,6 +1,6 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.OneExistingCluster.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.OneExistingCluster.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -31,4 +31,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.OneRecentCluster.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.OneRecentCluster.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -85,4 +85,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.ThreeClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.ThreeClusters.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -85,4 +85,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.TwoExistingClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.TwoExistingClusters.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -58,4 +58,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.TwoRecentClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.TwoRecentClusters.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -85,4 +85,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.WithObsoleteClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.WithObsoleteClusters.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-labelledby="#recent-clusters-label"
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-1vj4bu4-MuiGrid-root"
@@ -85,4 +85,4 @@
       </button>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.Basic.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.Basic.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root css-10d1a0h-MuiButtonBase-root"
     tabindex="0"
@@ -22,4 +22,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconColor.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconColor.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root css-10d1a0h-MuiButtonBase-root"
     tabindex="0"
@@ -22,4 +22,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconSize.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconSize.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root css-10d1a0h-MuiButtonBase-root"
     tabindex="0"
@@ -22,4 +22,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.Primary.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.Primary.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root css-10d1a0h-MuiButtonBase-root"
     tabindex="0"
@@ -22,4 +22,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
   >
@@ -1008,4 +1008,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Notifications/__snapshots__/List.List.stories.storyshot
+++ b/frontend/src/components/App/Notifications/__snapshots__/List.List.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
@@ -1571,4 +1571,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -794,4 +794,4 @@
       />
     </button>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.Empty.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.Empty.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -40,4 +40,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -780,4 +780,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -780,4 +780,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1190,4 +1190,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1192,4 +1192,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettingsDetails.WithAutoSave.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettingsDetails.WithAutoSave.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
@@ -99,4 +99,4 @@
       />
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettingsDetails.WithoutAutoSave.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettingsDetails.WithoutAutoSave.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
@@ -120,4 +120,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
@@ -271,4 +271,4 @@
       </dl>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/__snapshots__/TopBar.NoToken.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.NoToken.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
@@ -105,4 +105,4 @@
       />
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
@@ -117,4 +117,4 @@
       </button>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/__snapshots__/TopBar.ProcessorAction.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.ProcessorAction.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
@@ -108,4 +108,4 @@
       </p>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/__snapshots__/TopBar.Token.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.Token.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
@@ -105,4 +105,4 @@
       />
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
@@ -133,4 +133,4 @@
       </button>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/DetailsViewSection/__snapshots__/DetailsViewSection.MatchRenderIt.stories.storyshot
+++ b/frontend/src/components/DetailsViewSection/__snapshots__/DetailsViewSection.MatchRenderIt.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/DetailsViewSection/__snapshots__/DetailsViewSection.NoMatchNoRender.stories.storyshot
+++ b/frontend/src/components/DetailsViewSection/__snapshots__/DetailsViewSection.NoMatchNoRender.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Navigation"
     class="MuiBox-root css-0"
@@ -162,4 +162,4 @@
       </div>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Navigation"
     class="MuiBox-root css-0"
@@ -183,4 +183,4 @@
       </div>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Navigation"
     class="MuiBox-root css-0"
@@ -1094,4 +1094,4 @@
       </div>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Navigation"
     class="MuiBox-root css-0"
@@ -1145,4 +1145,4 @@
       </div>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.NoSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.NoSidebar.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.NotVisibleSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.NotVisibleSidebar.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <nav
     aria-label="Navigation"
     class="MuiBox-root css-0"
@@ -1145,4 +1145,4 @@
       </div>
     </div>
   </nav>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Selected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Selected.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -34,4 +34,4 @@
       </li>
     </ul>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -78,4 +78,4 @@
       </li>
     </ul>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -78,4 +78,4 @@
       </li>
     </ul>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Unselected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Unselected.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -34,4 +34,4 @@
       </li>
     </ul>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -1,7 +1,5 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <main
     class="MuiBox-root css-0"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -1,6 +1,4 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <main
     class="MuiBox-root css-0"
   >
@@ -27,4 +25,4 @@
       </div>
     </div>
   </main>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
@@ -1,5 +1,3 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <span />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
@@ -1,5 +1,3 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <span />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
@@ -1,5 +1,3 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <span />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
@@ -1,5 +1,3 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <span />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
   >
@@ -75,7 +75,6 @@
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
-                          
                           <div
                             class="recharts-wrapper"
                             style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
@@ -108,29 +107,14 @@
                                 tabindex="0"
                               >
                                 <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
-                                />
-                                <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
+                                  class="recharts-layer"
                                 >
-                                  <path
-                                    class="recharts-sector"
-                                    cx="61"
-                                    cy="61"
-                                    d="M 61,16.199999999999996
-    A 44.800000000000004,44.800000000000004,0,
-    1,1,
-    60.99921809249515,16.20000000682343
-  L 60.999410078712856,27.200000005148027
-            A 33.800000000000004,33.800000000000004,0,
-            1,0,
-            61,27.199999999999996 Z"
-                                    fill="#e0e0e0"
-                                    name="total"
-                                    role="img"
-                                    stroke="#e0e0e0"
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
                                   />
                                 </g>
@@ -193,7 +177,6 @@
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
-                          
                           <div
                             class="recharts-wrapper"
                             style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
@@ -226,29 +209,14 @@
                                 tabindex="0"
                               >
                                 <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
-                                />
-                                <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
+                                  class="recharts-layer"
                                 >
-                                  <path
-                                    class="recharts-sector"
-                                    cx="61"
-                                    cy="61"
-                                    d="M 61,16.199999999999996
-    A 44.800000000000004,44.800000000000004,0,
-    1,1,
-    60.99921809249515,16.20000000682343
-  L 60.999410078712856,27.200000005148027
-            A 33.800000000000004,33.800000000000004,0,
-            1,0,
-            61,27.199999999999996 Z"
-                                    fill="#e0e0e0"
-                                    name="total"
-                                    role="img"
-                                    stroke="#e0e0e0"
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
                                   />
                                 </g>
@@ -296,7 +264,6 @@
                           >
                             Pods
                           </p>
-                          
                         </div>
                         <p
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
@@ -312,7 +279,6 @@
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
-                          
                           <div
                             class="recharts-wrapper"
                             style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
@@ -345,55 +311,21 @@
                                 tabindex="0"
                               >
                                 <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
+                                  class="recharts-layer"
                                 >
-                                  <path
-                                    class="recharts-sector"
-                                    cx="61"
-                                    cy="61"
-                                    d="M 61,16.199999999999996
-    A 44.800000000000004,44.800000000000004,0,
-    0,1,
-    61,105.80000000000001
-  L 61,94.80000000000001
-            A 33.800000000000004,33.800000000000004,0,
-            0,0,
-            61,27.199999999999996 Z"
-                                    fill="#000"
-                                    name="ready"
-                                    role="img"
-                                    stroke="#e0e0e0"
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
                                   />
                                 </g>
-                                <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
-                                >
-                                  <path
-                                    class="recharts-sector"
-                                    cx="61"
-                                    cy="61"
-                                    d="M 61,105.80000000000001
-    A 44.800000000000004,44.800000000000004,0,
-    0,1,
-    60.99999999999999,16.199999999999996
-  L 60.99999999999999,27.199999999999996
-            A 33.800000000000004,33.800000000000004,0,
-            0,0,
-            61,94.80000000000001 Z"
-                                    fill="#c62828"
-                                    name="notReady"
-                                    role="img"
-                                    stroke="#e0e0e0"
-                                    tabindex="-1"
-                                  />
-                                </g>
-                                <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
-                                />
                                 <text
                                   class="recharts-text recharts-label"
                                   fill="#808080"
@@ -438,7 +370,6 @@
                           >
                             Nodes
                           </p>
-                          
                         </div>
                         <p
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
@@ -454,7 +385,6 @@
                           aria-live="polite"
                           class="MuiBox-root css-2esbmj"
                         >
-                          
                           <div
                             class="recharts-wrapper"
                             style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
@@ -487,36 +417,21 @@
                                 tabindex="0"
                               >
                                 <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
+                                  class="recharts-layer"
                                 >
-                                  <path
-                                    class="recharts-sector"
-                                    cx="61"
-                                    cy="61"
-                                    d="M 61,16.199999999999996
-    A 44.800000000000004,44.800000000000004,0,
-    1,1,
-    60.99921809249515,16.20000000682343
-  L 60.999410078712856,27.200000005148027
-            A 33.800000000000004,33.800000000000004,0,
-            1,0,
-            61,27.199999999999996 Z"
-                                    fill="#000"
-                                    name="ready"
-                                    role="img"
-                                    stroke="#e0e0e0"
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
                                   />
                                 </g>
-                                <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
-                                />
-                                <g
-                                  class="recharts-layer recharts-pie-sector"
-                                  tabindex="-1"
-                                />
                                 <text
                                   class="recharts-text recharts-label"
                                   fill="#808080"
@@ -704,7 +619,7 @@
                         class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-ut8iii-MuiPaper-root-MuiAlert-root"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-an9bbg-MuiPaper-root-MuiAlert-root"
                           role="alert"
                         >
                           <div
@@ -1643,4 +1558,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.Basic.stories.storyshot
+++ b/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.Basic.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="Some label"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.LargeAndColorful.stories.storyshot
+++ b/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.LargeAndColorful.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="Some label"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.LongDescription.stories.storyshot
+++ b/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.LongDescription.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="Some label"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.NoData.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.NoData.stories.storyshot
@@ -1,6 +1,6 @@
-<div>
+<DocumentFragment>
   <div
     class="recharts-responsive-container css-a9n7s9"
     style="width: 95%; height: 20px; min-width: 0;"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.Percent100.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.Percent100.stories.storyshot
@@ -1,6 +1,6 @@
-<div>
+<DocumentFragment>
   <div
     class="recharts-responsive-container css-a9n7s9"
     style="width: 95%; height: 20px; min-width: 0;"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.Percent50.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.Percent50.stories.storyshot
@@ -1,6 +1,6 @@
-<div>
+<DocumentFragment>
   <div
     class="recharts-responsive-container css-a9n7s9"
     style="width: 95%; height: 20px; min-width: 0;"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.Tooltip.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.Tooltip.stories.storyshot
@@ -1,6 +1,6 @@
-<div>
+<DocumentFragment>
   <div
     class="recharts-responsive-container css-a9n7s9"
     style="width: 95%; height: 20px; min-width: 0;"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.NoData.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.NoData.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-busy="true"
     aria-live="polite"
@@ -34,4 +34,4 @@
       </span>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent100.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent100.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-busy="false"
     aria-live="polite"
@@ -81,4 +81,4 @@
       9 / 9 Requested
     </p>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent50.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent50.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     aria-busy="false"
     aria-live="polite"
@@ -81,4 +81,4 @@
       5 / 10 Requested
     </p>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.BrokenFallback.stories.storyshot
+++ b/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.BrokenFallback.stories.storyshot
@@ -1,3 +1,3 @@
-<div>
+<DocumentFragment>
   disabled under test to avoid console spam
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.BrokenFallbackElement.stories.storyshot
+++ b/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.BrokenFallbackElement.stories.storyshot
@@ -1,3 +1,3 @@
-<div>
+<DocumentFragment>
   disabled under test to avoid console spam
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.BrokenNoFallback.stories.storyshot
+++ b/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.BrokenNoFallback.stories.storyshot
@@ -1,3 +1,3 @@
-<div>
+<DocumentFragment>
   disabled under test to avoid console spam
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.NoProblem.stories.storyshot
+++ b/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.NoProblem.stories.storyshot
@@ -1,5 +1,5 @@
-<div>
+<DocumentFragment>
   <i>
     This is not failing.
   </i>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentMessage.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentMessage.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -17,13 +17,12 @@
       </h1>
       <h2
         class="MuiTypography-root MuiTypography-h2 css-15otqr2-MuiTypography-root"
+      />
+      <h3
+        class="MuiTypography-root MuiTypography-h3 css-3hjpok-MuiTypography-root"
       >
-        <h3
-          class="MuiTypography-root MuiTypography-h3 css-3hjpok-MuiTypography-root"
-        >
-          Not sure what to do!
-        </h3>
-      </h2>
+        Not sure what to do!
+      </h3>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentTitle.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentTitle.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -38,4 +38,4 @@
       </h2>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.Default.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -29,4 +29,4 @@
       </h2>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.DifferentImage.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.DifferentImage.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -29,4 +29,4 @@
       </h2>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.NumberGraphic.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.NumberGraphic.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -25,4 +25,4 @@
       </h2>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.StringGraphic.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.StringGraphic.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -29,4 +29,4 @@
       </h2>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.StringMessage.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.StringMessage.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
   >
@@ -22,4 +22,4 @@
       </h2>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.HeaderLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.HeaderLabel.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-t0zib5-MuiGrid-root"
   >
@@ -25,4 +25,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.HeaderLabelToolTip.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.HeaderLabelToolTip.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-t0zib5-MuiGrid-root"
   >
@@ -28,4 +28,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.HoverInfoLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.HoverInfoLabel.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <p
     aria-label="hover info"
     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
@@ -6,4 +6,4 @@
   >
     Some label
   </p>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.HoverInfoLabelInfo.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.HoverInfoLabelInfo.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <p
     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
     data-mui-internal-clone-element="true"
   >
     Some label
   </p>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.IconPosition.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.IconPosition.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <p
     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
     data-mui-internal-clone-element="true"
   >
     Some label
   </p>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.LabelProps.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.LabelProps.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <p
     class="MuiTypography-root MuiTypography-body2 css-1qbbu4b-MuiTypography-root"
     data-mui-internal-clone-element="true"
   >
     Some label
   </p>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/InfoLabel.InfoLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/InfoLabel.InfoLabel.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-2 css-4lm93d-MuiGrid-root"
   >
@@ -22,4 +22,4 @@
       </span>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/NameLabel.NameLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/NameLabel.NameLabel.stories.storyshot
@@ -1,7 +1,7 @@
-<div>
+<DocumentFragment>
   <span
     class="MuiTypography-root MuiTypography-body1 css-1ukuq4j-MuiTypography-root"
   >
     A name label
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Error.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Error.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <span
     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
     style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
   >
     error
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Success.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Success.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <span
     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
     style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
   >
     success
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Warning.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Warning.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <span
     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
     style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
   >
     warning
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Label.stories/__snapshots__/ValueLabel.ValueLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/ValueLabel.ValueLabel.stories.storyshot
@@ -1,7 +1,7 @@
-<div>
+<DocumentFragment>
   <span
     class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
   >
     A ValueLabel is here
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/NameValueTable/__snapshots__/NameValueTable.Empty.stories.storyshot
+++ b/frontend/src/components/common/NameValueTable/__snapshots__/NameValueTable.Empty.stories.storyshot
@@ -1,5 +1,5 @@
-<div>
+<DocumentFragment>
   <dl
     class="MuiGrid-root MuiGrid-container css-bddxam-MuiGrid-root"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/NameValueTable/__snapshots__/NameValueTable.WithChildren.stories.storyshot
+++ b/frontend/src/components/common/NameValueTable/__snapshots__/NameValueTable.WithChildren.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <dl
     class="MuiGrid-root MuiGrid-container css-bddxam-MuiGrid-root"
   >
@@ -45,4 +45,4 @@
       </span>
     </dd>
   </dl>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/NameValueTable/__snapshots__/NameValueTable.WithHiddenLastChildren.stories.storyshot
+++ b/frontend/src/components/common/NameValueTable/__snapshots__/NameValueTable.WithHiddenLastChildren.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <dl
     class="MuiGrid-root MuiGrid-container css-bddxam-MuiGrid-root"
   >
@@ -31,4 +31,4 @@
       </span>
     </dd>
   </dl>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Closed.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Closed.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.ShowNoNotes.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.ShowNoNotes.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/UpdatePopup.Closed.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/UpdatePopup.Closed.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiSnackbar-root MuiSnackbar-anchorOriginBottomRight css-1mdvdtb-MuiSnackbar-root"
     role="presentation"
@@ -69,4 +69,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/UpdatePopup.Show.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/UpdatePopup.Show.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiSnackbar-root MuiSnackbar-anchorOriginBottomRight css-1mdvdtb-MuiSnackbar-root"
     role="presentation"
@@ -69,4 +69,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResourceClosed.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResourceClosed.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.MetadataDisplay.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.MetadataDisplay.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -95,4 +95,4 @@
       </dd>
     </dl>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.WithExtraRows.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.WithExtraRows.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -137,4 +137,4 @@
       </dd>
     </dl>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.WithOwnerReferences.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.WithOwnerReferences.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -105,11 +105,9 @@
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
           href="/"
         >
-          Deployment
-          : 
-          kube-scheduler
+          Deployment: kube-scheduler
         </a>
       </dd>
     </dl>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -722,4 +722,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -655,4 +655,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -655,4 +655,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -534,4 +534,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/SimpleEditor.Simple.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/SimpleEditor.Simple.stories.storyshot
@@ -1,7 +1,7 @@
-<div>
+<DocumentFragment>
   <textarea
     aria-label="yaml Code"
     class="css-oj69rz"
     spellcheck="false"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/ViewButton.View.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ViewButton.View.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="View YAML"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Resource/__snapshots__/ViewButton.ViewOpen.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ViewButton.ViewOpen.stories.storyshot
@@ -1,6 +1,4 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <button
     aria-label="View YAML"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
@@ -12,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Basic.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Basic.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-1v5z18m"
   >
@@ -10,8 +10,7 @@
         id="label-id"
         style="word-break: break-all; white-space: normal;"
       >
-        This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic pr
-        …
+        This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic pr…
         <button
           aria-controls="label-id"
           arial-label="Expand"
@@ -26,4 +25,4 @@
       </label>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Empty.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Empty.stories.storyshot
@@ -1,5 +1,5 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-1v5z18m"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Expanded.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Expanded.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-1v5z18m"
   >
@@ -25,4 +25,4 @@
       </label>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ShortText.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ShortText.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-1v5z18m"
   >
@@ -13,4 +13,4 @@
       </label>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -664,4 +664,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -759,4 +759,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -788,4 +788,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -788,4 +788,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -788,4 +788,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -764,4 +764,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -788,4 +788,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -689,4 +689,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -13,8 +13,7 @@
       <b>
         Current URL search:
       </b>
-       
-      ?p=2
+       ?p=2
     </p>
     <div
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
@@ -635,4 +634,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -13,8 +13,7 @@
       <b>
         Current URL search:
       </b>
-       
-      ?p=2
+       ?p=2
     </p>
     <div
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
@@ -625,4 +624,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -788,4 +788,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -491,4 +491,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -668,4 +668,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-xj31rx-MuiPaper-root"
   >
@@ -690,4 +690,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithProgress.stories.storyshot
+++ b/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithProgress.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-cmkit5-MuiPaper-root"
   >
@@ -16,7 +16,6 @@
           >
             My chart
           </p>
-          
         </div>
         <p
           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
@@ -32,7 +31,6 @@
           aria-live="polite"
           class="MuiBox-root css-2esbmj"
         >
-          
           <div
             class="recharts-wrapper"
             style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
@@ -103,4 +101,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithoutProgress.stories.storyshot
+++ b/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithoutProgress.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-cmkit5-MuiPaper-root"
   >
@@ -31,4 +31,4 @@
       />
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.JustText.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.JustText.stories.storyshot
@@ -1,5 +1,5 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthLg css-64uahr-MuiContainer-root"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.WithIcon.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.WithIcon.stories.storyshot
@@ -1,5 +1,5 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthLg css-64uahr-MuiContainer-root"
   />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.Add.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.Add.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="Add"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.Interactive.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.Interactive.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="Add"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.NotInteractive.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.NotInteractive.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="Add"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -10,4 +10,4 @@
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/ActionsNotifier.None.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ActionsNotifier.None.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/ActionsNotifier.Some.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ActionsNotifier.Some.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="SnackbarContainer-bottom SnackbarContainer-left SnackbarContainer-root css-uwcd5u"
   >
@@ -47,4 +47,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/AlertNotification.Error.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/AlertNotification.Error.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/AlertNotification.NoError.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/AlertNotification.NoError.stories.storyshot
@@ -1,1 +1,1 @@
-<div />
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/ConfirmButton.Confirm.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmButton.Confirm.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="confirm undo"
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1gp6czg-MuiButtonBase-root-MuiButton-root"
@@ -11,4 +11,4 @@
     />
   </button>
   <div />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/ConfirmButton.ExtendsButton.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmButton.ExtendsButton.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <button
     aria-label="confirm undo"
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-h2z0wl-MuiButtonBase-root-MuiButton-root"
@@ -11,4 +11,4 @@
     />
   </button>
   <div />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialog.stories.storyshot
@@ -1,5 +1,3 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <div />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialogClosed.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialogClosed.stories.storyshot
@@ -1,3 +1,3 @@
-<div>
+<DocumentFragment>
   <div />
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Dialog.Dialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.Dialog.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogAlreadyInFullScreen.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogAlreadyInFullScreen.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogWithCloseButton.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogWithCloseButton.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogWithFullScreenButton.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogWithFullScreenButton.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/LabelListItem.List.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/LabelListItem.List.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <span
     aria-label="a label
 another label
@@ -8,4 +8,4 @@ yet another label"
   >
     a label, another label, yet another label
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Link.AutoTooltip.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Link.AutoTooltip.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <span
     aria-label="a link"
     class=""
@@ -11,4 +11,4 @@
       a link
     </a>
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Link.Basic.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Link.Basic.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <a
     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
     href="/"
   >
     a link
   </a>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Link.ExplicitTooltip.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Link.ExplicitTooltip.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <span
     aria-label="A tooltip"
     class=""
@@ -11,4 +11,4 @@
       a link
     </a>
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Link.Params.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Link.Params.stories.storyshot
@@ -1,8 +1,8 @@
-<div>
+<DocumentFragment>
   <a
     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
     href="/"
   >
     a link
   </a>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Loader.WithContainer.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Loader.WithContainer.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-5cned0"
   >
@@ -23,4 +23,4 @@
       </svg>
     </span>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Loader.WithoutContainer.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Loader.WithoutContainer.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <span
     class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-wdedfu-MuiCircularProgress-root"
     role="progressbar"
@@ -19,4 +19,4 @@
       />
     </svg>
   </span>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/LogViewer.SomeLogs.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/LogViewer.SomeLogs.stories.storyshot
@@ -1,3 +1,1 @@
-<div
-  aria-hidden="true"
-/>
+<DocumentFragment />

--- a/frontend/src/components/common/__snapshots__/NamespacesAutocomplete.Some.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/NamespacesAutocomplete.Some.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1tw9w9k-MuiAutocomplete-root"
   >
@@ -64,4 +64,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionBox.CustomTitle.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.CustomTitle.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -9,4 +9,4 @@
       class="MuiBox-root css-1txv3mw"
     />
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionBox.HeaderProps.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.HeaderProps.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -26,4 +26,4 @@
       class="MuiBox-root css-1txv3mw"
     />
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionBox.Titled.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.Titled.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -26,4 +26,4 @@
       class="MuiBox-root css-1txv3mw"
     />
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionBox.TitledChildren.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.TitledChildren.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -30,4 +30,4 @@
       </p>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionBox.WithChildren.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.WithChildren.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -10,4 +10,4 @@
       </p>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionHeader.Actions.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.Actions.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -41,4 +41,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionHeader.Main.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.Main.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -19,4 +19,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionHeader.Normal.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.Normal.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -19,4 +19,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionHeader.NormalNoPadding.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.NormalNoPadding.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-17atqe3-MuiGrid-root"
   >
@@ -19,4 +19,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SectionHeader.Subsection.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.Subsection.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -19,4 +19,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1msda30-MuiPaper-root-MuiTableContainer-root"
   >
@@ -115,4 +115,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1msda30-MuiPaper-root-MuiTableContainer-root"
   >
@@ -136,4 +136,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -188,4 +188,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -164,4 +164,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -164,4 +164,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -220,4 +220,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -158,4 +158,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -153,4 +153,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -13,8 +13,7 @@
       <b>
         Current URL search:
       </b>
-       
-      ?p=2
+       ?p=2
     </p>
     <div
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1msda30-MuiPaper-root-MuiTableContainer-root"
@@ -150,4 +149,4 @@
       </table>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
   >
@@ -13,8 +13,7 @@
       <b>
         Current URL search:
       </b>
-       
-      ?p=2
+       ?p=2
     </p>
     <div
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1msda30-MuiPaper-root-MuiTableContainer-root"
@@ -140,4 +139,4 @@
       </table>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
   >
@@ -162,4 +162,4 @@
       </tbody>
     </table>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiTabs-root css-1ujnqem-MuiTabs-root"
   >
@@ -71,4 +71,4 @@
       tab body 2
     </p>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiTabs-root css-1ujnqem-MuiTabs-root"
   >
@@ -71,4 +71,4 @@
       We start on the second tab using defaultIndex=1
     </p>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -343,4 +331,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -328,7 +316,7 @@
                             </div>
                             <div
                               aria-hidden="true"
-                              class="visible scrollbar horizontal"
+                              class="invisible scrollbar horizontal"
                               role="presentation"
                               style="position: absolute; width: 0px; height: 12px; left: 0px; bottom: 0px;"
                             >
@@ -346,7 +334,7 @@
                             />
                             <div
                               aria-hidden="true"
-                              class="visible scrollbar vertical"
+                              class="invisible scrollbar vertical"
                               role="presentation"
                               style="position: absolute; width: 14px; height: 5px; right: 0px; top: 0px;"
                             >
@@ -575,7 +563,7 @@
                             </div>
                             <div
                               aria-hidden="true"
-                              class="visible scrollbar horizontal"
+                              class="invisible scrollbar horizontal"
                               role="presentation"
                               style="position: absolute; width: 0px; height: 12px; left: 0px; bottom: 0px;"
                             >
@@ -593,7 +581,7 @@
                             />
                             <div
                               aria-hidden="true"
-                              class="visible scrollbar vertical"
+                              class="invisible scrollbar vertical"
                               role="presentation"
                               style="position: absolute; width: 14px; height: 5px; right: 0px; top: 0px;"
                             >
@@ -822,7 +810,7 @@
                             </div>
                             <div
                               aria-hidden="true"
-                              class="visible scrollbar horizontal"
+                              class="invisible scrollbar horizontal"
                               role="presentation"
                               style="position: absolute; width: 0px; height: 12px; left: 0px; bottom: 0px;"
                             >
@@ -840,7 +828,7 @@
                             />
                             <div
                               aria-hidden="true"
-                              class="visible scrollbar vertical"
+                              class="invisible scrollbar vertical"
                               role="presentation"
                               style="position: absolute; width: 14px; height: 5px; right: 0px; top: 0px;"
                             >
@@ -1079,4 +1067,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -771,4 +771,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
   >
@@ -62,19 +62,7 @@
                 />
                 <div
                   class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                >
-                  <button
-                    aria-label="View YAML"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                    data-mui-internal-clone-element="true"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
                 />
@@ -1280,4 +1268,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -749,9 +749,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-11hnma5-MuiTableCell-root"
                   data-index="4"
-                >
-                  
-                </td>
+                />
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeMedium css-1k7434z-MuiTableCell-root"
                   data-index="5"
@@ -892,4 +890,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCR.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCR.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-19midj6"
   >
@@ -8,4 +8,4 @@
       Error getting custom resource nonexistentcustomresource: No mock custom resource for you
     </p>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCRD.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCRD.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-19midj6"
   >
@@ -8,4 +8,4 @@
       Error getting custom resource definition error.crd.io: No mock CRD for you
     </p>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.LoadingCRD.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.LoadingCRD.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-5cned0"
   >
@@ -23,4 +23,4 @@
       </svg>
     </span>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
   >
@@ -333,4 +333,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
   >
@@ -769,4 +769,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -208,7 +208,6 @@
                     data-mui-internal-clone-element="true"
                   >
                     *
-                    
                   </p>
                 </dd>
                 <dt
@@ -433,4 +432,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -432,4 +432,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
   >
@@ -1246,4 +1246,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -529,4 +517,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Error.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -98,4 +98,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.NoItemYet.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.NoItemYet.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -109,4 +109,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -936,4 +936,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -206,9 +206,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    php-apache
+                    Deployment/php-apache
                   </a>
                 </dd>
                 <dt
@@ -594,4 +592,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Error.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -85,4 +85,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.NoItemYet.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.NoItemYet.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -96,4 +96,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -896,9 +896,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    php-apache
+                    Deployment/php-apache
                   </a>
                 </td>
                 <td
@@ -993,9 +991,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    php-apache
+                    Deployment/php-apache
                   </a>
                 </td>
                 <td
@@ -1090,9 +1086,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    php-apache
+                    Deployment/php-apache
                   </a>
                 </td>
                 <td
@@ -1187,9 +1181,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    php-apache
+                    Deployment/php-apache
                   </a>
                 </td>
                 <td
@@ -1284,9 +1276,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    php-apache
+                    Deployment/php-apache
                   </a>
                 </td>
                 <td
@@ -1474,4 +1464,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -312,4 +300,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -339,4 +327,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -495,9 +495,7 @@
                     aria-label="Default Ingress Class"
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
-                  >
-                    
-                  </p>
+                  />
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1my6grb-MuiTableCell-root"
@@ -656,4 +654,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -461,4 +449,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -487,4 +475,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.Empty.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.Empty.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
     style="display: flex; margin-bottom: 5px;"
@@ -12,4 +12,4 @@
     </a>
     (Prefix)
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.morePath.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.morePath.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
     style="display: flex; margin-bottom: 5px;"
@@ -12,4 +12,4 @@
     </a>
     (Prefix)
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.soloPath.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.soloPath.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-0"
     style="display: flex; margin-bottom: 5px;"
@@ -12,4 +12,4 @@
     </a>
     (Prefix)
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -970,4 +970,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1280,4 +1280,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -338,4 +326,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -726,4 +726,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -451,4 +439,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -643,4 +643,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -2419,9 +2407,7 @@
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-113h9jm-MuiTableCell-root"
                         data-index="4"
-                      >
-                        
-                      </td>
+                      />
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19qh9pa-MuiTableCell-root"
                         data-index="5"
@@ -3220,4 +3206,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -722,4 +722,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
   >
@@ -45,7 +45,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-ut8iii-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-an9bbg-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -1009,9 +1009,7 @@
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-g49sdf-MuiTableCell-root"
                     data-index="7"
-                  >
-                    
-                  </td>
+                  />
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nzc431-MuiTableCell-root"
                     data-index="8"
@@ -1086,9 +1084,7 @@
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-165tvm3-MuiTableCell-root"
                     data-index="5"
-                  >
-                    
-                  </td>
+                  />
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-4hrpnu-MuiTableCell-root"
                     data-index="6"
@@ -1098,9 +1094,7 @@
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-g49sdf-MuiTableCell-root"
                     data-index="7"
-                  >
-                    
-                  </td>
+                  />
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nzc431-MuiTableCell-root"
                     data-index="8"
@@ -1248,4 +1242,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Error.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -76,19 +76,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -828,8 +816,7 @@
                     >
                       ID:
                     </span>
-                     
-                    docker.io/library/alpine@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c
+                     docker.io/library/alpine@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c
                   </p>
                 </dd>
                 <dt
@@ -1009,4 +996,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -76,19 +76,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -776,7 +764,6 @@
                   >
                     busybox
                   </p>
-                  
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-16fae59-MuiGrid-root"
@@ -930,8 +917,7 @@
                     >
                       ID:
                     </span>
-                     
-                    docker.io/library/busybox@sha256:125113b35efe765c89a8ed49593e719532318d26828c58e26b26dd7c4c28a673
+                     docker.io/library/busybox@sha256:125113b35efe765c89a8ed49593e719532318d26828c58e26b26dd7c4c28a673
                   </p>
                 </dd>
                 <dt
@@ -1029,7 +1015,6 @@
                   >
                     busybox
                   </p>
-                  
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-16fae59-MuiGrid-root"
@@ -1214,4 +1199,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -76,19 +76,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -909,8 +897,7 @@
                     >
                       ID:
                     </span>
-                     
-                    sha256:554cfcf2aa85635c0b1ae9506f36f50118419766221651e70dfdc94631317b4d
+                     sha256:554cfcf2aa85635c0b1ae9506f36f50118419766221651e70dfdc94631317b4d
                   </p>
                 </dd>
                 <dt
@@ -1177,4 +1164,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -76,19 +76,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -897,7 +885,6 @@
                   >
                     doesnotexist:nover
                   </p>
-                  
                 </dd>
               </dl>
             </div>
@@ -1068,4 +1055,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Running.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Running.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -76,19 +76,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -787,8 +775,7 @@
                     >
                       ID:
                     </span>
-                     
-                    docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+                     docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
                   </p>
                 </dd>
                 <dt
@@ -995,4 +982,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Successful.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Successful.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -76,19 +76,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -825,8 +813,7 @@
                     >
                       ID:
                     </span>
-                     
-                    docker.io/library/alpine@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c
+                     docker.io/library/alpine@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c
                   </p>
                 </dd>
                 <dt
@@ -1012,4 +999,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1011,9 +1011,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-113h9jm-MuiTableCell-root"
                   data-index="5"
-                >
-                  
-                </td>
+                />
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19qh9pa-MuiTableCell-root"
                   data-index="6"
@@ -1727,4 +1725,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/PodLogs.Logs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.Logs.stories.storyshot
@@ -1,6 +1,4 @@
-<div
-  aria-hidden="true"
->
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -801,8 +799,7 @@
                     >
                       ID:
                     </span>
-                     
-                    docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+                     docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
                   </p>
                 </dd>
                 <dt
@@ -1009,4 +1006,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/podDetailsVolumeSection.Empty.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/podDetailsVolumeSection.Empty.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -26,4 +26,4 @@
       class="MuiBox-root css-1txv3mw"
     />
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/podDetailsVolumeSection.Short.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/podDetailsVolumeSection.Short.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -157,4 +157,4 @@
       </dl>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/pod/__snapshots__/podDetailsVolumeSection.Successful.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/podDetailsVolumeSection.Successful.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -482,4 +482,4 @@
       </dl>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -266,36 +266,28 @@
                     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
                     style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
                   >
-                    Allowed disruptions
-                    :
-                    1
+                    Allowed disruptions:1
                   </span>
                   <br />
                   <span
                     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
                     style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
                   >
-                    Current
-                    :
-                    2
+                    Current:2
                   </span>
                   <br />
                   <span
                     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
                     style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
                   >
-                    Desired
-                    :
-                    1
+                    Desired:1
                   </span>
                   <br />
                   <span
                     class="MuiTypography-root MuiTypography-body1 css-tzfmv0-MuiTypography-root"
                     style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
                   >
-                    Total
-                    :
-                    2
+                    Total:2
                   </span>
                   <br />
                 </dd>
@@ -355,4 +347,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Error.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -85,4 +85,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.NoItemYet.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.NoItemYet.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -96,4 +96,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1120,4 +1120,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -287,4 +287,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Error.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -85,4 +85,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.NoItemYet.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.NoItemYet.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -96,4 +96,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -804,4 +804,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
   >
@@ -1262,4 +1262,4 @@ pod-template-hash=a123456
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -426,4 +426,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Error.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -85,4 +85,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.NoItemYet.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.NoItemYet.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -96,4 +96,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1133,4 +1133,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -312,4 +300,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -561,4 +561,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -357,4 +345,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -475,4 +463,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -860,4 +860,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -376,4 +364,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1076,9 +1076,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ixqt80-MuiTableCell-root"
                   data-index="2"
-                >
-                  
-                </td>
+                />
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-t1m8lf-MuiTableCell-root"
                   data-index="3"
@@ -1173,9 +1171,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ixqt80-MuiTableCell-root"
                   data-index="2"
-                >
-                  
-                </td>
+                />
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-t1m8lf-MuiTableCell-root"
                   data-index="3"
@@ -1203,9 +1199,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-x8g4gs-MuiTableCell-root"
                   data-index="6"
-                >
-                  
-                </td>
+                />
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeMedium css-vmbuil-MuiTableCell-root"
                   data-index="7"
@@ -1357,4 +1351,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -376,4 +364,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -808,4 +808,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -376,4 +364,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -808,4 +808,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -193,9 +181,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    Deployment
-                    /
-                    multi-container-deployment
+                    Deployment/multi-container-deployment
                   </a>
                 </dd>
                 <dt
@@ -206,9 +192,7 @@
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
                 >
-                  Update Mode
-                  :
-                  Auto
+                  Update Mode:Auto
                 </dd>
               </dl>
             </div>
@@ -326,9 +310,7 @@
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                    >
-                      
-                    </td>
+                    />
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     />
@@ -358,9 +340,7 @@
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                    >
-                      
-                    </td>
+                    />
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                     />
@@ -683,4 +663,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Error.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Error.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -85,4 +85,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.NoItemYet.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.NoItemYet.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -96,4 +96,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiBox-root css-j1fy4m"
   >
@@ -1120,4 +1120,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -476,9 +464,7 @@
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                        >
-                          
-                        </td>
+                        />
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                         >
@@ -651,4 +637,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -473,9 +461,7 @@
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                        >
-                          
-                        </td>
+                        />
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                         >
@@ -648,4 +634,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
   >
@@ -735,4 +735,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -462,9 +450,7 @@
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                        >
-                          
-                        </td>
+                        />
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                         >
@@ -637,4 +623,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
   >
@@ -67,19 +67,7 @@
               />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              >
-                <button
-                  aria-label="View YAML"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
+              />
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               />
@@ -459,9 +447,7 @@
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
-                        >
-                          
-                        </td>
+                        />
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
                         >
@@ -634,4 +620,4 @@
     </div>
   </div>
   ;
-</div>
+</DocumentFragment>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
   >
@@ -735,4 +735,4 @@
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>

--- a/frontend/src/i18n/LocaleSelect/__snapshots__/LocaleSelect.Initial.stories.storyshot
+++ b/frontend/src/i18n/LocaleSelect/__snapshots__/LocaleSelect.Initial.stories.storyshot
@@ -1,4 +1,4 @@
-<div>
+<DocumentFragment>
   <div
     class="MuiFormControl-root css-k2e4wk-MuiFormControl-root"
   >
@@ -37,4 +37,4 @@
       </svg>
     </div>
   </div>
-</div>
+</DocumentFragment>


### PR DESCRIPTION
Main change is removing "waitFor" in the test code. It would wait until rendered stuff matched the snapshot which wasn't ideal. Now it is more deterministic. Second rerender was added because material react table was misbehaving, but rerendering twice for some reason works. Also added "asFragment" as it seems to return rendered content more consistently, just using "container" would sometimes return empty div

fixes an issue with snapshots in #2042, tested by rebasing that branch on this fix 