### PR TITLE
charts: Fix script to tests charts template

### DIFF
--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,10 +45,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -70,10 +70,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -97,7 +97,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.24.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -29,10 +29,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49,10 +49,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -74,10 +74,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -101,7 +101,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.24.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,10 +45,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -70,10 +70,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -97,7 +97,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.24.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -17,10 +17,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37,10 +37,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -62,10 +62,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -89,7 +89,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.24.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -17,10 +17,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37,10 +37,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -62,10 +62,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -89,7 +89,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.24.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.0"
           imagePullPolicy: IfNotPresent
           
           # Check if externalSecret is enabled

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,10 +45,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -70,10 +70,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.23.0
+    helm.sh/chart: headlamp-0.24.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.24.1"
+    app.kubernetes.io/version: "0.25.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -97,7 +97,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.24.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.0"
           imagePullPolicy: IfNotPresent
           
           env:


### PR DESCRIPTION
This updates script to test template charts, this ensures when there is new release, the expected templates are updated with the correct version before comparison, avoiding test failures due to version mismatch.

Fixes: #2240