### PR TITLE
charts: Add signing of Helm charts

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -34,10 +34,37 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
+      - name: Prepare GPG key
+        run: |
+          gpg_dir=.cr-gpg
+          mkdir "$gpg_dir"
+
+          # referring keyring to private key of gpg
+          keyring="$gpg_dir/secring.gpg"
+
+          # storing base64 GPG key into keyring
+          base64 -d <<< "$GPG_KEYRING_BASE64" > "$keyring"
+
+          passphrase_file="$gpg_dir/passphrase"
+
+          # storing passphrase data into a file
+          echo "$GPG_PASSPHRASE" > "$passphrase_file"
+
+          # saving passphrase into github-environment
+          echo "CR_PASSPHRASE_FILE=$passphrase_file" >> "$GITHUB_ENV"
+
+          # saving private key into github-environemnt
+          echo "CR_KEYRING=$keyring" >> "$GITHUB_ENV"
+        env:
+          GPG_KEYRING_BASE64: "${{ secrets.GPG_KEYRING_BASE64 }}" #Referring secrets of github above
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ github.token }}"
+          CR_KEY: "${{ secrets.GPG_SIGNING_KEY_NAME }}" # Name used while creating key
+          CR_SIGN: true # set to true to sign images
         with:
           config: .github/cr.yaml
           mark_as_latest: false # only headlamp is set to latest

--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -23,6 +23,9 @@ maintainers:
 version: 0.23.0
 appVersion: 0.24.1
 annotations:
+  artifacthub.io/signKey: |
+    fingerprint: 2956B7F7167769370C93730C7264DA7B85D08A37
+    url: https://keys.openpgp.org/vks/v1/by-fingerprint/2956B7F7167769370C93730C7264DA7B85D08A37
   artifacthub.io/category: monitoring-logging
   artifacthub.io/license: Apache-2.0
   artifacthub.io/screenshots: |


### PR DESCRIPTION
This add steps to releasing of Helm charts where it uses the gpg keys to sign and release the charts.

Fixes: #1989