### PR TITLE
frontend: apiProxy: Pass in namespace to testAuth

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -1641,8 +1641,8 @@ export async function metrics(
 //@todo: these need documenting.
 //@todo: these need return types.
 
-export async function testAuth(cluster = '') {
-  const spec = { namespace: 'default' };
+export async function testAuth(cluster = '', namespace = 'default') {
+  const spec = { namespace };
   const clusterName = cluster || getCluster();
 
   return post('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews', { spec }, false, {


### PR DESCRIPTION
This fix allows `testAuth` to take in a namespace parameter if given and fall back to using the default namespace if not given. Added changes to the `testAuth` tests in `apiProxy.test.ts` to account for this.

related: #754

### Testing
- [x] Run `cd frontend && npm test -- --coverage`
- [x] Ensure that `testAuth` tests in `apiProxy.test.ts` are successful