### PR TITLE
docs: redirect broken links

### DIFF
--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -154,7 +154,7 @@ For more on how to extract files into there see "Shipping and Deploying Plugins"
 ### More on making a headlamp container image including plugins
 
 See the blog post
-"[Get up to speed deploying Headlamp with plugins](https://headlamp.dev/blog/2022/10/get-up-to-speed-deploying-headlamp-with-plugins/)"
+"[Get up to speed deploying Headlamp with plugins](https://headlamp.dev/blog/2022/10/20/get-up-to-speed-deploying-headlamp-with-plugins/)"
 for more information on building a container image with your plugins.
 
 ## Writing storybook stories

--- a/docs/development/plugins/functionality.md
+++ b/docs/development/plugins/functionality.md
@@ -57,118 +57,118 @@ what we have so far:
 ### App Bar Action
 
 Show a component in the app bar (in the top right) with
-[registerAppBarAction](../api/modules/plugin_registry.md#registerappbaraction).
+[registerAppBarAction](../api/plugin/registry/functions/registerappbaraction).
 
 ![screenshot of the header showing two actions](./images/podcounter_screenshot.png)
 
 - Example plugin shows [How To Register an App Bar Action](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/pod-counter)
-- API reference for [registerAppBarAction](../api/modules/plugin_registry.md#registerappbaraction)
+- API reference for [registerAppBarAction](../api/plugin/registry/functions/registerappbaraction)
 
 ### App Logo
 
 Change the logo (at the top left) with
-[registerAppLogo](../api/modules/plugin_registry.md#registerapplogo).
+[registerAppLogo](../api/plugin/registry/functions/registerapplogo).
 
 ![screenshot of the logo being changed](./images/change-logo.png)
 
 - Example plugin shows [How To Change The Logo](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/change-logo)
-- API reference for [registerAppLogo](../api/modules/plugin_registry.md#registerapplogo)
+- API reference for [registerAppLogo](../api/plugin/registry/functions/registerapplogo)
 
 ### App Menus
 
 Add menus when Headlamp is running as an app.
-[Headlamp.setAppMenu](../api/classes/plugin_lib.Headlamp.md#setappmenu)
+[Headlamp.setAppMenu](../api/plugin/lib/classes/Headlamp#setappmenu)
 
 ![screenshot of the logo being changed](./images/app-menus.png)
 
 - Example plugin shows [How To Add App Menus](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/app-menus)
-- API reference for [Headlamp.setAppMenu](../api/classes/plugin_lib.Headlamp.md#setappmenu)
+- API reference for [Headlamp.setAppMenu](../api/plugin/lib/classes/Headlamp#setappmenu)
 
 ### Cluster Chooser
 
 Change the Cluster Chooser button (in the middle top of the Headlamp app bar) with
-[registerClusterChooser](../api/modules/plugin_registry.md#registerclusterchooser).
+[registerClusterChooser](../api/plugin/registry/functions/registerclusterchooser).
 
 ![screenshot of the cluster chooser button](./images/cluster-chooser.png)
 
 - Example plugin shows [How To Register Cluster Chooser button](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/clusterchooser)
-- API reference for [registerClusterChooser](../api/modules/plugin_registry.md#registerclusterchooser)
+- API reference for [registerClusterChooser](../api/plugin/registry/functions/registerclusterchooser)
 
 ### Details View Header Action
 
 Show a component to the top right area of a detail view
 (in the area of the screenshot below that's highlighted as yellow)
-[registerDetailsViewHeaderAction](../api/modules/plugin_registry.md#registerdetailsviewheaderaction).
+[registerDetailsViewHeaderAction](../api/plugin/registry/functions/registerdetailsviewheaderaction).
 
 ![screenshot of the header showing two actions](./images/header_actions_screenshot.png)
 
 - Example plugin shows [How To set a Details View Header Action](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/details-view)
-- API reference for [registerDetailsViewHeaderAction](../api/modules/plugin_registry.md#registerdetailsviewheaderaction)
+- API reference for [registerDetailsViewHeaderAction](../api/plugin/registry/functions/registerdetailsviewheaderaction)
 
 ### Details View Section
 
-Change sections in cluster resources' details views with [registerDetailsViewSectionsProcessor](../api/modules/plugin_registry.md#registerdetailsviewsectionsprocessor). This allows you to remove, add, update, or shuffle sections within details views, including the back link.
+Change sections in cluster resources' details views with [registerDetailsViewSectionsProcessor](../api/plugin/registry/functions/registerdetailsviewsectionsprocessor). This allows you to remove, add, update, or shuffle sections within details views, including the back link.
 
 Or simply append a component at the bottom of different details views with
-[registerDetailsViewSection](../api/modules/plugin_registry.md#registerdetailsviewsection).
+[registerDetailsViewSection](../api/plugin/registry/functions/registerdetailsviewsection).
 
 ![screenshot of the appended Details View Section](./images/details-view.jpeg)
 
 - Example plugin shows [How To set a Details View Section](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/details-view)
-- API reference for [registerDetailsViewSection](../api/modules/plugin_registry.md#registerdetailsviewsection)
+- API reference for [registerDetailsViewSection](../api/plugin/registry/functions/registerdetailsviewsection)
 
 ### Dynamic Clusters
 
 Set a cluster dynamically, rather than have the backend read it from configuration files.
-[Headlamp.setCluster](../api/classes/plugin_lib.Headlamp.md#setcluster).
+[Headlamp.setCluster](../api/plugin/lib/classes/Headlamp.md#setcluster).
 
 - Example plugin shows [How To Dynamically Set a Cluster](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/dynamic-clusters)
-- API reference for [Headlamp.setCluster](../api/classes/plugin_lib.Headlamp.md#setcluster)
+- API reference for [Headlamp.setCluster](../api/plugin/lib/classes/Headlamp.md#setcluster)
 
 ### Route
 
 Show a component (in Headlamps main area) at a given URL with
-[registerRoute](../api/modules/plugin_registry.md#registerroute).
+[registerRoute](../api/plugin/registry/functions/registerroute).
 
 - Example plugin shows [How To Register a Route](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/sidebar), and how to remove a route.
-- API reference for [registerRoute](../api/modules/plugin_registry.md#registerroute)
-- API reference for [registerRouteFilter](../api/modules/plugin_registry.md#registerroutefilter)
+- API reference for [registerRoute](../api/plugin/registry/functions/registerroute)
+- API reference for [registerRouteFilter](../api/plugin/registry/functions/registerroutefilter)
 
 ### Sidebar Item
 
 Add sidebar items (menu on the left) with
-[registerSidebarEntry](../api/modules/plugin_registry.md#registersidebarentry).
-Remove sidebar items with [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registersidebarentryfilter).
+[registerSidebarEntry](../api/plugin/registry/functions/registersidebarentry).
+Remove sidebar items with [registerSidebarEntryFilter](../api/plugin/registry/functions/registersidebarentryfilter).
 
 ![screenshot of the sidebar being changed](./images/sidebar.png)
 
 - Example plugin shows [How To add items to the sidebar](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/sidebar), and also how to remove sidebar items.
-- API reference for [registerSidebarEntry](../api/modules/plugin_registry.md#registersidebarentry)
-- API reference for [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registersidebarentryfilter)
+- API reference for [registerSidebarEntry](../api/plugin/registry/functions/registersidebarentry)
+- API reference for [registerSidebarEntryFilter](../api/plugin/registry/functions/registersidebarentryfilter)
 
 ### Tables
 
-Change what tables across Headlamp show with [registerResourceTableColumnsProcessor](../api/modules/plugin_registry.md#registersidebarentry). This allows you to remove, add, update, or shuffle table columns.
+Change what tables across Headlamp show with [registerResourceTableColumnsProcessor](../api/plugin/registry/functions/registersidebarentry). This allows you to remove, add, update, or shuffle table columns.
 
 ![screenshot of the pods list with a context menu added by a plugin](./images/table-context-menu.png)
 
 - Example plugin shows [How to add a context menu to each row in the pods list table](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/tables).
-- API reference for [registerResourceTableColumnsProcessor](../api/modules/plugin_registry.md#registerresourcetablecolumnsprocessor)
+- API reference for [registerResourceTableColumnsProcessor](../api/plugin/registry/functions/registerresourcetablecolumnsprocessor)
 
 ### Headlamp Events
 
 Headlamp has the concept of "Headlamp events". Those are fired when something relevant happens in Headlamp.
 
-React to Headlamp events with [registerHeadlampEventCallback](../api/modules/plugin_registry.md#registerheadlampeventcallback).
+React to Headlamp events with [registerHeadlampEventCallback](../api/plugin/registry/functions/registerheadlampeventcallback).
 
 ![screenshot of a snackbar notification when an event occurred](./images/event-snackbar.png)
 
 - Example plugin shows [How to show snackbars for Headlamp events](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/headlamp-events).
-- API reference for [registerHeadlampEventCallback](../api/modules/plugin_registry.md#registerheadlampeventcallback)
+- API reference for [registerHeadlampEventCallback](../api/plugin/registry/functions/registerheadlampeventcallback)
 
 ### Plugin Settings
 
-The plugins can have user configurable settings that can be used to change the behavior of the plugin. The plugin settings can be created using [registerPluginSettings](../api/modules/plugin_registry.md#registerpluginsettings).
+The plugins can have user configurable settings that can be used to change the behavior of the plugin. The plugin settings can be created using [registerPluginSettings](../api/plugin/registry/functions/registerpluginsettings).
 
 - Example plugin shows [How to create plugin settings and use them](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/change-logo)
 


### PR DESCRIPTION
fixed links breaking after changes to API docs. See Issue [2227](https://github.com/headlamp-k8s/headlamp/issues/2227).