### PR TITLE
frontend: Provide fallback for makeStyles in pluginLib

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -8,6 +8,7 @@ import * as ReactMonacoEditor from '@monaco-editor/react';
 import * as MuiLab from '@mui/lab';
 import * as MuiMaterial from '@mui/material';
 import * as MuiMaterialStyles from '@mui/material/styles';
+import { styled } from '@mui/system';
 import * as Lodash from 'lodash';
 import * as MonacoEditor from 'monaco-editor';
 import * as Notistack from 'notistack';
@@ -52,6 +53,13 @@ window.pluginLib = {
   MuiMaterial: {
     ...MuiMaterial,
     styles: MuiMaterialStyles,
+  },
+  /**
+   * @mui/styles is not compatible with React.StrictMode or React 18, and it will not be updated.
+   * Workaround is using styled function from @mui/system
+   */
+  MuiStyles: {
+    makeStyles: styled,
   },
   MuiLab,
   React,


### PR DESCRIPTION
Since @mui/styles is deprecated and @mui/material/styles doesn't work with React 18 we can provide `styled` from @mui/system as a replacement for makeStyles function

This fixes prometheus plugin

## Testing done

make app-linux
Open app
See that prometheus plugin now works