### PR TITLE
frontend: Allow editor to auto-resize in case of text size change

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -70,6 +70,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   const editorOptions = {
     selectOnLineNumbers: true,
     readOnly: isReadOnly(),
+    automaticLayout: true,
   };
   const { i18n } = useTranslation();
   const [lang, setLang] = React.useState(i18n.language);

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -425,7 +425,7 @@ export function DataField(props: DataFieldProps) {
           value={value as string}
           language={language}
           onMount={handleEditorDidMount}
-          options={{ readOnly: true, lineNumbers: 'off' }}
+          options={{ readOnly: true, lineNumbers: 'off', automaticLayout: true }}
           theme={themeName === 'dark' ? 'vs-dark' : 'light'}
         />
       </Box>
@@ -446,7 +446,7 @@ export function DataField(props: DataFieldProps) {
             value={value as string}
             language={language}
             onMount={handleEditorDidMount}
-            options={{ readOnly: true, lineNumbers: 'off' }}
+            options={{ readOnly: true, lineNumbers: 'off', automaticLayout: true }}
             theme={themeName === 'dark' ? 'vs-dark' : 'light'}
           />
         </Box>


### PR DESCRIPTION
If you to a config map view which shows data and your system text size setting is increased above 130% the monaco editor collapses, This PR allows it to resize itself on text size change