### PR TITLE
frontend: Update typedoc version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -127,9 +127,9 @@
         "redux-mock-store": "^1.5.4",
         "resize-observer-polyfill": "^1.5.1",
         "storybook": "^7.6.7",
-        "typedoc": "0.22.10",
-        "typedoc-plugin-markdown": "3.11.14",
-        "typedoc-plugin-rename-defaults": "0.4.0",
+        "typedoc": "^0.26.5",
+        "typedoc-plugin-markdown": "^4.2.3",
+        "typedoc-plugin-rename-defaults": "^0.7.1",
         "vitest-canvas-mock": "^0.3.3",
         "vitest-websocket-mock": "^0.3.0",
         "vm-browserify": "^1.1.2"
@@ -5792,6 +5792,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-mc1cLbm6UQ8RxLc0dZES7v5rkH+99LxQp/ZvTqV3NLyYsO/fD6JhEflP1H5b2SDq9gI0+0G36AVZWxvounfR9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -19207,12 +19227,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -19476,6 +19490,16 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/lint-staged": {
       "version": "10.5.4",
@@ -20015,6 +20039,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/markdown-to-jsx": {
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.7.tgz",
@@ -20026,18 +20068,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/matcher-collection": {
@@ -20227,6 +20257,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -22907,6 +22944,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-2.1.1.tgz",
@@ -24816,14 +24863,24 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
-      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.12.0.tgz",
+      "integrity": "sha512-BuAxWOm5JhRcbSOl7XCei8wGjgJJonnV0oipUupPY58iULxUGyHhW5CF+9FRMuM1pcJ5cGEJGll1LusX6FwpPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "@shikijs/core": "1.12.0",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/shiki/node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/side-channel": {
@@ -26322,67 +26379,104 @@
       "license": "MIT"
     },
     "node_modules/typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.26.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.5.tgz",
+      "integrity": "sha512-Vn9YKdjKtDZqSk+by7beZ+xzkkr8T8CYoiasqyt4TTRFy5+UHzL/mF/o4wGBjRF+rlWQHDb0t6xCpA3JNL5phg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "shiki": "^1.9.1",
+        "yaml": "^2.4.5"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "3.11.14",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.14.tgz",
-      "integrity": "sha512-lh47OQvl0079nB18YL9wuTRRhMpjo300SZKfx/xpQY8qG+GINeSxTod95QBELeI0NP81sNtUbemRDrn5nyef4Q==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.2.3.tgz",
+      "integrity": "sha512-esucQj79SFYOv0f5XVha7QWdLUH5C5HRlDf7Z8CXzHedmVPn7jox6Gt7FdoBXN8AFxyHpa3Lbuxu65Dobwt+4Q==",
       "dev": true,
-      "dependencies": {
-        "handlebars": "^4.7.7"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "typedoc": ">=0.22.0"
+        "typedoc": "0.26.x"
       }
     },
     "node_modules/typedoc-plugin-rename-defaults": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.4.0.tgz",
-      "integrity": "sha512-7m7MbNZKcxCA4Z+0MW06sFEmuQ+he1xfc+rLRtvvQcQypPTd3fgFmkEJKVu42t8mONC+kKS/WkbmqwzsiqI1YQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.1.tgz",
+      "integrity": "sha512-hgg4mAy5IumgUmPOnVVGmGywjTGtUCmRJ2jRbseqtXdlUuYKj652ODL9joUWFt5uvNu4Dr/pNILc/qsKGHJw+w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^8.0.0"
+      },
       "peerDependencies": {
-        "typedoc": "0.22.x"
+        "typedoc": ">=0.22.x <0.27.x"
       }
     },
-    "node_modules/typedoc/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+    "node_modules/typedoc-plugin-rename-defaults/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typedoc/node_modules/yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/typescript": {
@@ -26396,6 +26490,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.5.3",
@@ -27880,18 +27981,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-      "dev": true
     },
     "node_modules/vue-template-compiler": {
       "version": "2.7.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -205,9 +205,9 @@
     "redux-mock-store": "^1.5.4",
     "resize-observer-polyfill": "^1.5.1",
     "storybook": "^7.6.7",
-    "typedoc": "0.22.10",
-    "typedoc-plugin-markdown": "3.11.14",
-    "typedoc-plugin-rename-defaults": "0.4.0",
+    "typedoc": "^0.26.5",
+    "typedoc-plugin-markdown": "^4.2.3",
+    "typedoc-plugin-rename-defaults": "^0.7.1",
     "vitest-canvas-mock": "^0.3.3",
     "vitest-websocket-mock": "^0.3.0",
     "vm-browserify": "^1.1.2"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,6 +20,7 @@
   "include": ["src"],
   "typedocOptions": {
     "out": "../docs/development/api",
+    "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-rename-defaults"],
     "entryPoints": [
       "src/lib/k8s/",
       "src/redux/reducers/reducers.tsx",
@@ -34,9 +35,14 @@
     "excludePrivate": true,
     "excludeProtected": true,
     "readme": "none",
-    "hideInPageTOC": true,
     "name": "API",
-    "indexTitle": "API Reference",
-    "entryDocument": "API.md"
+    "useCodeBlocks": "true",
+    "entryFileName": "API.md",
+    "hidePageHeader": "true",
+    "hideBreadcrumbs": "true",
+    "expandParameters": "true",
+    "parametersFormat": "table",
+    "indexFormat": "table",
+    "classPropertiesFormat": "table"
   }
 }


### PR DESCRIPTION
Required for new typescript version https://github.com/headlamp-k8s/headlamp/pull/2219

The latest typedoc and markdown have some breaking changes resulting in a different file format. It's a bit easier to navigate than the current one but still not the best. There's some work needed to make the API docs more approachable.

Testing done:

- [x] Generated new API docs and previewed them in the headlamp website

Actions needed after this:

- [ ] Update links in the documentation that point to any page in API (since folder structure is different now)
- [ ] Explore more options/plugins for typedoc to make API reference more approachable 

For now I'm keeping the current generated API docs as is