### PR TITLE
frontend: Include styles in MuiMaterial in pluginLib

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -7,6 +7,7 @@ import * as Iconify from '@iconify/react';
 import * as ReactMonacoEditor from '@monaco-editor/react';
 import * as MuiLab from '@mui/lab';
 import * as MuiMaterial from '@mui/material';
+import * as MuiMaterialStyles from '@mui/material/styles';
 import * as MuiStyles from '@mui/styles';
 import * as Lodash from 'lodash';
 import * as MonacoEditor from 'monaco-editor';
@@ -49,7 +50,10 @@ window.pluginLib = {
     __esModule: true,
   },
   CommonComponents,
-  MuiMaterial,
+  MuiMaterial: {
+    ...MuiMaterial,
+    styles: MuiMaterialStyles,
+  },
   MuiStyles,
   MuiLab,
   React,


### PR DESCRIPTION
When plugins try to use `@mui/x-tree-view/TreeView` it fails because importing `@mui/material/styles` fails. 
Webpack version (0.24.1) also fails 

This fixes that

With this fix plugins can use Tree component like so 

```
import { TreeItem } from '@mui/x-tree-view/TreeItem';
import { TreeView } from '@mui/x-tree-view/TreeView';
```

- [x] Tested by using Tree component in plugins importing the treeview (on main and 0.24.1)