### PR TITLE
backend: send working list of contexts

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/headlamp-k8s/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 const kubeConfigFilePath = "./test_data/kubeconfig1"
@@ -48,17 +49,35 @@ func TestLoadContextsFromKubeConfigFile(t *testing.T) {
 	t.Run("valid_file", func(t *testing.T) {
 		kubeConfigFile := kubeConfigFilePath
 
-		contexts, err := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
-		require.NoError(t, err)
-
-		require.Equal(t, 2, len(contexts))
+		contexts, errs := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
+		require.Empty(t, errs, "Expected no errors for valid file")
+		require.Equal(t, 2, len(contexts), "Expected 2 contexts from valid file")
 	})
 
 	t.Run("invalid_file", func(t *testing.T) {
 		kubeConfigFile := "invalid_kubeconfig"
 
-		_, err := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
-		require.Error(t, err)
+		contexts, errs := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
+		require.NotEmpty(t, errs, "Expected errors for invalid file")
+		require.Empty(t, contexts, "Expected no contexts from invalid file")
+	})
+
+	t.Run("autherror", func(t *testing.T) {
+		kubeConfigFile := "./test_data/kubeconfig_autherr"
+
+		contexts, errs := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
+		require.NotEmpty(t, errs, "Expected errors for invalid auth file")
+		require.Empty(t, contexts, "Expected no contexts from invalid auth file")
+	})
+
+	t.Run("partially_valid_contexts", func(t *testing.T) {
+		kubeConfigFile := "./test_data/kubeconfig_partialcontextvalid"
+
+		contexts, errs := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
+		require.NotEmpty(t, errs, "Expected some errors for partially valid file")
+		require.NotEmpty(t, contexts, "Expected some valid contexts from partially valid file")
+		require.Equal(t, 1, len(contexts), "Expected one context from the partially valid file")
+		require.Equal(t, "valid-context", contexts[0].Name, "Expected context name to be 'valid-context'")
 	})
 }
 
@@ -107,10 +126,9 @@ func TestLoadContextsFromBase64String(t *testing.T) {
 		// Encode the content using base64 encoding
 		base64String := base64.StdEncoding.EncodeToString(kubeConfigContent)
 
-		contexts, err := kubeconfig.LoadContextsFromBase64String(base64String, kubeconfig.DynamicCluster)
-		require.NoError(t, err)
-
-		require.Equal(t, 2, len(contexts))
+		contexts, errs := kubeconfig.LoadContextsFromBase64String(base64String, kubeconfig.DynamicCluster)
+		require.Empty(t, errs, "Expected no errors for valid base64")
+		require.Equal(t, 2, len(contexts), "Expected 2 contexts from valid base64")
 		assert.Equal(t, kubeconfig.DynamicCluster, contexts[0].Source)
 	})
 
