### PR TITLE
Fix sidebar and topbar on mobile

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -399,7 +399,7 @@ export function PureTopBar({
       >
         <Toolbar
           sx={{
-            [theme.breakpoints.down('xs')]: {
+            [theme.breakpoints.down('sm')]: {
               paddingLeft: 0,
               paddingRight: 0,
             },

--- a/frontend/src/components/App/__snapshots__/TopBar.NoToken.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.NoToken.stories.storyshot
@@ -4,7 +4,7 @@
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-js7vbf-MuiToolbar-root"
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-b3zdwt-MuiToolbar-root"
     >
       <svg
         aria-hidden="true"

--- a/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
@@ -4,7 +4,7 @@
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-js7vbf-MuiToolbar-root"
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-b3zdwt-MuiToolbar-root"
     >
       <svg
         aria-hidden="true"

--- a/frontend/src/components/App/__snapshots__/TopBar.ProcessorAction.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.ProcessorAction.stories.storyshot
@@ -4,7 +4,7 @@
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-js7vbf-MuiToolbar-root"
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-b3zdwt-MuiToolbar-root"
     >
       <svg
         aria-hidden="true"

--- a/frontend/src/components/App/__snapshots__/TopBar.Token.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.Token.stories.storyshot
@@ -4,7 +4,7 @@
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-js7vbf-MuiToolbar-root"
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-b3zdwt-MuiToolbar-root"
     >
       <svg
         aria-hidden="true"

--- a/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
@@ -4,7 +4,7 @@
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed mui-fixed css-1nczbvg-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-js7vbf-MuiToolbar-root"
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-b3zdwt-MuiToolbar-root"
     >
       <svg
         aria-hidden="true"

--- a/frontend/src/components/Sidebar/HeadlampButton.tsx
+++ b/frontend/src/components/Sidebar/HeadlampButton.tsx
@@ -36,14 +36,7 @@ export default function HeadlampButton({
   }
 
   return (
-    <Box
-      sx={theme => ({
-        paddingTop: theme.spacing(1.5),
-        paddingLeft: isSmall ? 0 : open ? theme.spacing(2) : theme.spacing(1),
-        paddingBottom: theme.spacing(1),
-        margin: isSmall && !open ? 5 : 0,
-      })}
-    >
+    <Box>
       <Button
         onClick={onToggleOpen}
         sx={theme => ({

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -112,7 +112,12 @@ export default function NavigationTabs() {
           tabChangeHandler(index);
         }}
         defaultIndex={defaultIndex}
-        sx={{ maxWidth: '85vw' }}
+        sx={{
+          maxWidth: '85vw',
+          [theme.breakpoints.down('sm')]: {
+            paddingTop: theme.spacing(1),
+          },
+        }}
         ariaLabel={t('translation|Navigation Tabs')}
       />
       <Divider />

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -262,13 +262,11 @@ export function PureSidebar({
 
   const contents = (
     <>
-      {!isTemporaryDrawer && (
-        <Box
-          sx={theme => ({
-            ...theme.mixins.toolbar,
-          })}
-        />
-      )}
+      <Box
+        sx={theme => ({
+          ...theme.mixins.toolbar,
+        })}
+      />
       <Grid
         sx={{
           height: '100%',


### PR DESCRIPTION
This is based on #1720 as that PR is inactive.
I have set @tazo90 as a co-author.

fixes #1719

How to test:
- [x] Open Headlamp and set a phone-like screen ratio in the browser's devtools: the top bar is not super thick (it was 3 times as thick as expected)
- [x] Open Headlamp and set a phone-like screen ratio in the browser's devtools: navigate to Workloads in a cluster view and realize that the navigation tabs' text is not pushed almost behind the top bar.
- [x] Open Headlamp and set a phone-like screen ratio in the browser's devtools: the 1st item of the sidebars (Home or Cluster) are not hidden behind the top bar
- [x] Double check for regressions in non-small screen ratios

![Nav tabs](https://github.com/headlamp-k8s/headlamp/assets/1029635/fd784b0a-7d4b-407b-bea3-b337ab940992)
![Sidebar](https://github.com/headlamp-k8s/headlamp/assets/1029635/c4b10d16-59fd-4db2-a9f5-be955398bd07)
