### PR TITLE
plugins/examples/pod-counter: Fix notifications issue

### DIFF
--- a/plugins/examples/pod-counter/src/index.tsx
+++ b/plugins/examples/pod-counter/src/index.tsx
@@ -20,6 +20,9 @@ registerAppBarAction(PodCounter);
 
 // We can also reorder the actions in the app bar.
 registerAppBarAction(function reorderNotifications({ actions }: AppBarActionsProcessorArgs) {
+  if (!actions) {
+    return actions;
+  }
   // Remove the notifications action button
   const newActions = actions.filter(action => action.id !== DefaultAppBarAction.NOTIFICATION);
 


### PR DESCRIPTION
Was causing a crash when actions is not there.

## How to test

- Load pod-counter
- don't see a pod-counter related issue in the web dev console