### PR TITLE
Makefile: github/workflows/frontend: Add i18n-check to CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,6 +78,10 @@ jobs:
         run: |
           make frontend-test
 
+      - name: Run frontend-i18n-check
+        run: |
+          make frontend-i18n-check
+  
   build:
     name: build
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ frontend-fixlint:
 frontend-tsc:
 	cd frontend && npm run tsc
 
+.PHONY: frontend-i18n-check
+frontend-i18n-check:
+	@echo "Checking translations. If this fails use: 'npm run i18n'"
+	cd frontend && npm run i18n -- --fail-on-update
+
 frontend-test:
 	cd frontend && npm run test -- --coverage
 

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -1,12 +1,9 @@
-import { execSync } from 'child_process';
 import { error } from 'console';
 import fs from 'fs';
 import * as glob from 'glob';
 
 const path = require('node:path');
 const allowlist = require('./allowlist.json');
-
-const frontendDir = path.join(__dirname, '..', '..');
 
 /*
  * Description:
@@ -118,19 +115,5 @@ describe('Test for non-intentional repeating translation keys', () => {
   test('Decide which keys are needed if already in use', async () => {
     const result = await checkKeys();
     expect(result).toBe(true);
-  });
-});
-
-function getTranslationChanges() {
-  // Get uncommitted changes in the tracked translation files.
-  return execSync(
-    `git status -uno --porcelain ${frontendDir}/src/i18n/locales/*/*.json`
-  ).toString();
-}
-
-describe('Forgotten translations', () => {
-  test('Check uncommitted translations', async () => {
-    execSync('npm run i18n', { cwd: frontendDir });
-    expect(getTranslationChanges()).toBe('');
   });
 });


### PR DESCRIPTION
Fixes tests so they are not run twice #2125

Running it inside the tests makes the translation files be written
when the tests run, causing the tests to run twice.

Running it as a pre-commit hook is a bit slow (3.0s), because
it looks at all the files that have changed, and then writes all
the translation files again.

So instead we run it in CI so it catches the issues.