@@ -118,7 +136,179 @@ func TestLoadContextsFromBase64String(t *testing.T) {
 		invalidBase64String := "invalid_base64"
 		source := 2
 
-		_, err := kubeconfig.LoadContextsFromBase64String(invalidBase64String, source)
-		require.Error(t, err)
+		contexts, errs := kubeconfig.LoadContextsFromBase64String(invalidBase64String, source)
+		require.NotEmpty(t, errs, "Expected errors for invalid base64")
+		require.Empty(t, contexts, "Expected no contexts from invalid base64")
+	})
+
+	t.Run("partially_valid_base64", func(t *testing.T) {
+		// Create a partially valid kubeconfig content
+		partiallyValidContent := `
+apiVersion: v1
+kind: Config
+contexts:
+- name: valid-context
+  context:
+    cluster: valid-cluster
+    user: valid-user
+- name: invalid-context
+  context:
+    cluster: invalid-cluster
+    user: invalid-user
+clusters:
+- name: valid-cluster
+  cluster:
+    server: https://valid.example.com
+users:
+- name: valid-user
+  user:
+    token: valid-token
+`
+		base64String := base64.StdEncoding.EncodeToString([]byte(partiallyValidContent))
+
+		contexts, errs := kubeconfig.LoadContextsFromBase64String(base64String, kubeconfig.DynamicCluster)
+		require.NotEmpty(t, errs, "Expected some errors for partially valid base64")
+		require.NotEmpty(t, contexts, "Expected some valid contexts from partially valid base64")
+		require.Equal(t, 1, len(contexts), "Expected one valid context from partially valid base64")
+		assert.Equal(t, "valid-context", contexts[0].Name, "Expected context name to be 'valid-context'")
+	})
+}
+
+func TestSetClusterField(t *testing.T) {
+	cluster := &api.Cluster{}
+
+	t.Run("set insecure-skip-tls-verify", func(t *testing.T) {
+		err := kubeconfig.SetClusterField(cluster, "insecure-skip-tls-verify", true)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if !cluster.InsecureSkipTLSVerify {
+			t.Error("Expected InsecureSkipTLSVerify to be true")
+		}
+	})
+
+	t.Run("set disable-compression", func(t *testing.T) {
+		err := kubeconfig.SetClusterField(cluster, "disable-compression", true)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if !cluster.DisableCompression {
+			t.Error("Expected DisableCompression to be true")
+		}
+	})
+
+	t.Run("invalid bool value", func(t *testing.T) {
+		err := kubeconfig.SetClusterField(cluster, "insecure-skip-tls-verify", "not a bool")
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+	})
+
+	t.Run("set certificate-authority-data", func(t *testing.T) {
+		validBase64 := base64.StdEncoding.EncodeToString([]byte("test data"))
+
+		err := kubeconfig.SetClusterField(cluster, "certificate-authority-data", validBase64)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if string(cluster.CertificateAuthorityData) != "test data" {
+			t.Errorf("Expected 'test data', got '%s'", string(cluster.CertificateAuthorityData))
+		}
+	})
+
+	t.Run("invalid base64 data", func(t *testing.T) {
+		err := kubeconfig.SetClusterField(cluster, "certificate-authority-data", "not base64")
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+	})
+
+	t.Run("invalid extensions", func(t *testing.T) {
+		err := kubeconfig.SetClusterField(cluster, "extensions", "not a map")
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+	})
+}
+
+//nolint:funlen
+func TestSetAuthInfoField(t *testing.T) {
+	authInfo := &api.AuthInfo{}
+
+	t.Run("set client-certificate-data", func(t *testing.T) {
+		validBase64 := base64.StdEncoding.EncodeToString([]byte("test cert"))
+
+		err := kubeconfig.SetAuthInfoField(authInfo, "client-certificate-data", validBase64)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if string(authInfo.ClientCertificateData) != "test cert" {
+			t.Errorf("Expected 'test cert', got '%s'", string(authInfo.ClientCertificateData))
+		}
+	})
+
+	t.Run("set impersonate-groups", func(t *testing.T) {
+		groups := []string{"group1", "group2"}
+
+		err := kubeconfig.SetAuthInfoField(authInfo, "impersonate-groups", groups)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if len(authInfo.ImpersonateGroups) != 2 ||
+			authInfo.ImpersonateGroups[0] != "group1" ||
+			authInfo.ImpersonateGroups[1] != "group2" {
+			t.Errorf("Expected [group1 group2], got %v", authInfo.ImpersonateGroups)
+		}
+	})
+
+	t.Run("set impersonate-user-extra", func(t *testing.T) {
+		extra := map[string][]string{
+			"key1": {"value1", "value2"},
+			"key2": {"value3"},
+		}
+
+		err := kubeconfig.SetAuthInfoField(authInfo, "impersonate-user-extra", extra)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if len(authInfo.ImpersonateUserExtra) != 2 ||
+			len(authInfo.ImpersonateUserExtra["key1"]) != 2 ||
+			authInfo.ImpersonateUserExtra["key2"][0] != "value3" {
+			t.Errorf("Expected map[key1:[value1 value2] key2:[value3]], got %v", authInfo.ImpersonateUserExtra)
+		}
+	})
+
+	t.Run("set auth-provider", func(t *testing.T) {
+		provider := map[interface{}]interface{}{
+			"name": "oidc",
+			"config": map[interface{}]interface{}{
+				"client-id":     "my-client",
+				"client-secret": "my-secret",
+			},
+		}
+
+		err := kubeconfig.SetAuthInfoField(authInfo, "auth-provider", provider)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if authInfo.AuthProvider == nil ||
+			authInfo.AuthProvider.Name != "oidc" ||
+			authInfo.AuthProvider.Config["client-id"] != "my-client" {
+			t.Errorf("Expected OIDC auth provider, got %v", authInfo.AuthProvider)
+		}
+	})
+
+	t.Run("invalid field", func(t *testing.T) {
+		err := kubeconfig.SetAuthInfoField(authInfo, "invalid-field", "some value")
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
 	})
 }

--- a/backend/pkg/kubeconfig/test_data/kubeconfig_autherr
+++ b/backend/pkg/kubeconfig/test_data/kubeconfig_autherr
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: test-cluster
+  cluster:
+    server: https://test-server:6443
+contexts:
+- name: invalid-context
+  context:
+    cluster: test-cluster
+    user: invalid-user
+- context:
+    cluster: test-cluster
+    user: invalid-user
+  name: invalid-context2
+users:
+- name: invalid-user
+  user:
+    client-certificate-data: abc
+    client-key-data: abc
+current-context: invalid-context

--- a/backend/pkg/kubeconfig/test_data/kubeconfig_partialcontextvalid
+++ b/backend/pkg/kubeconfig/test_data/kubeconfig_partialcontextvalid
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: test-cluster
+  cluster:
+    server: https://test-server:6443
+contexts:
+- name: invalid-context
+  context:
+    cluster: test-cluster
+    user: invalid-user
+- context:
+    cluster: test-cluster
+    user: valid-user
+  name: valid-context
+users:
+- name: invalid-user
+  user:
+    client-certificate-data: abc
+    client-key-data: abc
+- name: valid-user
+  user:
+    client-certificate-data: dGVzdC1jZXJ0LWRhdGE=
+    client-key-data: dGVzdC1jZXJ0LWRhdGE=
+current-context: valid-context


### PR DESCRIPTION
If there is a problem with the kubeconfig in any of the context or cluster, headlamp won't be rendered useless. It would throw human readable message to the backend and show the list of working clusters.

- Fixes: #1628
- The original issue was here: https://github.com/headlamp-k8s/headlamp/issues/1349

### Testing

- In your kubeconfig add some context with partial validity. For reference please check [here](https://github.com/headlamp-k8s/headlamp/blob/e13376a49d4191032926373e11d30a1a6c5ff4f7/backend/pkg/kubeconfig/test_data/kubeconfig_partialcontextvalid)
- Run backend `cd backend && go run ./cmd -dev`
- Run frontend `cd frontend && npm start`
- You should see errors in backend and only valid clusters in frontend.
- You can try with different kubeconfig and check.