### PR TITLE
frontend: Fix Chooser popup header visibility

### DIFF
--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -31,7 +31,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authtoken-dialog-title"
           style="display: flex;"
         >
@@ -71,7 +71,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <h2
             class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -54,7 +54,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authtoken-dialog-title"
           style="display: flex;"
         >
@@ -94,7 +94,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <h2
             class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -27,7 +27,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authchooser-dialog-title"
           style="display: flex;"
         >
@@ -67,7 +67,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <main
             class="MuiBox-root css-dvxtzn"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -27,7 +27,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authchooser-dialog-title"
           style="display: flex;"
         >
@@ -67,7 +67,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <main
             class="MuiBox-root css-dvxtzn"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -27,7 +27,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authchooser-dialog-title"
           style="display: flex;"
         >
@@ -67,7 +67,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <main
             class="MuiBox-root css-dvxtzn"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -27,7 +27,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authchooser-dialog-title"
           style="display: flex;"
         >
@@ -67,7 +67,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <main
             class="MuiBox-root css-dvxtzn"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -27,7 +27,7 @@
         role="dialog"
       >
         <h2
-          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-pn1b2i-MuiTypography-root-MuiDialogTitle-root"
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-wlr4ab-MuiTypography-root-MuiDialogTitle-root"
           id="authchooser-dialog-title"
           style="display: flex;"
         >
@@ -67,7 +67,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-pb2b3-MuiDialogContent-root"
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10qwcju-MuiDialogContent-root"
         >
           <main
             class="MuiBox-root css-xi606m"

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -294,7 +294,6 @@ export function ClusterDialog(props: ClusterDialogProps) {
     >
       <DialogTitle
         sx={{
-          background: theme.palette.common.black,
           textAlign: 'center',
           alignItems: 'center',
           display: 'flex',
@@ -309,10 +308,7 @@ export function ClusterDialog(props: ClusterDialogProps) {
               }}
               size="small"
             >
-              <InlineIcon
-                icon={'mdi:information-outline'}
-                color={theme.palette.primary.contrastText}
-              />
+              <InlineIcon icon={'mdi:information-outline'} />
             </IconButton>
           ),
         ]}
@@ -323,10 +319,10 @@ export function ClusterDialog(props: ClusterDialogProps) {
             height: '32px',
             width: 'auto',
           }}
-          themeName="dark"
         />
       </DialogTitle>
       <DialogContent
+        dividers
         sx={{
           [theme.breakpoints.up('sm')]: {
             minWidth: 500,


### PR DESCRIPTION
Currently the header blends in with the background and in dark mode makes Info button not visible

Current, Dark mode:

![image](https://github.com/user-attachments/assets/97497ef0-a6b9-4682-aa54-04641a418788)

Current, Light Mode:

![image](https://github.com/user-attachments/assets/bc2080c4-5c82-422d-bd49-c54a673d39c7)

After the change, Dark mode:

![image](https://github.com/user-attachments/assets/53381fd0-6d85-4e3b-a8fd-fb03ca80fd4a)

After the change, Light mode:

![image](https://github.com/user-attachments/assets/5431d3ad-2bc6-4551-88bc-a331a1619ef6)

