### PR TITLE
frontend: ingress: Handle missing HTTP paths

### DIFF
--- a/frontend/src/components/ingress/Details.stories.tsx
+++ b/frontend/src/components/ingress/Details.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, Story } from '@storybook/react';
 import Ingress, { KubeIngress } from '../../lib/k8s/ingress';
 import { TestContext } from '../../test';
 import Details from './Details';
-import { PORT_INGRESS, RESOURCE_INGRESS } from './storyHelper';
+import { PORT_INGRESS, RESOURCE_INGRESS, WILDCARD_TLS_INGRESS } from './storyHelper';
 
 export default {
   title: 'Ingress/DetailsView',
@@ -39,4 +39,9 @@ WithTLS.args = {
 export const WithResource = Template.bind({});
 WithResource.args = {
   ingressJson: RESOURCE_INGRESS,
+};
+
+export const WithWildcardTLS = Template.bind({});
+WithWildcardTLS.args = {
+  ingressJson: WILDCARD_TLS_INGRESS,
 };

--- a/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
@@ -1,0 +1,348 @@
+<DocumentFragment>
+  <div
+    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-p0cik4"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-w7fpvq-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+          />
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+            style="padding-top: 3px;"
+          >
+            Back
+          </p>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-p0cik4"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+              >
+                Ingress
+              </h1>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item css-43x3z6-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-p0cik4"
+      >
+        <div
+          class="MuiBox-root css-j1fy4m"
+        >
+          <div
+            aria-busy="false"
+            aria-live="polite"
+            class="MuiBox-root css-1txv3mw"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <dl
+                class="MuiGrid-root MuiGrid-container css-uximdg-MuiGrid-root"
+              >
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
+                >
+                  Name
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    wildcard-tls-example-ingress
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
+                >
+                  Namespace
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+                    href="/"
+                  >
+                    default
+                  </a>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
+                >
+                  Creation
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    2023-07-19T09:48:42.000Z
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
+                >
+                  Default Backend
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    -
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
+                >
+                  Ports
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1qti38g-MuiTypography-root"
+                  >
+                    443
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-trrd7p-MuiGrid-root"
+                >
+                  TLS
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                >
+                  <span
+                    aria-label="wildcard-cert 🞂 *.one.domain.tld, *.two.domain.tld"
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
+                    wildcard-cert 🞂 *.one.domain.tld, *.two.domain.tld
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-16fae59-MuiGrid-root"
+                >
+                  Class Name
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
+                />
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-p0cik4"
+      />
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-p0cik4"
+      >
+        <div
+          class="MuiBox-root css-j1fy4m"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1qm9nul-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-70qvj9"
+              >
+                <h2
+                  class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                >
+                  Events
+                </h2>
+                <div
+                  class="MuiBox-root css-ldp2l3"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1txv3mw"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1msda30-MuiPaper-root-MuiTableContainer-root"
+            >
+              <table
+                class="MuiTable-root css-vd1o8p-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                >
+                  <tr
+                    class="MuiTableRow-root MuiTableRow-head css-73w7uv-MuiTableRow-root"
+                  >
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-t33dlg-MuiTableCell-root"
+                      scope="col"
+                    >
+                      Type
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-t33dlg-MuiTableCell-root"
+                      scope="col"
+                    >
+                      Reason
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-t33dlg-MuiTableCell-root"
+                      scope="col"
+                    >
+                      From
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-t33dlg-MuiTableCell-root"
+                      scope="col"
+                    >
+                      Message
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-ojhczg-MuiTableCell-root"
+                      scope="col"
+                    >
+                      Age
+                      <button
+                        aria-label="sort swap"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                >
+                  <tr
+                    class="MuiTableRow-root css-73w7uv-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      Normal
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      Created
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      kubelet
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiBox-root css-k008qs"
+                      >
+                        <label
+                          id=""
+                          style="word-break: break-all; white-space: normal;"
+                        >
+                          Created
+                        </label>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1k1onho-MuiTableCell-root"
+                    >
+                      <p
+                        aria-label="2021-03-01T00:00:00.000Z"
+                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        3mo
+                      </p>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>

--- a/frontend/src/components/ingress/storyHelper.ts
+++ b/frontend/src/components/ingress/storyHelper.ts
@@ -93,6 +93,28 @@ export const RESOURCE_INGRESS = {
   },
 };
 
+export const WILDCARD_TLS_INGRESS = {
+  apiVersion: 'networking.k8s.io/v1',
+  kind: 'Ingress',
+  metadata: {
+    creationTimestamp: '2023-07-19T09:48:42Z',
+    generation: 1,
+    name: 'wildcard-tls-example-ingress',
+    namespace: 'default',
+    resourceVersion: '1234',
+    uid: 'abc1234',
+  },
+  spec: {
+    rules: [{ host: '*.one.domain.tld' }, { host: '*.two.domain.tld' }],
+    tls: [
+      {
+        hosts: ['*.one.domain.tld', '*.two.domain.tld'],
+        secretName: 'wildcard-cert',
+      },
+    ],
+  },
+};
+
 export const RESOURCE_INGRESS_CLASS = {
   apiVersion: 'networking.k8s.io/v1',
   kind: 'IngressClass',

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -92,31 +92,38 @@ class Ingress extends makeKubeObject<KubeIngress>('ingress') {
     const rules: IngressRule[] = [];
 
     this.spec!.rules?.forEach(({ http, host }) => {
-      const paths = http.paths.map(({ backend, path }) => {
-        if (!!(backend as LegacyIngressBackend).serviceName) {
-          return {
-            path,
-            backend: {
-              service: {
-                name: (backend as LegacyIngressBackend).serviceName,
-                port: {
-                  number: parseInt((backend as LegacyIngressBackend).servicePort, 10),
+      if (http) {
+        const paths = http.paths.map(({ backend, path }) => {
+          if (!!(backend as LegacyIngressBackend).serviceName) {
+            return {
+              path,
+              backend: {
+                service: {
+                  name: (backend as LegacyIngressBackend).serviceName,
+                  port: {
+                    number: parseInt((backend as LegacyIngressBackend).servicePort, 10),
+                  },
                 },
               },
-            },
-          };
-        } else {
-          return {
-            path,
-            backend: backend as IngressBackend,
-          };
-        }
-      });
+            };
+          } else {
+            return {
+              path,
+              backend: backend as IngressBackend,
+            };
+          }
+        });
 
-      rules.push({
-        host,
-        http: { paths },
-      });
+        rules.push({
+          host,
+          http: { paths },
+        });
+      } else {
+        rules.push({
+          host,
+          http: { paths: [] },
+        });
+      }
     });
 
     this.cachedRules = rules;


### PR DESCRIPTION
This change addresses a regression where Headlamp would crash when encountering an ingress that does not specify HTTP paths. This is particularly relevant for ingresses that only specify TLS settings for wildcard subdomains.

Fixes: #2261 

### Testing
- [X] Open Headlamp and apply an ingress which specifies `.spec.tls` for a wildcard subdomain, such as:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: wildcard
spec:
  rules:
    - host: '*.one.domain.tld'
    - host: '*.two.domain.tld'
  tls:
    - hosts:
        - '*.one.domain.tld'
        - '*.two.domain.tld'
      secretName: wildcard-cert
```

- [X] Navigate to the Ingresses page in the Network tab and ensure that the page does not crash