### PR TITLE
app: Fix serialization error in app

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -989,7 +989,9 @@ function startElecron() {
     });
 
     mainWindow.webContents.on('dom-ready', () => {
-      mainWindow?.webContents.send('currentMenu', getDefaultAppMenu());
+      const defaultMenu = getDefaultAppMenu();
+      const currentMenu = JSON.parse(JSON.stringify(defaultMenu));
+      mainWindow?.webContents.send('currentMenu', currentMenu);
     });
 
     mainWindow.on('closed', () => {


### PR DESCRIPTION
There was a serialization error sending the data webContents.


## how to test

This error was in the console.
![image](https://github.com/user-attachments/assets/04c10b9c-c828-4ab2-9a20-9964b65f17ff)


- "Navigation" menu still works
- app-menus example plugin still works


![app-menus plugin](https://github.com/user-attachments/assets/e6bf5323-99f7-429d-ac97-4f918346caef)

