### PR TITLE
frontend: Adds JSON / object / KubeObjectInterface options

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -679,8 +679,11 @@ function singleApiFactory(group: string, version: string, resource: string) {
       queryParams?: QueryParameters,
       cluster?: string
     ) => streamResult(url, name, cb, errCb, queryParams, cluster),
-    post: (body: KubeObjectInterface, queryParams?: QueryParameters, cluster?: string) =>
-      post(url + asQuery(queryParams), body, true, { cluster }),
+    post: (
+      body: JSON | object | KubeObjectInterface,
+      queryParams?: QueryParameters,
+      cluster?: string
+    ) => post(url + asQuery(queryParams), body, true, { cluster }),
     put: (body: KubeObjectInterface, queryParams?: QueryParameters, cluster?: string) =>
       put(`${url}/${body.metadata.name}` + asQuery(queryParams), body, true, { cluster }),
     patch: (body: OpPatch[], name: string, queryParams?: QueryParameters, cluster?: string) =>


### PR DESCRIPTION

Linked to PR: https://github.com/headlamp-k8s/headlamp/pull/1727

## Description

This PR enhances the `singleApiFactory` function in `apiProxy.ts` to improve its flexibility. The `post` function within `singleApiFactory` has been updated to accept parameters of different types: JSON, `object`, or `KubeObjectInterface`. This change ensures that the function can handle various data formats more efficiently, making it more versatile and robust.

## Changes

- [x] Updated the `post` function in `singleApiFactory` to accept parameters of type JSON, `object`, or `KubeObjectInterface`.
