### PR TITLE
frontend: Prevent success pop-up on invalid operations

### DIFF
--- a/frontend/src/redux/clusterActionSlice.ts
+++ b/frontend/src/redux/clusterActionSlice.ts
@@ -242,7 +242,7 @@ export const executeClusterAction = createAsyncThunk(
         if (controller.signal.aborted) {
           return rejectWithValue('Action cancelled');
         }
-        callback();
+        await Promise.resolve(callback());
         dispatchSuccess();
       } catch (err) {
         if ((err as Error).message === 'Action cancelled' || controller.signal.aborted) {


### PR DESCRIPTION
This change ensures that invalid resource operations (e.g. changing a resource kind) do not trigger a success notification. Previously, the app would indicate a successful attempt to apply changes even when it is unsuccessful. Now when trying to perform an invalid apply/edit operation, instead the editor will reappear with the error message and a failure notification.

Fixes: #2123

### Testing

- [x] Create/edit a resource (using the Create button in cluster view or Edit button in resource view)
- [x] Perform an invalid operation (e.g. change the kind, add '!' to the name)
- [x] Ensure that the editor pops up with the error message and a failure notification