### PR TITLE
frontend: Mark some modules in pluginLib as esModule

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -35,11 +35,19 @@ import Registry, * as registryToExport from './registry';
 
 window.pluginLib = {
   ApiProxy,
-  ReactMonacoEditor,
+  ReactMonacoEditor: {
+    ...ReactMonacoEditor,
+    // required for compatibility with plugins built with webpack
+    __esModule: true,
+  },
   MonacoEditor,
   K8s,
   ConfigStore,
-  Crd,
+  Crd: {
+    ...Crd,
+    // required for compatibility with plugins built with webpack
+    __esModule: true,
+  },
   CommonComponents,
   MuiMaterial,
   MuiStyles,


### PR DESCRIPTION
To maintain compatibility with plugins that are using webpack, some modules that have default exports need to have a special __esModule property so that plugins can grab the default export

- [x] Tested Kompose plugin with current version 0.24.1 (built with webpack)
- [x] Tested Kompose plugin with main branch (plugin crashes)
- [x] Tested Kompose plugin with this change (plugin works as expected)