### PR TITLE
frontend: Fix missing optional dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -141,6 +141,11 @@
       "engines": {
         "node": ">=20.11.1",
         "npm": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "*",
+        "@rollup/rollup-linux-x64-gnu": "*",
+        "@rollup/rollup-win32-x64-msvc": "*"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,11 @@
     "vitest": "^2.0.5",
     "cheerio": "1.0.0-rc.12"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-arm64": "*",
+    "@rollup/rollup-linux-x64-gnu": "*",
+    "@rollup/rollup-win32-x64-msvc": "*"
+  },
   "scripts": {
     "prestart": "npm run make-version",
     "start": "cross-env REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp vite",


### PR DESCRIPTION
Due to bug in the NPM (https://github.com/npm/cli/issues/4828) it generates inconsistent package-lock and app may fail on other platforms

Needed for #2231 