### PR TITLE
frontend: Add crosslinks from CR additional printercolumns to secrets

### DIFF
--- a/frontend/src/components/crd/CustomResourceDetails.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.tsx
@@ -71,6 +71,20 @@ function getExtraInfo(extraInfoSpec: AdditionalPrinterColumns, item: KubeCRD) {
     if (spec.jsonPath === '.metadata.creationTimestamp') {
       return;
     }
+    if (spec.jsonPath.toLowerCase().includes('secret')) {
+      const name = JSONPath({ path: '$' + spec.jsonPath, json: item })[0];
+      const secret = (
+        <Link routeName={'Secret'} params={{ namespace: item.metadata.namespace, name: name }}>
+          {name}
+        </Link>
+      );
+      extraInfo.push({
+        name: spec.name,
+        value: secret,
+        hide: false,
+      });
+      return;
+    }
 
     let value: string | undefined;
     try {

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -143,6 +143,19 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
 
           return value;
         },
+        render: (resource: KubeObject) => {
+          const value = getValueWithJSONPath(resource, colSpec.jsonPath);
+          const namespace = resource.metadata.namespace;
+          if (colSpec.name.toLowerCase().includes('secret') && value) {
+            return (
+              <Link routeName={'Secret'} params={{ namespace: namespace, name: value }}>
+                {value}
+              </Link>
+            );
+          } else {
+            return <span>{getValueWithJSONPath(resource, colSpec.jsonPath)}</span>;
+          }
+        },
       });
     }
 


### PR DESCRIPTION
If the additional printer column of a CRD contains the "secret" keyword, then display an hyperlink to the secret page in the same namespace.
Fix #2278
Signed-off-by: guilhane <guilhane.bourgoin@orange.com>