### PR TITLE
charts: Fix env values type

### DIFF
--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -237,14 +237,7 @@
             "description": "Name of the environment variable"
           },
           "value": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              }
-            ],
+            "type": "string",
             "description": "Value of the environment variable"
           }
         },

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -88,10 +88,10 @@ config:
 
 # -- An optional list of environment variables
 # env:
-  # - name: KUBERNETES_SERVICE_HOST
-  #   value: localhost
-  # - name: KUBERNETES_SERVICE_PORT
-  #   value: 6443
+#   - name: KUBERNETES_SERVICE_HOST
+#     value: "localhost"
+#   - name: KUBERNETES_SERVICE_PORT
+#     value: "6443"
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
As per k8s documentation, the type of
deploy.spec.template.spec.containers.env should be "string".

Fixes: #1896