### PR TITLE
github: build-container: Fix cached image loading

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         path: ~/image-cache
         # cache the container image. All the paths this PR depends on except the e2e-tests folder for the key.
-        key: ${{ runner.os }}-image-${{ hashFiles('backend/pkg/**', 'backend/cmd/**', 'frontend/src/**', 'frontend/package.json', 'frontend/package-lock.json', 'Makefile', '.github/**', 'Dockerfile', 'Dockerfile.plugins') }}
+        key: ${{ runner.os }}-image-${{ hashFiles('backend/pkg/**', 'backend/cmd/**', 'backend/go.*', 'frontend/src/**', 'frontend/package.json', 'frontend/package-lock.json', 'Makefile', '.github/workflows/build-container.yml', 'Dockerfile', 'Dockerfile.plugins') }}
     - name: Restore Cached Docker Images
       if: steps.cache-image-restore.outputs.cache-hit == 'true'
       run: |
@@ -81,7 +81,6 @@ jobs:
         echo -n "verifying images:"
         docker images
     - name: Import images to kind
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
       run: |
         export SHELL=/bin/bash
         kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-test:latest --name test


### PR DESCRIPTION
Before cached images meant that the e2e tests would fail.

Additionally, before changing go dependencies meant that the
image would not rebuild. Now if backend dependencies change
a new image is built and tested.

In this job you'll see that it uses a cached image, and the job fails. https://github.com/headlamp-k8s/headlamp/actions/runs/10042659886/job/27753598525

It seems to be because when things are cached we were skipping loading the images into kind. So we change it to always load the images into kind... no matter if the image is built or restored from cache.


---

There's a test of the caching behavior in the PR here: https://github.com/headlamp-k8s/headlamp/pull/2189
The job that successfully builds even though it is using caching is here: https://github.com/headlamp-k8s/headlamp/actions/runs/10044873649/job/27795185747