### PR TITLE
frontend KubeConfigLoader: Do not override Next button's color

### DIFF
--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -102,15 +102,6 @@ const WideButton = styled(Button)({
   maxWidth: '300px',
 });
 
-const BlackButton = styled(WideButton)(({ theme }) => ({
-  backgroundColor: theme.palette.sidebarBg,
-  color: theme.palette.primaryColor,
-  '&:hover': {
-    opacity: '0.8',
-    backgroundColor: theme.palette.sidebarBg,
-  },
-}));
-
 const enum Step {
   LoadKubeConfig,
   SelectClusters,
@@ -293,7 +284,7 @@ function KubeConfigLoader() {
                     alignItems="stretch"
                   >
                     <Grid item>
-                      <BlackButton
+                      <WideButton
                         variant="contained"
                         color="primary"
                         onClick={() => {
@@ -302,7 +293,7 @@ function KubeConfigLoader() {
                         disabled={selectedClusters.length === 0}
                       >
                         {t('translation|Next')}
-                      </BlackButton>
+                      </WideButton>
                     </Grid>
                     <Grid item>
                       <WideButton
@@ -341,9 +332,9 @@ function KubeConfigLoader() {
             <Box style={{ padding: '32px' }}>
               <Typography>{t('translation|Clusters successfully set up!')}</Typography>
             </Box>
-            <BlackButton variant="contained" onClick={() => history.replace('/')}>
+            <WideButton variant="contained" onClick={() => history.replace('/')}>
               {t('translation|Finish')}
-            </BlackButton>
+            </WideButton>
           </Box>
         );
     }


### PR DESCRIPTION
The button was supposed to be black but the text was also being set as black. Since primary buttons are now blue from the theme, we shouldn't hardcode their color like that when it comes to normal buttons. This patch removes that custom styling from that "next" button, making it use the default primary color.