### PR TITLE
app: Fix defaultPluginsDir on unix

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -9,3 +9,4 @@
 /electron/windowSize.js
 /electron/plugin-management.js
 electron/windowSize.test.js
+electron/env-paths.js

--- a/app/electron/env-paths.ts
+++ b/app/electron/env-paths.ts
@@ -1,0 +1,80 @@
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+/*
+From https://github.com/sindresorhus/env-paths
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+const homedir = os.homedir();
+const tmpdir = os.tmpdir();
+const { env } = process;
+
+const macos = name => {
+  const library = path.join(homedir, 'Library');
+
+  return {
+    data: path.join(library, 'Application Support', name),
+    config: path.join(library, 'Preferences', name),
+    cache: path.join(library, 'Caches', name),
+    log: path.join(library, 'Logs', name),
+    temp: path.join(tmpdir, name),
+  };
+};
+
+const windows = name => {
+  const appData = env.APPDATA || path.join(homedir, 'AppData', 'Roaming');
+  const localAppData = env.LOCALAPPDATA || path.join(homedir, 'AppData', 'Local');
+
+  return {
+    // Data/config/cache/log are invented by me as Windows isn't opinionated about this
+    data: path.join(localAppData, name, 'Data'),
+    config: path.join(appData, name, 'Config'),
+    cache: path.join(localAppData, name, 'Cache'),
+    log: path.join(localAppData, name, 'Log'),
+    temp: path.join(tmpdir, name),
+  };
+};
+
+// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+const linux = name => {
+  const username = path.basename(homedir);
+
+  return {
+    data: path.join(env.XDG_DATA_HOME || path.join(homedir, '.local', 'share'), name),
+    config: path.join(env.XDG_CONFIG_HOME || path.join(homedir, '.config'), name),
+    cache: path.join(env.XDG_CACHE_HOME || path.join(homedir, '.cache'), name),
+    // https://wiki.debian.org/XDGBaseDirectorySpecification#state
+    log: path.join(env.XDG_STATE_HOME || path.join(homedir, '.local', 'state'), name),
+    temp: path.join(tmpdir, username, name),
+  };
+};
+
+export default function envPaths(name, { suffix = 'nodejs' } = {}) {
+  if (typeof name !== 'string') {
+    throw new TypeError(`Expected a string, got ${typeof name}`);
+  }
+
+  // Add suffix to prevent possible conflict with native apps
+  const theName = suffix ? `${name}-${suffix}` : name;
+
+  if (process.platform === 'darwin') {
+    return macos(theName);
+  }
+
+  if (process.platform === 'win32') {
+    return windows(theName);
+  }
+
+  return linux(theName);
+}

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -15,6 +15,7 @@ import semver from 'semver';
 import stream from 'stream';
 import tar from 'tar';
 import zlib from 'zlib';
+import envPaths from './env-paths';
 
 // comment out for testing
 // function sleep(ms) {
@@ -51,7 +52,7 @@ interface PluginData {
   artifacthubVersion: string;
 }
 
-class PluginManager {
+export class PluginManager {
   /**
    * Installs a plugin from the specified URL.
    * @param {string} URL - The URL of the plugin to install.
@@ -529,23 +530,7 @@ function checkValidPluginFolder(folder) {
  * @returns {string} The path to the default plugins directory.
  */
 function defaultPluginsDir() {
-  let baseDir;
-
-  switch (process.platform) {
-    case 'win32':
-      baseDir = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
-      break;
-    case 'darwin':
-      baseDir = path.join(os.homedir(), 'Library', 'Application Support');
-      break;
-    default:
-      baseDir = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
-  }
-
-  const configDirPath = path.join(baseDir, 'Headlamp');
-  const dataDir = fs.existsSync(configDirPath) ? configDirPath : baseDir;
-
-  return path.join(dataDir, 'plugins');
+  const paths = envPaths('Headlamp', { suffix: '' });
+  const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
+  return path.join(configDir, 'plugins');
 }
-
-export { PluginManager };

--- a/app/package.json
+++ b/app/package.json
@@ -119,6 +119,7 @@
       "electron/i18next.config.js",
       "electron/i18n-helper.js",
       "electron/windowSize.js",
+      "electron/env-paths.js",
       "electron/plugin-management.js"
     ],
     "extraResources": [

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "2023",
+    "target": "ES2023",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Now it gives ~/.config/Headlamp/plugins

Now it uses the same envPaths version so the plugin paths should be consistent.