### PR TITLE
frontend: Fix refreshToken

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -208,7 +208,7 @@ async function refreshToken(token: string | null): Promise<void> {
   const decodedToken: any = decodeToken(token);
 
   // return if the token doesn't have an expiry time
-  if (!decodedToken.exp) {
+  if (!decodedToken?.exp) {
     return;
   }
   // convert expiry seconds to date object


### PR DESCRIPTION
the token expiry check in refreshToken was failing when the decodeToken returned null.this patch adds a check to see if the decodedToken exists before accessing the .exp property

Fixes: https://github.com/headlamp-k8s/headlamp/issues/2268

