### PR TITLE
github container-publish: Add qemu action + update docker action version

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -28,8 +28,10 @@ jobs:
     steps:
     - name: Check out the repo
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
+      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
     - name: Figure out the tag based on event trigger
       env:
         TRIGGER: ${{ github.event_name }}


### PR DESCRIPTION
This change was necessary to fix the container image publishing job. The newer versions were needed so that current github workers can create container images.