### PR TITLE
Fix helm chart ingress

### DIFF
--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -378,7 +378,7 @@
               "paths": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "object"
                 }
               }
             }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -172,8 +172,8 @@ ingress:
     []
     # - host: chart-example.local
     #   paths:
-    #     path: /
-    #     type: ImplementationSpecifichosts
+    #     - path: /
+    #       type: ImplementationSpecifichosts
   # -- Ingress TLS configuration
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
Fix for values.schema.json in helm chart.
With type "string" it cannot validate paths.path array in values.yaml