### PR TITLE
frontend: Check translations in pre commit hook instead of a test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -117,6 +117,7 @@
     "build-typedoc": "typedoc",
     "build-storybook": "storybook build -o ../docs/development/storybook",
     "i18n": "i18next 'src/**/*.{ts,tsx}' -c ./src/i18n/i18next-parser.config.js",
+    "check-i18n": "i18next 'src/**/*.{ts,tsx}' -c ./src/i18n/i18next-parser.config.js --fail-on-update || { echo '\n\n[i18n] Some translations are missing or outdated. Run `npm run i18n` to update them.\n\n'; exit 1; }",
     "tsc": "tsc",
     "make-version": "node ./make-env.js"
   },
@@ -134,7 +135,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "npm run check-i18n && lint-staged"
     }
   },
   "lint-staged": {

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -1,12 +1,9 @@
-import { execSync } from 'child_process';
 import { error } from 'console';
 import fs from 'fs';
 import * as glob from 'glob';
 
 const path = require('node:path');
 const allowlist = require('./allowlist.json');
-
-const frontendDir = path.join(__dirname, '..', '..');
 
 /*
  * Description:
@@ -118,19 +115,5 @@ describe('Test for non-intentional repeating translation keys', () => {
   test('Decide which keys are needed if already in use', async () => {
     const result = await checkKeys();
     expect(result).toBe(true);
-  });
-});
-
-function getTranslationChanges() {
-  // Get uncommitted changes in the tracked translation files.
-  return execSync(
-    `git status -uno --porcelain ${frontendDir}/src/i18n/locales/*/*.json`
-  ).toString();
-}
-
-describe('Forgotten translations', () => {
-  test('Check uncommitted translations', async () => {
-    execSync('npm run i18n', { cwd: frontendDir });
-    expect(getTranslationChanges()).toBe('');
   });
 });


### PR DESCRIPTION
This fixes tests being run twice #2125 
This will also check translation even if you forget to run tests 