### PR TITLE
github: build-container: Fix container build

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -118,8 +118,8 @@ jobs:
       run: kubectl apply -f e2e-tests/kubernetes-headlamp-ci.yaml
     - name: Run e2e tests
       run: |
-        echo "------------------------------------sleeping 3...------------------------------------"
-        sleep 6
+        echo "------------------------------------sleeping 12...------------------------------------"
+        sleep 12
         kubectl get services --all-namespaces
         kubectl get deployments -n kube-system
         echo "------------------Waiting for headlamp deployment to be available...------------------"


### PR DESCRIPTION
Wait a bit longer for headlamp service, because before often it would fail.

- some failing builds: https://github.com/headlamp-k8s/headlamp/actions/runs/10041408876/job/27749428400 https://github.com/headlamp-k8s/headlamp/actions/runs/10041295773/job/27749068280
- passes now: https://github.com/headlamp-k8s/headlamp/actions/runs/10041825495/job/27750786807 , https://github.com/headlamp-k8s/headlamp/actions/runs/10042072148/job/27751631559?pr=2186 , https://github.com/headlamp-k8s/headlamp/actions/runs/10042072148/job/27751631559
