### PR TITLE
github: backend-test: Skip coverage except for PRs

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Run tests and calculate code coverage
         run: |
+          set -x
           cd backend
           go test ./... -coverprofile=coverage.out -covermode=atomic -coverpkg=./...
           testcoverage=$(go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+')
@@ -72,6 +73,12 @@ jobs:
       - name: Get base branch code coverage
         if: ${{ github.event_name }} == 'pull_request'
         run: |
+          set -x
+          if [[ -z "${{ github.base_ref }}" ]]; then
+            echo "Base branch is empty. Skipping code coverage comparison."
+            exit 0
+          fi
+
           cd backend
           base_branch="${{ github.base_ref }}"
           testcoverage="${{ env.coverage }}"
@@ -86,6 +93,12 @@ jobs:
       - name: Compare code coverage
         if: ${{ github.event_name }} == 'pull_request'
         run: |
+          set -x
+          if [[ -z "${{ github.base_ref }}" ]]; then
+            echo "Base branch is empty. Skipping code coverage comparison."
+            exit 0
+          fi
+
           testcoverage="${{ env.coverage }}"
           base_coverage="${{ env.base_coverage }}"
           if [[ -z $testcoverage || -z $base_coverage ]]; then
@@ -105,6 +118,11 @@ jobs:
       - name: Comment on PR
         if: ${{ github.event_name }} == 'pull_request'
         run: |
+          set -x
+          if [[ -z "${{ github.base_ref }}" ]]; then
+            echo "Base branch is empty. Skipping code coverage comparison."
+            exit 0
+          fi
           testcoverage="${{ env.coverage }}"
           base_coverage="${{ env.base_coverage }}"
           coverage_diff="${{ env.coverage_diff }}"

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -70,6 +70,7 @@ jobs:
         shell: bash
 
       - name: Get base branch code coverage
+        if: ${{ github.event_name }} == 'pull_request'
         run: |
           cd backend
           base_branch="${{ github.base_ref }}"
@@ -83,6 +84,7 @@ jobs:
         shell: bash
 
       - name: Compare code coverage
+        if: ${{ github.event_name }} == 'pull_request'
         run: |
           testcoverage="${{ env.coverage }}"
           base_coverage="${{ env.base_coverage }}"
@@ -101,6 +103,7 @@ jobs:
         shell: bash
 
       - name: Comment on PR
+        if: ${{ github.event_name }} == 'pull_request'
         run: |
           testcoverage="${{ env.coverage }}"
           base_coverage="${{ env.base_coverage }}"


### PR DESCRIPTION
Prior to this PR, tests running from branches (not PRs) would fail in the backend coverage scripts.

- **github: backend-test: Skip coverage steps unless PR**
- **github: backend-test: Add tracing to steps for easy debugging**

### testing done

I created a testing-rc- branch which triggers the CI on branch pushes. You can see the testing-rc-... branch CI run passes now: https://github.com/headlamp-k8s/headlamp/actions/runs/9760869672 Whereas before this would fail.

---

NOTE: the charts CI failure is unrelated. There's a PR to fix it here: https://github.com/headlamp-k8s/headlamp/pull/2122