### PR TITLE
frontend k8s/service: Make spec.ports optional to reflect the K8s API 

### DIFF
--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -32,7 +32,7 @@ export default function ServiceList() {
           id: 'ports',
           label: t('Ports'),
           getValue: service => service.getPorts()?.join(', '),
-          render: service => <LabelListItem labels={service.getPorts()} />,
+          render: service => <LabelListItem labels={service.getPorts() ?? []} />,
         },
         {
           id: 'selector',

--- a/frontend/src/lib/k8s/service.ts
+++ b/frontend/src/lib/k8s/service.ts
@@ -17,7 +17,7 @@ export interface KubeLoadBalancerIngress {
 export interface KubeService extends KubeObjectInterface {
   spec: {
     clusterIP: string;
-    ports: {
+    ports?: {
       name: string;
       nodePort: number;
       port: number;


### PR DESCRIPTION
Simple PR just changing the type of spec.ports in KubeService.