### PR TITLE
Export lib/k8s/cluster/getAllowedNamespaces

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -17,8 +17,24 @@ import StatefulSet from './statefulSet';
 
 export const HEADLAMP_ALLOWED_NAMESPACES = 'headlamp.allowed-namespaces';
 
-function getAllowedNamespaces() {
-  const cluster = getCluster();
+/**
+ * Gives an optionally configured list of allowed namespaces.
+ *
+ * @param cluster Optional cluster to check for allowed namespaces.
+ *                If not given the current cluster allowed name spaces are used.
+ *
+ * @returns A list of configured name spaces for the given cluster or current cluster.
+ *          If a zero length list, then no allowed namespace has been configured for cluster.
+ *          If length > 0, allowed namespaces have been configured for this cluster.
+ *          If not in a cluster it returns [].
+ *
+ * There are cases where a user doesn't have the authority to list
+ * all the namespaces. In that case it becomes difficult to access things
+ * around Headlamp. To prevent this we can allow the user to pass a set
+ * of namespaces they know they have access to and we can use this set to
+ * make requests to the API server.
+ */
+export function getAllowedNamespaces(cluster: string | null = getCluster()): string[] {
   if (!cluster) {
     return [];
   }

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.9.2",
+  "version": "0.10.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.9.2",
+      "version": "0.10.0-alpha.2",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.9.2",
+  "version": "0.10.0-alpha.2",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "main": "lib/index.js",
   "types": "./lib/additional.d.ts",


### PR DESCRIPTION
There was a request to use getAllowedNamespaces in plugins

- **frontend: k8s/cluster: Export getAllowedNamespaces**
- **headlamp-plugin: Bump version to 0.10.0-alpha.2**

Fixes #2301

## How to test

1) Use Headlamp from this branch
2) Install the alpha release of  `npm i @kinvolk/headlamp-plugin@0.10.0-alpha.2` in a plugin
3) Add this into a plugin src/index.tsx and after install the plugin with `npm start`
```ts
import { getAllowedNamespaces } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
alert(getAllowedNamespaces())
```

4) In Headlamp go to a cluster page, and go to cluster settings and add an 'allowed namespace'
5) Reload cluster page and see alert with the allowed name spaces you just added.
