### PR TITLE
frontend: Fix table search when some values are undefined

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -272,7 +272,7 @@ function ResourceTableContent<RowItem>(props: ResourceTableProps<RowItem>) {
           };
 
           if ('getValue' in column) {
-            mrtColumn.accessorFn = column.getValue;
+            mrtColumn.accessorFn = item => column.getValue?.(item) ?? '';
           } else if ('getter' in column) {
             mrtColumn.accessorFn = column.getter;
           } else {

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -414,12 +414,12 @@
                         Class Name
                       </div>
                       <span
-                        aria-label="Sort by Class Name descending"
+                        aria-label="Sort by Class Name ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Class Name descending"
+                          aria-label="Sort by Class Name ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -494,12 +494,12 @@
                           Taints
                         </div>
                         <span
-                          aria-label="Sort by Taints descending"
+                          aria-label="Sort by Taints ascending"
                           class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                           data-mui-internal-clone-element="true"
                         >
                           <span
-                            aria-label="Sort by Taints descending"
+                            aria-label="Sort by Taints ascending"
                             class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
                             role="button"
                             tabindex="0"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -491,12 +491,12 @@
                         Allow Volume Expansion
                       </div>
                       <span
-                        aria-label="Sort by Allow Volume Expansion descending"
+                        aria-label="Sort by Allow Volume Expansion ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Allow Volume Expansion descending"
+                          aria-label="Sort by Allow Volume Expansion ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -491,12 +491,12 @@
                         Allow Volume Expansion
                       </div>
                       <span
-                        aria-label="Sort by Allow Volume Expansion descending"
+                        aria-label="Sort by Allow Volume Expansion ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Allow Volume Expansion descending"
+                          aria-label="Sort by Allow Volume Expansion ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"


### PR DESCRIPTION
Right now if you search within a table and some row cell has "undefined" as a value it crashes the page. 
This change will handle null and undefined values and replace them with a string, which table expects 