### PR TITLE
winget: Updates  manifest schema

### DIFF
--- a/app/windows/winget/templates/Headlamp.Headlamp.installer.yaml
+++ b/app/windows/winget/templates/Headlamp.Headlamp.installer.yaml
@@ -1,23 +1,15 @@
 PackageIdentifier: Headlamp.Headlamp
 PackageVersion: __PACKAGE_VERSION__
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+ReleaseDate: __RELEASE_DATE__
 Installers:
   - Architecture: x64
-    InstallerLocale: en-US
-    InstallerType: exe
     InstallerUrl: __INSTALLER_URL__
     InstallerSha256: __INSTALLER_SHA256__
-    Scope: user
-    InstallModes:
-      - interactive
-      - silent
-    InstallerSwitches:
-      Silent: /S
-      SilentWithProgress: /S
-    AppsAndFeaturesEntries:
-      - DisplayName: Headlamp
-        DisplayVersion: __PACKAGE_VERSION__
-        Publisher: Headlamp
-        InstallerType: exe
-    ReleaseDate: __RELEASE_DATE__
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/app/windows/winget/templates/Headlamp.Headlamp.locale.en-US.yaml
+++ b/app/windows/winget/templates/Headlamp.Headlamp.locale.en-US.yaml
@@ -19,9 +19,9 @@ Tags:
   - monitoring
   - logging
   - cncf
+ReleaseNotesUrl: __RELEASE_NOTES_URL__
 Documentations:
   - DocumentLabel: headlamp documentation
     DocumentUrl: https://headlamp.dev/docs/latest
-ReleaseNotesUrl: __RELEASE_NOTES_URL__
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/app/windows/winget/templates/Headlamp.Headlamp.yaml
+++ b/app/windows/winget/templates/Headlamp.Headlamp.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: Headlamp.Headlamp
 PackageVersion: __PACKAGE_VERSION__
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
# Update Winget Schema to 1.6.0

Fixes #2191 

## Description

This PR updates the Winget schema used in Headlamp from version 1.5.0 to 1.6.0. Additionally, the `DisplayVersion` field, which has been removed by Winget contributors, is removed to align with the latest schema requirements and maintain compatibility.

## Changes

- [x] Updated Winget schema version from 1.5.0 to 1.6.0.
- [x] Removed the deprecated `DisplayVersion` field as per Winget contributors' guidelines.

## Verification

- [x] Ensured that the schema update to 1.6.0 is correctly implemented and all references are updated.
- [x] Verified that removing the `DisplayVersion` field does not cause any issues and aligns with the latest Winget schema.