### PR TITLE
frontend: vite.config: Fix coverage report names, and excludes

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
     ],
     coverage: {
       reporter: ['text'],
+      exclude: ['node_modules/**', 'build/**']
     },
     restoreMocks: false,
     setupFiles: ['./src/setupTests.ts'],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -50,8 +50,8 @@ export default defineConfig({
       },
     ],
     coverage: {
-      reporter: ['text'],
-      exclude: ['node_modules/**', 'build/**']
+      reporter: [['text', {maxCols: 200}]],
+      exclude: ['node_modules/**', 'build/**'],
     },
     restoreMocks: false,
     setupFiles: ['./src/setupTests.ts'],


### PR DESCRIPTION
Before the names were cut off. Also node_modules were included.

For https://github.com/headlamp-k8s/headlamp/issues/2125

(As a bonus it goes from 45s to 33s on my work-laptop-slower-than-my-phone.)

### how to test

- See coverage report in CI (names are readable) See the CI run in this PR: https://github.com/headlamp-k8s/headlamp/actions/runs/9764162592/job/26951811504?pr=2127#step:5:3775
- Locally run `CI=true make frontend-test` (names are readable, and node_modules not there)
- Locally run `make frontend-test` (names are readable, and node_modules not there)
