### PR TITLE
docs: fix bad link in plugin dev docs

### DIFF
--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -154,7 +154,7 @@ For more on how to extract files into there see "Shipping and Deploying Plugins"
 ### More on making a headlamp container image including plugins
 
 See the blog post
-"[Get up to speed deploying Headlamp with plugins](https://headlamp.dev/blog/2022/10/20/get-up-to-speed-deploying-headlamp-with-plugins/)"
+"[Get up to speed deploying Headlamp with plugins](https://headlamp.dev/blog/2022/10/20/best-practices-for-deploying-headlamp-with-plugins)"
 for more information on building a container image with your plugins.
 
 ## Writing storybook stories


### PR DESCRIPTION
This is a broken reference in the docs.

(Can anyone let me know if this doc is outdated before I invest a bunch of time and find out it doesn't work?)

I won't hold this PR up by marking it as a draft, because the link is definitely broken, but if the doc is outdated and that's why the reference is bad, then maybe we shouldn't merge it. (I'll get around to building headlamp today with flux plugin that's in development, if the documents are good, but ...)