### PR TITLE
docs: Improve documentation a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Headlamp is an easy-to-use and extensible Kubernetes web UI.
 
-Headlamp was created to be a Kubernetes web UI that has the traditional functionality of other
-web UIs/dashboards available (i.e. to list and view resources) as well as other features.
+Headlamp was created to blend the traditional feature set of other web UIs/dashboards
+(i.e., to list and view resources) with added functionality.
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/headlamp-k8s/headlamp/screenshots/videos/headlamp_quick_run.gif" width="80%">
@@ -13,7 +13,7 @@ web UIs/dashboards available (i.e. to list and view resources) as well as other 
 
 ## Features
 
-- Vendor independent / generic Kubernetes UI
+- Vendor-independent / generic Kubernetes UI
 - Works in-cluster, or locally as a desktop app
 - Multi-cluster
 - Extensible through plugins
@@ -44,8 +44,8 @@ web UIs/dashboards available (i.e. to list and view resources) as well as other 
 
 If you want to deploy Headlamp in your cluster, check out the instructions on running it [in-cluster](https://headlamp.dev/docs/latest/installation/in-cluster/).
 
-If you have a kube config already, you can quickly try Headlamp locally as a
-[desktop application](https://headlamp.dev/docs/latest/installation/desktop/),
+If you have a kubeconfig already, you can quickly try Headlamp locally as a
+[desktop application](https://headlamp.dev/docs/latest/installation/desktop/)
 for [Linux](https://headlamp.dev/docs/latest/installation/desktop/linux-installation),
 [Mac](https://headlamp.dev/docs/latest/installation/desktop/mac-installation),
 or [Windows](https://headlamp.dev/docs/latest/installation/desktop/win-installation).
@@ -55,7 +55,7 @@ in the default path so Headlamp can use it.
 ### Accessing
 
 Headlamp uses [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac) for checking
-whether and how users can access resources. If you try Headlamp with a token that has very limited
+users' access to resources. If you try Headlamp with a token that has very limited
 permissions, you may not be able to view your cluster resources correctly.
 
 See the documentation on [how to easily get a Service Account token](https://headlamp.dev/docs/latest/installation#create-a-service-account-token) for your cluster.
@@ -63,9 +63,8 @@ See the documentation on [how to easily get a Service Account token](https://hea
 ## Tested platforms
 
 We maintain a list of the [Kubernetes platforms](./docs/platforms.md) we have
-tested Headlamp with, and invite you to add any missing platform you have
-tested, or comments if there are regressions in already filed platforms that
-should be consider.
+tested Headlamp with. We invite you to add any missing platforms you have
+tested, or comment if there are any regressions in the existing ones.
 
 ## Extensions / Plugins
 
@@ -82,7 +81,7 @@ in the Kubernetes Slack.
 ## Roadmap / Release Planning
 
 If you are interested in the direction of the project, we maintain a
-[Roadmap](https://github.com/orgs/headlamp-k8s/projects/1/views/1) for it, with the
+[Roadmap](https://github.com/orgs/headlamp-k8s/projects/1/views/1). It has the
 biggest changes planned so far, as well as a [board](https://github.com/orgs/headlamp-k8s/projects/1/) tracking each release.
 
 ## License

--- a/app/README.md
+++ b/app/README.md
@@ -24,7 +24,7 @@ Note, it runs the development servers for the backend and the frontend as well. 
 - `npm run build`: Copies in all the files and compiles the code. Builds into an unpacked folder in dist/. Useful for testing.
 - `npm run compile-electron`: Compiles the TypeScript code in electron/ folder into JavaScript.
 - `npm run copy-icons`: Copies the icons from the frontend/ folders into build/icons.
-- `npm run copy-plugins`: Is used to bundle plugins in the .plugins folder into the built app.
+- `npm run copy-plugins`: Used to bundle plugins in the .plugins folder into the built app.
 - `npm run dev`: Uses the built code in ../frontend from `npm run build` in that folder.
 - `npm run dev-only-app`: Uses the development front end server.
 - `npm run i18n`: Extract the translations discovered in the electron/ folder source code.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,9 +15,9 @@ Please refer to the Kinvolk [Code of Conduct](https://github.com/kinvolk/contrib
 
 ## Development practices
 
-The Headlamp project follows the [Kinvolk Contribution Guidelines](https://github.com/kinvolk/contribution)
+The Headlamp project follows the [Kinvolk Contribution Guidelines](https://github.com/kinvolk/contribution),
 which promotes good and consistent contribution practices across Kinvolk's
-projects. Before start contributing, and in addition to this section, please
+projects. Before starting to contribute, and in addition to this section, please
 read those guidelines.
 
 ## Filing an issue or feature request
@@ -28,7 +28,7 @@ you think are useful.
 ### Security issues
 
 For filing security issues that are sensitive and should not be public, please
-send an email to security@headlamp.dev .
+send an email to <security@headlamp.dev> .
 
 ## Translations
 
@@ -38,7 +38,7 @@ dedicated [i18n docs](./development/).
 ### Complex contributions
 
 If you have a complex contribution in mind (meaning changes in the architecture
-or a lot of LOC changed), it is advisable to first file a Github issue and
+or a lot of LOC changed), it is advisable to first file a GitHub issue and
 discuss the implementation with the project's maintainers.
 
 ## Coding style
@@ -65,13 +65,13 @@ the CI checks are passing for your PR.
 
 ## Commit guidelines
 
-For the general guidelines on making PRs/commits easier to review, please check
+For general guidelines on making PRs/commits easier to review, please check
 out Kinvolk's
 [contribution guidelines on git](https://github.com/kinvolk/contribution/tree/master/topics/git.md).
 
 ## Testing
 
-The frontend is tested via Storybook related snapshots. So new components should have
+The frontend is tested via Storybook-related snapshots. So new components should have
 an associated story when possible.
 
 For running the frontend tests, use the following command:

--- a/docs/development/backend.md
+++ b/docs/development/backend.md
@@ -3,12 +3,12 @@ title: Backend
 sidebar_position: 1
 ---
 
-Headlamp's backend is written in Go and is in charge of redirecting the
-client requests to the right clusters, as well as to return any available
+Headlamp's backend is written in Go. It is in charge of redirecting
+client requests to the right clusters and returning any available
 plugins for the client to use.
 
-The backend most basic and essential function is to read the cluster information
-from the given configuration, and set up proxies to the defined clusters as
+The backend's most essential function is to read the cluster information
+from the given configuration and set up proxies to the defined clusters as
 well as endpoints to them. This means that instead of having a set of
 endpoints related to the functionality available to the client, it simply
 redirects the requests to the defined proxies.

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -36,7 +36,7 @@ make docs
 ```
 
 The API output markdown is generated in docs/development/api and is not
-committed to git, but is shown on the website at
+committed to Git, but is shown on the website at
 [headlamp/latest/development/api](https://headlamp.dev/docs/latest/development/api/)
 
 ## Storybook
@@ -50,7 +50,7 @@ make storybook
 ```
 
 If you are adding new stories, please wrap your story components with the `TestContext` helper
-component as it sets up the store, memory router, and other utilities that may be needed for
+component. This sets up the store, memory router, and other utilities that may be needed for
 current or future stories:
 
 ```jsx

--- a/docs/development/i18n/contributing.md
+++ b/docs/development/i18n/contributing.md
@@ -3,15 +3,15 @@ title: Contributing to Internationalization
 sidebar_label: Contributing
 ---
 
-This section introduces some concepts for contributing translations, and is
+This section introduces some concepts for contributing translations and is
 especially important when submitting a new language.
 
-**Important:** If you are adding a new language, keep in mind that while all
-the specific Kubernetes components' names are translatable, it doesn't mean
-that all of them should have a corresponding name in your language. Please,
-refer to the [Kubernetes localized docs](https://kubernetes.io/docs/home/) in
-your language (if they exist) in order to understand which components should
-be translated and which should be left in the original form.
+**Important:** If you add a new language, keep in mind that while all
+the specific Kubernetes components' names are translatable, not all of them
+will have a corresponding name in your language. Please refer to the
+[Kubernetes localized docs](https://kubernetes.io/docs/home/) in your
+language (if they exist) to understand which components should
+be translated and which should be left in their original form.
 
 ## Namespaces
 
@@ -32,7 +32,7 @@ In order to better express context for a translation, we use the [i18next contex
 return t("translation|Desired", { context: "pods" });
 ```
 
-In the example above, we give the extra context of "pods" for the word "Desired", meaning it refers to the concept of pod, and precisely more than one (in case the target language of
+In the example above, we give the extra context of "pods" for the word "Desired". It refers to the concept of pod, and precisely more than one (in case the target language of
 the translation distinguishes between plural and singular for this word).
 
 In the translated files, the context will show up in the respective key as:
@@ -49,19 +49,19 @@ And should be translated without that context suffix. For example, for Spanish:
 
 #### Technical Jargon words
 
-For some technical/jargon terms there often isn't a good translation for
+For some technical/jargon terms, there often isn't a good translation for
 them. To find these ones, it can be good to look at existing documentation
 like the k8s docs.
 
 The word "Pods" is a good example of a technical word that is used in Spanish.
 Maybe it could directly translate to "Vainas", but "Pods" is used instead.
 
-- https://kubernetes.io/es/docs/concepts/workloads/pods/pod/
-- https://kubernetes.io/docs/concepts/workloads/pods/pod/
+- <https://kubernetes.io/es/docs/concepts/workloads/pods/pod/>
+- <https://kubernetes.io/docs/concepts/workloads/pods/pod/>
 
 ## Number formatting
 
-Numbers are formatted in a locale specific way. For example in 'en'
+Numbers are formatted in a locale-specific way. For example in 'en'
 they are formatted like `1,000,000` but with 'de' they are formatted
 like `1.000.000`.
 
@@ -86,7 +86,7 @@ Here's an example of using date formatting:
     });
 ```
 
-## Adding a new language.
+## Adding a new language
 
 Create a folder using the locale code in:
 `frontend/src/i18n/locales/` and `app/electron/locales`
@@ -98,8 +98,8 @@ Integrated components may need to be adjusted (MaterialUI/Monaco etc).
 
 ## Translating missing strings
 
-Since technical development happens more frequently than translations, chances
-are that developers introduce new strings that need to be translated, and will
+Technical development happens more frequently than translations. Thus, chances
+are that developers introduce new strings that need to be translated and will
 be stored as empty strings (defaulting to English) in the translation files.
 
 In order to more easily spot and translate the missing strings, we have two CLI
@@ -122,7 +122,7 @@ tools:
 
 ## Material UI
 
-Some Material UI components are localized, and are configured
+Some Material UI components are localized and are configured
 via a theme provider.
 
 See the Material UI
@@ -131,7 +131,7 @@ and also `frontend/src/i18n/ThemeProviderNexti18n.tsx` where integration is done
 
 ## Storybook integration
 
-TODO: not implmented. There's no working addons that let you set a language easily.
+TODO: not implemented. There's no working addons that let you set a language easily.
 
 ## Monaco editor integration
 

--- a/docs/development/i18n/index.md
+++ b/docs/development/i18n/index.md
@@ -9,10 +9,10 @@ react-i18next libraries.
 
 ## Default language, and locales
 
-We started with an international English, and that will be the fallback language.
+We started with an international English and that will be the fallback language.
 
-Now we're starting with locales familiar, and will accept
-translations through github.
+Now we're starting with locales familiar to us and will accept
+translations through GitHub.
 
 ## Browser based language detection
 
@@ -20,7 +20,7 @@ We use
 [i18next-browser-languagedetector](https://github.com/i18next/i18next-browser-languageDetector#readme)
 
 This can select the browser language through various means like through
-cookies, the html language tag and other ways.
+cookies or the html language tag.
 
 One way to change the locale is to use `?lng=en` in the URL.
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -8,7 +8,7 @@ This is a quickstart guide for building and running Headlamp for development.
 Please make sure you read the [Contribution Guidelines](../contributing.md) as well
 before starting to contribute to the project.
 
-See [platforms](../platforms.md) to find out which browsers, OS and flavours of Kubernetes we support.
+See [platforms](../platforms.md) to find out which browsers, OS and flavors of Kubernetes we support.
 
 ## Dependencies to get started
 
@@ -86,7 +86,7 @@ make app-win
 For Windows, by default it will produce an installer using [NSIS (Nullsoft Scriptable Install System)](https://sourceforge.net/projects/nsis/).
 
 If you prefer an `.msi` installer, then be sure to install the [WiX Toolset](https://wixtoolset.org/) and have its `light.exe` and `candle.exe` in the Windows path.
-E.g. if you are using WiX Toolset version 3.11, this can be done by running the following command,
+E.g., if you are using WiX Toolset version 3.11, this can be done by running the following command,
 before the one above:
 
 ```bash
@@ -136,7 +136,7 @@ IMAGE_BASE=debian:latest make image
 
 If no IMAGE_BASE is specified, then a default image is used (see Dockerfile for exact default image used).
 
-This is useful if there are requirements on what base images can be used in an environment.
+This is useful if there are requirements on which base images can be used in an environment.
 
 So far Debian variants (including Ubuntu), and Alpine Linux are supported.
 If you have other requirements, please get in touch.
@@ -163,19 +163,19 @@ Successfully tagged headlamp-k8s/headlamp:development
 $ docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube headlamp-k8s/headlamp:development /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
 ```
 
-Then go to https://localhost:4466 in your browser.
+Then go to <https://localhost:4466> in your browser.
 
 ### Minikube "in-cluster"
 
-These instructions are for if you want to use Headlamp running "in-cluster",
+These instructions are for if you want to run Headlamp "in-cluster",
 and test it locally on minikube with a local container image.
 
-We assume you've already setup a minikube
+We assume you've already set up minikube
 (probably with `minikube start --driver=docker`).
 
 #### Container image in the minikube docker environment
 
-First we have to make the container image in the minikube docker environment.
+First, we have to make the container image in the minikube docker environment.
 This is needed because minikube looks for container images in there, not
 ones made in the local docker environment.
 
@@ -184,7 +184,7 @@ eval $(minikube docker-env)
 DOCKER_IMAGE_VERSION=development make image
 ```
 
-#### Create a deployment yaml.
+#### Create a deployment yaml
 
 ```bash
 kubectl create deployment headlamp -n kube-system --image=headlamp-k8s/headlamp:development -o yaml --dry-run -- /headlamp/headlamp-server -html-static-dir /headlamp/frontend -in-cluster -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
@@ -252,22 +252,22 @@ Go to the URL printed by minikube in your browser, and get your token to login.
 
 ### Shipping plugins in the Docker image
 
-Since the Headlamp server has an option (`-plugins-dir`) for indicating where to find any plugins,
-a deployment of Headlamp using the Docker image can mount a plugins folder
+The Headlamp server has an option (`-plugins-dir`) for indicating where to find any plugins.
+Thus, a deployment of Headlamp using the Docker image can mount a plugins folder
 and point to it by using the mentioned option.
 
 An alternative is to build an image that ships some plugins in it. For that,
-just create a ".plugins" folder in the Headlamp project directory as the Dockerfile
+just create a ".plugins" folder in the Headlamp project directory, as the Dockerfile
 will include it and point to it by default.
 
 ## Special Build Options
 
-Here are some options that can be used when building Headlamp, to change its default behavior.
+Here are some options that can be used when building Headlamp to change its default behavior.
 
 ### Update Checks
 
-When in the **desktop app**, by default, Headlamp will check for new versions from its Github page and warn the user about it,
-as well as showing the release notes after updating to a new version.
+In the **desktop app**, by default, Headlamp will check for new versions from its GitHub page and warn the user about it.
+It will also show the release notes after updating to a new version.
 
 This behavior can be turned off by adding the following to a `.env` file in the `app/` folder:
 

--- a/docs/development/oidc.md
+++ b/docs/development/oidc.md
@@ -3,7 +3,7 @@ title: Testing OIDC
 sidebar_position: 4
 ---
 
-OIDC (OpenID Connect) is a protocol that allows web applications to authenticate users through an identity provider and obtain basic profile information about the user.
+OIDC (OpenID Connect) is a protocol that allows web applications to authenticate users through an identity provider. It also obtains basic profile information about the user.
 
 ## Testing OIDC with Kubernetes API Server
 
@@ -16,7 +16,7 @@ This guide will walk you through the process of testing OIDC on a Minikube clust
 
 ### Start Minikube
 
-- Start Minikube without enabling OIDC: `minikube start`. This is done to avoid RBAC (Role-Based Access Control) issues during startup. However, we can enable OIDC once the cluster is running.
+- Start Minikube without enabling OIDC: `minikube start`. This is done to avoid RBAC (Role-Based Access Control) issues during startup. But, we can enable OIDC once the cluster is running.
 
 ### SSH into Minikube
 

--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -3,7 +3,7 @@ title: Building and Shipping Plugins
 sidebar_label: Building & Shipping
 ---
 
-This section explains how to start developing a Headlamp plugin, and how
+This section explains how to start developing a Headlamp plugin and how
 to ship it once finished.
 
 ## Creating a new plugin
@@ -26,7 +26,7 @@ Using the above commands means that Headlamp will **automatically reload**
 whenever to make a change to the plugin.
 
 ℹ️ This automatic reload does not happen when running in-cluster,
-even if the plugins folder is changed. i.e. if you want to serve
+even if the plugins folder is changed. I.e., if you want to serve
 updated plugins, you need to restart the server.
 
 ## Code Formatting, Linting, and Type Checking
@@ -89,8 +89,8 @@ npx @kinvolk/headlamp-plugin build myplugins
 
 ## Shipping and Deploying Plugins
 
-Once a plugin is ready to be shipped (built for production) it needs to
-be placed in a "plugins directory", for Headlamp to load them.
+Once a plugin is ready to be shipped (built for production), it needs to
+be placed in a "plugins directory" for Headlamp to load it.
 
 For example, if we have built 3 plugins called MyPlugin1, MyPlugin2, and
 MyPlugin3, they should be added to a directory in the following structure:
@@ -105,7 +105,7 @@ MyPlugin3, they should be added to a directory in the following structure:
     main.js
 ```
 
-If our plugins are places in `myplugins`, we can conveniently create that
+If our plugins are placed in `myplugins`, we can conveniently create that
 folder with the following command:
 
 ```bash
@@ -130,7 +130,7 @@ the `-plugin-dir` option should point to the directory:
 ### Using plugins on the desktop version
 
 The Headlamp desktop app will look for the plugins directory (in the format
-mentioned above) either under the user's Headlamp configuration folder,
+mentioned above). This will be either under the user's Headlamp configuration folder
 or within the current folder as `.plugins` if the former doesn't exist.
 
 ### Bundling plugins with desktop version
@@ -162,7 +162,7 @@ for more information on building a container image with your plugins.
 
 What is a storybook story?
 
-From https://storybook.js.org/docs/web-components/get-started/introduction
+From <https://storybook.js.org/docs/web-components/get-started/introduction>
 
 > Storybook is a tool for UI development. It makes development faster and
 > easier by isolating components. This allows you to work on one component
@@ -183,14 +183,14 @@ $ npm run storybook
 Your browser should open and show you a Message component with three
 different states the component can be in.
 
-Notices that there is a Message.stories.tsx to go along with the Message.tsx
+Note that there is a Message.stories.tsx to go along with the Message.tsx
 which has the `<Message>` component defined within it. See that file for an
 example of how to write a story.
 
 ### Snapshot testing
 
 Another benefit of writing storybook stories is that they can act as
-unit tests for regression testing. With storyshots it will save snapshots
+unit tests for regression testing. Storyshots will save snapshots
 of html for the different states that a component can be in. See the
 [Snapshot tests](https://storybook.js.org/docs/react/writing-tests/snapshot-testing)
 guide in the storybook documentation for more information.
@@ -243,16 +243,16 @@ jobs:
       - run: npx @kinvolk/headlamp-plugin build .
 ```
 
-Please see the github documentation for further details on workflows and actions.
+Please see the GitHub documentation for further details on workflows and actions.
 
 ## Upgrading package
 
-There's a command which handles much of upgrading plugins to the latest headlamp-plugin version. This upgrade command also audits packages, formats code, lints and type checks.
+There's a command that handles much of the upgrading of plugins to the latest headlamp-plugin version. This upgrade command also audits packages, formats code, lints, and type checks.
 
-Additionally this handles some code changes needed for plugins. For example, it handles running the material-ui 4 to mui 5 'codemod' code changes, and creates missing configuration added in different versions of headlamp-plugin.
+Additionally, this handles some code changes needed for plugins. For example, it handles running the material-ui 4 to mui 5 'codemod' code changes and creates missing configuration added in different versions of headlamp-plugin.
 
 Testing is necessary after running the upgrade command.
-Of course make sure you have a backup of your plugin folder before running it.
+Of course, make sure you have a backup of your plugin folder before running it.
 
 ```bash
 npx @kinvolk/headlamp-plugin upgrade --headlamp-plugin-version=latest your-plugin-folder

--- a/docs/development/plugins/functionality.md
+++ b/docs/development/plugins/functionality.md
@@ -3,7 +3,7 @@ title: Plugins Functionality
 sidebar_label: Functionality
 ---
 
-Headlamp's plugins exist for changing or adding functionality related to
+Headlamp's plugins exist to change or add functionality related to
 the user interface and experience.
 
 ## Plugins Lib
@@ -17,14 +17,14 @@ The main ones are:
 - K8s: Kubernetes related functionality
 - Headlamp: To register plugins
 - CommonComponents: React components commonly used in the Headlamp UI
-- Notification: This module contains two exported members one is Notification, a class which can be used to prepare notifications that are accepted by headlamp and the other one is setNotificationsInStore it is a dispatcher function which accepts a notification object prepared from the Notification class and when called it brings the notifications from plugin land to headlamp ecosystem so that headlamp can parse the notification and display it.
+- Notification: This module contains two exported members. The first is Notification, a class that can be used to prepare notifications accepted by headlamp. The second is setNotificationsInStore. It's a dispatcher function that accepts a notification object from the Notification class. When called, it brings the notifications from plugin land to the Headlamp ecosystem so that Headlamp can parse the notification and display it.
 - Router: To get or generate routes
 
 ### Shared Modules
 
-Headlamp ships many of the common npm modules that should be shared by both
-the plugins and Headlamp itself, and includes the config files for editors
-like VS Code to find them.
+Headlamp ships many common npm modules shared by both the plugins and
+Headlamp itself and includes the config files for editors like VS Code
+to find them.
 
 These are:
 
@@ -38,14 +38,14 @@ These are:
 - recharts
 
 Thus, plugins only need to install dependencies that are not yet provided by Headlamp.
-Yet, if any dependencies already covered by Headlamp are installed by the plugins, you
-just need to make sure they are the same version that Headlamp supports, as these will
-not be bundled when [building the plugin](./building.md).
+If any dependencies already covered by Headlamp are installed by the plugins, ensure
+that they are the same version that Headlamp supports. These will not be bundled when
+[building the plugin](./building.md).
 Particularly, the mentioned modules will be replaced by their version that's included
-in a global objects called `pluginLib`.
+in a global object called `pluginLib`.
 
-Older plugin development guides still asked developers to use e.g. React in the following
-way `const React: window.pluginLib.React`, but this is no longer needed.
+Older plugin development guides still asked developers to use, e.g., React, in the following
+way: `const React: window.pluginLib.React`. But, this is no longer needed.
 
 ## Functionality
 
@@ -168,7 +168,7 @@ React to Headlamp events with [registerHeadlampEventCallback](../api/plugin/regi
 
 ### Plugin Settings
 
-The plugins can have user configurable settings that can be used to change the behavior of the plugin. The plugin settings can be created using [registerPluginSettings](../api/plugin/registry/functions/registerpluginsettings).
+The plugins can have user-configurable settings that can be used to change the behavior of the plugin. The plugin settings can be created using [registerPluginSettings](../api/plugin/registry/functions/registerpluginsettings).
 
 - Example plugin shows [How to create plugin settings and use them](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples/change-logo)
 

--- a/docs/development/plugins/how-to.md
+++ b/docs/development/plugins/how-to.md
@@ -2,20 +2,20 @@
 title: How to create a Plugin
 ---
 
-This section will walk you through a basic plugin development.
+This section will walk you through basic plugin development.
 
 ## Types
 
-If you are using Typescript for developing the plugin, the
-`@kinvolk/headlamp-plugin` package does ship some type declarations in
-`@kinvolk/headlamp-plugin/types`. Please notice that the whole external
-plugin mechanics are still in an early development phase and thus only the
-actual type declarations (and not the corresponding code) is shipped in this
+If you are using TypeScript to develop the plugin, the
+`@kinvolk/headlamp-plugin` package ships some type declarations in
+`@kinvolk/headlamp-plugin/types`. Please note that the whole external
+plugin mechanics are still in an early development phase. Thus, only the
+actual type declarations (and not the corresponding code) are shipped in this
 package.
 
 ## Hello Kubernetes
 
-The following example will show a basic plugin declaration and registration
+The following example will show basic plugin declaration and registration
 in a file that should match the `src/index.tsx` structure explained in the
 [building](./building) section.
 

--- a/docs/development/plugins/index.md
+++ b/docs/development/plugins/index.md
@@ -3,7 +3,7 @@ title: Plugins
 sidebar_position: 6
 ---
 
-Plugins are one of the key features of Headlamp. They allow you to change how and what information is displayed, as well as other functionality. The ultimate goal of the plugins system is to allow vendors to build and deploy Headlamp with extra functionality without having to maintain a fork of the project.
+Plugins are one of the key features of Headlamp. They allow you to change how and what information is displayed and may serve various use cases. The plugins system aims to allow vendors to add features to Headlamp without having to maintain a fork of the project.
 
 ## Using plugins
 
@@ -32,9 +32,9 @@ for more details.
 
 ## Developing Plugins
 
-Plugins are supposed to be built and shipped out-of-tree, i.e. instead of managing the plugins'
-code within the Headlamp project or a Headlamp fork (which would require
-always rebuilding/maintaining Headlamp when changing a plugin), they're
-supposed to be built outside of the project and loaded by Headlamp.
+Plugins are meant to be build and shipped out-of-tree (i.e., outside of the project and loaded by
+Headlamp). This is opposed to managing the plugins' code within the Headlamp
+project or within a Headlamp fork. Such a setup would require always
+rebuilding/maintaining Headlamp when changing a plugin.
 
 Learn [how to create a Headlamp plugin](./building.md).

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -24,7 +24,7 @@ Steps:
 
 ### Kwok for low resource usage load testing of Headlamp
 
-> [KWOK](https://github.com/kubernetes-sigs/kwok) is a toolkit that enables setting up a cluster of thousands of Nodes in seconds. Under the scene, all Nodes are simulated to behave like real ones, so the overall approach employs a pretty low resource footprint that you can easily play around on your laptop.
+> [KWOK](https://github.com/kubernetes-sigs/kwok) is a toolkit that enables setting up a cluster of thousands of Nodes in seconds. All Nodes are simulated to behave like real ones, which creates a pretty low resource footprint that you can easily play around with on your machine.
 
 - [KWOK installation](https://kwok.sigs.k8s.io/docs/user/installation/)
 
@@ -45,7 +45,7 @@ kubectl config get-contexts
 
 #### Generating Initial Data
 
-This will create 900 nodes, 9000 pods, and 1000 events as fast as possible. Then it will create 1 event per second up to a total of 9000 events. Also one per second: 100 new nodes, and 1000 new pods. Finally it will create 15 clusters.
+This will create 900 nodes, 9000 pods, and 1000 events as fast as possible. Then it will create 1 event per second up to a total of 9000 events. Also one per second: 100 new nodes and 1000 new pods. Finally, it will create 15 clusters.
 
 ```bash
 cd load-tests
@@ -71,7 +71,7 @@ node scripts/create-events.js 9000 1 & node scripts/create-nodes.js 100 1 & node
 
 #### Cleaning up clusters
 
-Kwok clusters can take up a lot of resources even doing nothing,
+Kwok clusters can take up a lot of resources even when doing nothing,
 due to the Kubernetes API server using resources even when idle.
 
 So when you're done, you can delete them like this.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,11 +7,11 @@ sidebar_position: 5
 
 ### What is Headlamp and who is it for?
 
-Headlamp is a graphical user interface specifically tailored for simplifying the management of Kubernetes clusters.
+Headlamp is a graphical user interface specifically tailored to simplify the management of Kubernetes clusters.
 
 ### What Kubernetes flavors or vendors does Headlamp support?
 
-Headlamp is designed to be vendor-agnostic, supporting a variety of Kubernetes flavors. For a comprehensive list of compatible platforms please refer to our [platforms section in the documentation](./platforms.md).
+Headlamp is designed to be vendor-agnostic, supporting a variety of Kubernetes flavors. For a full list of compatible platforms, please refer to our [platforms section in the documentation](./platforms.md).
 
 ### Is Headlamp a desktop or web application?
 
@@ -19,7 +19,7 @@ Headlamp is available both as a desktop application and a web application. The d
 
 ### Is there any cost involved in using Headlamp?
 
-Headlamp a 100% open source project, under the Apache 2.0 License. It is thus available at no charge, and users are encouraged to modify and redistribute it in accordance with the license terms.
+Headlamp is a 100% open source project, under the Apache 2.0 License. It is thus available at no charge, and users are encouraged to modify and redistribute it in accordance with the license terms.
 
 ### Can I use Headlamp for commercial purposes?
 
@@ -35,15 +35,15 @@ You can find the list of Headlamp's maintainers in its [MAINTAINERS.md](https://
 
 ### What capabilities / credentials does Headlamp require to access my Kubernetes cluster?
 
-Headlamp doesn't require access to the cluster in itself. It instead relies to RBAC when connecting to the Kubernetes API server, meaning that it's the users that are required the credentials to access the cluster (via a service token or client certificate). Headlamp may store the token in the browser's local storage, but never in its backend/server.
+Headlamp doesn't require access to the cluster itself; it instead relies on RBAC to connect to the Kubernetes API server. This means that it's the user(s) who must have the required credentials to access the cluster (via a service token or client certificate). Headlamp may store the token in the browser's local storage, but never in its backend/server.
 
 ### Is Headlamp customizable?
 
-Yes, Headlamp is highly customizable, thanks to its robust plugin system. This system allows for the extension of Headlamp's core functionalities, catering to specific use cases and workflows. For more information on creating and managing plugins, visit our [plugins page](./development/plugins/building.md).
+Yes, Headlamp is highly customizable, thanks to its robust plugin system. This system extends Headlamp's core functionalities, catering to specific use cases and workflows. For more information on creating and managing plugins, visit our [plugins page](./development/plugins/building.md).
 
 ### How often is Headlamp updated?
 
-Headlamp tries to have a new features version released every month. Sometimes, there may be delays for a couple of weeks. Bug fix versions can be released in between feature versions, whenever appropriate (releases fixing critical bugs are often released quickly after a fix is added).
+Headlamp tries to have a new feature version released every month. Sometimes, there may be delays of a couple of weeks. Bug fix versions can also be released between feature versions, whenever appropriate. These are often released quickly after a fix is added.
 
 ---
 
@@ -55,7 +55,7 @@ To install Headlamp, follow the detailed instructions provided in the [official 
 
 ### Can I install Headlamp in my Kubernetes cluster?
 
-Absolutely, Headlamp can be deployed directly within your Kubernetes cluster. Detailed instructions for in-cluster installation can be found in the [in-cluster installation guide](./installation/in-cluster/index.md).
+Absolutely! Headlamp can be deployed directly within your Kubernetes cluster. Detailed instructions for in-cluster installation can be found in the [in-cluster installation guide](./installation/in-cluster/index.md).
 
 ---
 
@@ -71,7 +71,7 @@ Yes, Headlamp enables direct management of Kubernetes resources through its user
 
 ### Headlamp is not showing delete/edit/scale buttons in a resource, why is that?
 
-Headlamp shows controls based on the user's role (RBAC), so if the user has e.g. no permissions to delete a resource, the delete button is not shown.
+Headlamp shows controls based on the user's role (RBAC), so if the user has, e.g., no permissions to delete a resource, the delete button is not shown.
 
 ### I cannot access any section in my cluster, it keeps saying Access Denied.
 
@@ -83,7 +83,7 @@ To add or remove plugins in Headlamp, you can follow the plugin management instr
 
 ### Is there a way to contribute to the development of Headlamp features?
 
-Absolutely! As an open-source project, Headlamp thrives on community contributions. You can contribute in various ways, including submitting pull requests, creating plugins, reporting issues, and suggesting new features. For more details on how to get involved, visit our [contribution section](./contributing.md).
+Absolutely! As an open source project, Headlamp thrives on community contributions. You can contribute in various ways, including submitting pull requests, creating plugins, reporting issues, and suggesting new features. For more details on how to get involved, visit our [contribution section](./contributing.md).
 
 ### How can I get help or assistance for Headlamp?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ sidebar_position: 1
 
 Headlamp is an easy-to-use and extensible Kubernetes web UI.
 
-Headlamp was created to be a Kubernetes web UI that has the traditional functionality of other
-web UIs/dashboards available (i.e. to list and view resources) as well as other features.
+Headlamp was created to blend the traditional feature set of other web UIs/dashboards
+(i.e., to list and view resources) with added functionality.
 
 Headlamp can be used [in-cluster](./installation/in-cluster), where it's accessed through a web browser,
 or as a [desktop application](./installation/desktop) (using the information defined in the user's
@@ -22,4 +22,3 @@ in the Kubernetes Slack.
 ## Frequently Asked Questions
 
 For more information about Headlamp, see the [Headlamp FAQ](./faq.md).
-    

--- a/docs/installation/base-url.md
+++ b/docs/installation/base-url.md
@@ -4,7 +4,7 @@ sidebar_label: Base URL
 sidebar_position: 3
 ---
 
-Normally Headlamp runs at the root of the domain. Hower you can also ask
+Normally Headlamp runs at the root of the domain. However, you can also ask
 to run it at a base-url like "/headlamp" for example.
 
 - default at the root of the domain: `https://headlamp.example.com/`.
@@ -25,7 +25,7 @@ If in doubt, host Headlamp on a separate origin (domain or port, don't use the `
 PUBLIC_URL="/headlamp" make run-frontend
 ```
 
-Then go to http://localhost:3000/headlamp/ in your browser.
+Then go to <http://localhost:3000/headlamp/> in your browser.
 
 ### Static build mode
 
@@ -34,7 +34,7 @@ cd frontend && npm install && npm run build && cd ..
 ./backend/headlamp-server -dev -base-url /headlamp -html-static-dir frontend/build
 ```
 
-Then go to http://localhost:4466/headlamp/ in your browser.
+Then go to <http://localhost:4466/headlamp/> in your browser.
 
 ### Docker mode
 

--- a/docs/installation/desktop/headless.mdx
+++ b/docs/installation/desktop/headless.mdx
@@ -4,8 +4,8 @@ sidebar_label: Headless Mode
 sidebar_position: 4
 ---
 
-Some users prefer running Headlamp using the desktop app, but directly in their web browser instead
-of the Electron's environment as this allows them to leverage the browser's functionality such as
+Some users prefer running Headlamp using the desktop app, but in their web browser instead of
+Electron's environment. This allows them to leverage the browser's functionality, such as
 bookmarks, groups, etc.
 
 Running Headlamp in the system's browser can be done by using the `--headless` CLI option.

--- a/docs/installation/desktop/index.mdx
+++ b/docs/installation/desktop/index.mdx
@@ -3,8 +3,8 @@ title: Desktop App
 sidebar_position: 2
 ---
 
-Headlamp can be run as a desktop application, for users who don't want to
-deploy it in cluster, or those who want to manage unrelated clusters locally.
+Headlamp can be run as a desktop application for users who do not want to
+deploy it in-cluster or those who want to manage unrelated clusters locally.
 
 There are desktop apps for [Linux](./linux-installation.md), [Mac](./mac-installation.md), and [Windows](./win-installation.md).
 
@@ -16,7 +16,7 @@ import DocCardList from '@theme/DocCardList';
 
 ## Use a non-default kube config file
 
-If you wish to use a non-default kube config file, then you can do it by
+If you wish to use a non-default kubeconfig file, then you can do it by
 providing it as an argument to Headlamp, e.g.:
 
 ```bash
@@ -31,7 +31,7 @@ KUBECONFIG=/my/different/kubeconfig /path/to/headlamp
 
 ### Use several kube config files
 
-If you need to use more than one kube config file at the same time, you can list
+If you need to use more than one kubeconfig file at the same time, you can list
 each config file path with a separator.
 
 import Tabs from '@theme/Tabs';
@@ -54,14 +54,14 @@ import TabItem from '@theme/TabItem';
 
 ## Access using OIDC
 
-OIDC has a feature makes more sense when
-[running Headlamp in a cluster](../in-cluster) as it will allow cluster operators to just
-give users a URL that they can use for logging in and access Headlamp.
-However, if you have your kube config set to use OIDC for the authentication (because you already
-authenticated and produced a kube config with that data), Headlamp will read those settings and
-try to use them for offering the effortless login to the cluster.
+OIDC has a useful feature for
+[running Headlamp in a cluster](../in-cluster). It allows cluster operators to just
+give users a URL that they can use to log in and access Headlamp.
+If your kubeconfig is set to use OIDC for authentication (you have already
+authenticated and produced a kubeconfig), Headlamp will read those settings. It
+will then try to use them to offer effortless login to the cluster.
 
-Still, the kube config OIDC settings will not provide a OIDC callback URL, so make sure that your OIDC configuration for your cluster include Headlamp's OIDC callback in its redirect URIs. i.e. say you're using
+Still, the kube config OIDC settings will not provide a OIDC callback URL. Make sure that your OIDC configuration for your cluster includes Headlamp's OIDC callback in its redirect URIs. I.e., say you're using
 Dex for the OIDC connection and you have it already configured in your
-kube config, then be sure to add the `/oidc-callback` endpoint with Headlamp's the local address
+kubeconfig. Then, be sure to add the `/oidc-callback` endpoint with Headlamp's local address
 to Dex's `staticClient.redirectURIs`: `http://localhost:6644/oidc-callback`.

--- a/docs/installation/desktop/linux-installation.md
+++ b/docs/installation/desktop/linux-installation.md
@@ -35,7 +35,7 @@ flatpak update io.kinvolk.Headlamp
 Headlamp can be used as an [AppImage](https://appimage.org/) by downloading and running it directly.
 
 To download, choose the AppImage file from the [latest release page](https://github.com/headlamp-k8s/headlamp/releases/latest).
-You can then run it with the following command (examplified for the AMD64, 0.16.0 version):
+You can then run it with the following command (exemplified for the AMD64, 0.16.0 version):
 
 ```bash
 ./Headlamp-0.16.0-linux-x64.AppImage
@@ -43,8 +43,8 @@ You can then run it with the following command (examplified for the AMD64, 0.16.
 
 ## Tarballs
 
-To run Headlamp from one of the tarballs, after downloading the tarball for the [latest release](https://github.com/headlamp-k8s/headlamp/releases/latest), you have to extract the contents from it and run
-the `headlamp` binary in the resulting folder (examplified below for the AMD64, 0.16.0 version):
+To run Headlamp from one of the tarballs, first download the tarball for the [latest release](https://github.com/headlamp-k8s/headlamp/releases/latest). Then, extract the contents from it and run
+the `headlamp` binary in the resulting folder (exemplified below for the AMD64, 0.16.0 version):
 
 ```bash
 tar xvzf ./Headlamp-0.16.0-linux-x64.tar.gz

--- a/docs/installation/desktop/mac-installation.md
+++ b/docs/installation/desktop/mac-installation.md
@@ -28,8 +28,8 @@ read the [official documentation](https://docs.brew.sh/Manpage).
 For Mac OS we provide a _.dmg_ file, so you need to download it from the [releases page](https://github.com/headlamp-k8s/headlamp/releases)
 and then follow the below steps :
 
-1. Double click the downloaded file to make its content available (name will show up in the Finder sidebar), usually a window opens showing the content as well
-2. Drag the application from the _DMG_ window into /Applications to install wait for the copy process to finish.
+1. Double click the downloaded file to make its content available (the name will show up in the Finder sidebar). Usually, a window opens showing the content as well.
+2. Drag the application from the _DMG_ window into /Applications to install, and wait for the copy process to finish.
 
 Once the installation process is completed you can find Headlamp as a desktop app in Applications directory.
 
@@ -38,4 +38,3 @@ Once the installation process is completed you can find Headlamp as a desktop ap
 To upgrade Headlamp when it's installed directly via the releases page, you have to download any newer version and re-install it. There is no automatic upgrade.
 
 If you install via brew it can manage upgrades for you.
-

--- a/docs/installation/desktop/win-installation.md
+++ b/docs/installation/desktop/win-installation.md
@@ -4,12 +4,12 @@ sidebar_label: Windows
 sidebar_position: 3
 ---
 
-Headlamp is available for Windows as a direct download from its [releases page](https://github.com/headlamp-k8s/headlamp/releases) on Github (.exe file) and from package registries
+Headlamp is available for Windows as a direct download from its [releases page](https://github.com/headlamp-k8s/headlamp/releases) on GitHub (.exe file) and from package registries
 like [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) and [Chocolatey](https://chocolatey.org/).
 
 ## Install via Winget
 
-To install Headlamp from the Winget registry. Simply run the following command:
+To install Headlamp from the Winget registry, simply run the following command:
 
 ```powershell
 winget install headlamp

--- a/docs/installation/in-cluster/dex/index.md
+++ b/docs/installation/in-cluster/dex/index.md
@@ -7,7 +7,7 @@ In this tutorial, we'll walk through the process of configuring Headlamp within 
 
 ## Configuring Dex
 
-To enable OIDC authentication in your Minikube cluster, you'll need to configure Dex. Before proceeding, follow the [getting started guide](https://dexidp.io/docs/getting-started/) to set up your Dex instance.Follow these steps to configure Dex:
+To enable OIDC authentication in your Minikube cluster, you'll need to configure Dex. Before proceeding, follow the [getting started guide](https://dexidp.io/docs/getting-started/) to set up your Dex instance. Follow these steps to configure Dex:
 
 1. Create a Dex configuration file. The following example demonstrates a basic configuration file for Dex, containing a
    static client, connector, and static password.
@@ -182,7 +182,7 @@ This will install Headlamp in the headlamp namespace with the OIDC configuration
 kubectl port-forward svc/headlamp-oidc 4466:80 -n headlamp
 ```
 
-5. Open your web browser and go to http://localhost:4466. Click on "sign-in." After completing the login flow successfully, you'll gain access to your Kubernetes cluster using Headlamp.
+5. Open your web browser and go to <http://localhost:4466>. Click on "sign-in." After completing the login flow successfully, you'll gain access to your Kubernetes cluster using Headlamp.
 
 ![Headlamp access](./headlamp-access1.jpg)
 ![Headlamp access](./headlamp-access2.jpg)
@@ -191,6 +191,6 @@ kubectl port-forward svc/headlamp-oidc 4466:80 -n headlamp
 
 ## Conclusion
 
-In this tutorial, we've explore the process of setting up Headlamp within a Kubernetes cluster, integrating it with OIDC (OpenID Connect) authentication provided by Dex. By following the steps outlined in this guide, you've successfully configured Headlamp to enhance your Kubernetes cluster management.
+In this tutorial, we've set up Headlamp within a Kubernetes cluster and integrated it with OIDC (OpenID Connect) authentication provided by Dex. By following the steps outlined in this guide, you've successfully configured Headlamp to enhance your Kubernetes cluster management.
 
-This setup allows you to benefit from Headlamp's user-friendly interface and advanced features, all while ensuring a secure and streamlined authentication through Dex. With the power of OIDC, you can easily and safely access and manage your Kubernetes resources.
+This setup allows you to enjoy Headlamp's user-friendly interface and advanced features. You can also be assured of secure and streamlined authentication through Dex. With the power of OIDC, you can easily and safely access and manage your Kubernetes resources.

--- a/docs/installation/in-cluster/eks/index.md
+++ b/docs/installation/in-cluster/eks/index.md
@@ -31,22 +31,23 @@ We will start by creating a Cognito user pool. This tutorial uses the AWS portal
 9. You can either chose sending email from Amazon SES or with Cognito, These emails are for MFA, account recovery, sign up, sign in workflows. For this tutorial we will use sending emails through Cognito.
    ![congigure-message-delivery](./cognito/configure-message-delivery.png)
 10. Click next to go to the Integrate your app view
-11. There are few things you have to take care of here,
+11. There are a few things you have to take care of here,
     - You can either use the hosted UI or create your own UI for the authentication workflows (We are using the Cognito hosted UI).
-    - You can also configure the domain name for the hosted UI (Also remember this is the issuer URL as well which we will later use to setup EKS with). We are using Cognito domain for this tutorial but you can chose your own custom domain as well.
-    - You can also configure the callback URLs for the auth flow. For this tutorial we are setting it to be
-      http://localhost:8000/oidc-callback as we will be running headlamp on this port but you can chose your own callback host as well based on your needs make sure to append /oidc-callback to the host since this is where headlamp expect the redirect from auth to occur.
-    - Client Secret - We want to generate a client secret as our headlamp app needs it to start the auth dance, So select Generate a client secret client secret column.
-    - You can also configure the scopes and claims for the tokens. For this tutorial make sure openid, profile, email scopes are selected, other scopes are optional.
+    - You can also configure the domain name for the hosted UI (Also remember this is the issuer URL as well, which we will later use to set up EKS with). We are using the Cognito domain for this tutorial, but you can choose your own custom domain as well.
+    - You can also configure the callback URLs for the auth flow. For this tutorial, we are setting it to be
+      <http://localhost:8000/oidc-callback> as we will be running headlamp on this port. Or, you can choose your own callback host as well based on your needs. Make sure to append /oidc-callback to the host since this is where Headlamp expects the redirect from auth to occur.
+    - Client Secret - We want to generate a client secret as our Headlamp app needs it to start the auth dance, so select Generate a client secret client secret column.
+    - You can also configure the scopes and claims for the tokens. For this tutorial, make sure the openid, profile, and email scopes are selected; other scopes are optional.
 
 ![Part one of three of a long form Cognito uses for App Configuration](./cognito/integrate-your-app1.png)
 ![Second part of Integrating App Cognito Form](./cognito/integrate-your-app2.png)
 ![Final part of Integrating App Cognito Form](./cognito/integrate-your-app3.png)
-In the above configurations make sure The Oauth 2.0 grant type is set to Authorization code grant. 12. Click next and you will be taken to the Review and Create view where you can review all the settings and create the user pool.
+In the above configurations make sure the Oauth 2.0 grant type is set to Authorization code grant.
+12. Click next and you will be taken to the Review and Create view where you can review all the settings and create the user pool.
 
 ## Setting up EKS cluster
 
-We will first start by creating an EKS cluster. For this tutorial we will use the aws console to create the cluster but you can use the eksctl or aws CLI as well.
+We will first start by creating an EKS cluster. For this tutorial we will use the AWS console to create the cluster but you can use the eksctl or AWS CLI as well.
 
 1. Go to the AWS console and navigate to the EKS service.
    ![EKS](./cluster/elastic_kubernetes_cluster.png)
@@ -80,12 +81,12 @@ After creating the EKS cluster, we need to configure the OIDC provider for the c
 
 ## Fetching EKS cluster locally to deploy Headlamp on it
 
-Make Sure you have the aws cli installed and setup with the necessary permissions to interact with the EKS cluster.
+Make Sure you have the AWS CLI installed and setup with the necessary permissions to interact with the EKS cluster.
 
-1. Installation steps for aws cli can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-2. Signin to the aws cli can be done by following the steps [here](https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html)
+1. Installation steps for AWS CLI can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+2. Signin to the AWS CLI can be done by following the steps [here](https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html)
 
-After setting up the aws cli, you can fetch the kubeconfig for the EKS cluster by running the following command
+After setting up the AWS CLI, you can fetch the kubeconfig for the EKS cluster by running the following command
 
 ```bash
 aws eks --region <YOUR_REGION_HERE> update-kubeconfig --name <YOUR_CLUSTER_NAME_HERE>
@@ -149,13 +150,13 @@ This will install Headlamp in the headlamp namespace with the OIDC configuration
 
 7. After a successful installation, you can access Headlamp by port-forwarding to the pod:
 
-Make sure the portforwarding is done to a port that you also set as the callback URL in the Cognito user pool configuration. So in our case if the callback URL is http://localhost:8000/oidc-callback then we should port forward to 8000.
+Make sure the portforwarding is done to a port that you also set as the callback URL in the Cognito user pool configuration. So in our case if the callback URL is <http://localhost:8000/oidc-callback> then we should port forward to 8000.
 
 ```shell
 kubectl port-forward svc/headlamp-oidc 8000:80 -n headlamp
 ```
 
-8. Open your web browser and go to http://localhost:8000. Click on "sign-in." After completing the login flow successfully, you'll gain access to your Kubernetes cluster using Headlamp.
+8. Open your web browser and go to <http://localhost:8000>. Click on "sign-in." After completing the login flow successfully, you'll gain access to your Kubernetes cluster using Headlamp.
    ![Headlamp Login](./headlamp_auth_screen.png)
    ![Cognito Login](./cognito_auth.png)
    ![Headlamp Dashboard](./headlamp_dashboard.png)

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -3,7 +3,7 @@ title: In-cluster
 sidebar_position: 1
 ---
 
-A common use-case for any Kubernetes web UI is to deploy it in-cluster and
+A common use case for any Kubernetes web UI is to deploy it in-cluster and
 set up an ingress server for having it available to users.
 
 ## Using Helm
@@ -19,7 +19,7 @@ helm repo add headlamp https://headlamp-k8s.github.io/headlamp/
 helm install my-headlamp headlamp/headlamp --namespace kube-system
 ```
 
-As usual it is possible to configure the helm release via the [values file](https://github.com/headlamp-k8s/headlamp/blob/main/charts/headlamp/values.yaml) or setting your preferred values directly.
+As usual, it is possible to configure the helm release via the [values file](https://github.com/headlamp-k8s/headlamp/blob/main/charts/headlamp/values.yaml) or setting your preferred values directly.
 
 ```bash
 # install headlamp with your own values.yaml
@@ -47,10 +47,10 @@ kubectl apply -f https://raw.githubusercontent.com/kinvolk/headlamp/main/kuberne
 
 With the instructions in the previous section, the Headlamp service should be
 running, but you still need the
-ingress server as mentioned. We provide an example sample ingress yaml file
+ingress server as mentioned. We provide a sample ingress YAML file
 for this purpose, but you have to manually replace the **URL** placeholder
-with the desired URL (the ingress file also assumes that you have contour
-and a cert-manager set up, but if you don't then you'll just not have TLS).
+with the desired URL. The ingress file also assumes that you have Contour
+and a cert-manager set up, but if you don't, then you'll just not have TLS.
 
 Assuming your URL is `headlamp.mydeployment.io`, getting the sample ingress
 file and changing the URL can quickly be done by:

--- a/docs/installation/in-cluster/keycloak/index.md
+++ b/docs/installation/in-cluster/keycloak/index.md
@@ -9,7 +9,7 @@ Note: This tutorial assumes that you have Keycloak hosted on a remote server. If
 
 ## Creating a Keycloak Client
 
-To enable OIDC authentication in your Minikube cluster, you'll need to create a Keycloak client.Before proceeding, follow the [getting started guide](https://www.keycloak.org/guides#getting-started) to set up your Keycloak instance. When creating a user in Keycloak, don't forget to also set the email address.Follow these steps to configure the client in your Keycloak admin panel:
+To enable OIDC authentication in your Minikube cluster, you'll need to create a Keycloak client. Before proceeding, follow the [getting started guide](https://www.keycloak.org/guides#getting-started) to set up your Keycloak instance. When creating a user in Keycloak, don't forget to also set the email address. Follow these steps to configure the client in your Keycloak admin panel:
 
 1. Start by accessing your Keycloak admin panel.
    > \<YOUR-KEYCLOAK-URL\>/admin
@@ -25,7 +25,7 @@ To enable OIDC authentication in your Minikube cluster, you'll need to create a 
 4. In the "Capability Config" step, enable "Client authentication" and proceed to the next step.
    ![Keycloak Create Client](./keycloak-create-client2.jpeg)
 
-5. Add "http://localhost:8000/\*" to the "Valid redirect URIs" and save your settings.
+5. Add "<http://localhost:8000/\>*" to the "Valid redirect URIs" and save your settings.
    ![Keycloak Create Client](./keycloak-create-client3.jpeg)
 
 ## Setting up Minikube with the Keycloak OIDC Configuration
@@ -171,7 +171,7 @@ This will install Headlamp in the headlamp namespace with the OIDC configuration
 kubectl port-forward svc/headlamp-oidc 4466:80 -n headlamp
 ```
 
-5. Open your web browser and go to http://localhost:4466. Click on "sign-in." After completing the login flow successfully, you'll gain access to your Kubernetes cluster using Headlamp.
+5. Open your web browser and go to <http://localhost:4466>. Click on "sign-in." After completing the login flow successfully, you'll gain access to your Kubernetes cluster using Headlamp.
 
 ![Headlamp access](./headlamp-access1.jpg)
 ![Headlamp access](./headlamp-access2.jpg)
@@ -179,6 +179,6 @@ kubectl port-forward svc/headlamp-oidc 4466:80 -n headlamp
 
 ## Conclusion
 
-In this tutorial, we've explored the process of setting up Headlamp within a Kubernetes cluster, integrating it with OIDC (OpenID Connect) authentication provided by Keycloak. By following the steps outlined in this guide, you've successfully configured Headlamp to enhance your Kubernetes cluster management.
+In this tutorial, we've set up Headlamp within a Kubernetes cluster and integrated it with OIDC (OpenID Connect) authentication provided by Keycloak. By following the steps outlined in this guide, you've successfully configured Headlamp to enhance your Kubernetes cluster management.
 
-This setup allows you to benefit from Headlamp's user-friendly interface and advanced features, all while ensuring a secure and streamlined authentication through Keycloak. With the power of OIDC, you can easily and safely access and manage your Kubernetes resources.
+This setup allows you to enjoy Headlamp's user-friendly interface and advanced features. You can also be assured of secure and streamlined authentication through Dex. With the power of OIDC, you can easily and safely access and manage your Kubernetes resources.

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -7,7 +7,7 @@ Headlamp supports OIDC for cluster users to effortlessly log in using a "Sign in
 
 ![screenshot the login dialog for a cluster](./oidc_button.png)
 
-For OIDC to be used, Headlamp needs to know how to configure it, so you have to provide the different OIDC-related arguments to Headlamp from your OIDC provider. Those are:
+To use OIDC, Headlamp needs to know how to configure it, so you have to provide the following OIDC-related arguments to Headlamp from your OIDC provider:
 
 - the client ID: `-oidc-client-id` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_ID`
 - the client secret: `-oidc-client-secret` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_SECRET`
@@ -50,4 +50,4 @@ then you have to:
 - Set `-oidc-idp-issuer-url` as Dex's URL (same as in `--oidc-issuer-url` in the Kubernetes APIServer)
 - Set `-oidc-scopes` if needed, e.g. `-oidc-scopes=profile,email,groups`
 
-**Note** If you already have another static client configured for Kubernetes to be used by the [apiserver's OIDC](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server) (OpenID Connect) configuration, it is important to ensure that a **single static client ID** i.e `-oidc-client-id` is used for both Dex and Headlamp. Additionally, the **redirectURIs** need to be specified for each client.
+**Note** If you already have another static client configured for Kubernetes for the [apiserver's OIDC](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server) (OpenID Connect) configuration, use a **single static client ID** i.e `-oidc-client-id` for both Dex and Headlamp. Additionally, the **redirectURIs** need to be specified for each client.

--- a/docs/installation/index.mdx
+++ b/docs/installation/index.mdx
@@ -9,7 +9,7 @@ Headlamp can be deployed in a Kubernetes [cluster](./in-cluster/index.md), or ru
 
 Currently you can log in Headlamp by using a **client-certificate** (as you may have configured with e.g. minikube), or a **bearer token**.
 
-Headlamp uses [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac) for checking whether and how users can access resources. This means that the
+Headlamp uses [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac) for checking users' access to resources This means that the
 recommended way to log in into Headlamp is to use a Service Account token.
 
 ### Create a Service Account token

--- a/docs/installation/metrics-server.md
+++ b/docs/installation/metrics-server.md
@@ -4,7 +4,7 @@ sidebar_label: Metrics Server
 sidebar_position: 4
 ---
 
-Headlamp can show information for resources usage if the Metrics Server is
+Headlamp can show information for resource usage if the Metrics Server is
 installed. If the Metrics Server is not installed, then a related notice is
 displayed as shown in the following screenshot:
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -5,12 +5,12 @@ sidebar_position: 3
 
 ## Tested Kubernetes Platforms
 
-This section shows the different platforms where Headlamp has been tested (in-cluster) or is intended to be tested, and useful observations about it.
+This section shows the platforms where Headlamp has been tested (in-cluster) or is to be tested, and useful observations about it.
 If you have tested Headlamp on a different flavor or Kubernetes, please file a PR or [issue](https://github.com/headlamp-k8s/headlamp/issues/new/choose) to add your remarks to the list.
 
-The "works" column refers to the overall Kubernetes related functionality when running in the respective platform; it may have 3 different values:
+The "works" column refers to the overall Kubernetes-related functionality when running on the respective platform; it may have 3 different values:
 
-- ✔️ : Has been tried and works fine to the extent of what has been tested
+- ✔️ : Has been tried and works well to the extent of what has been tested
 - ❌ : Has been tried and didn't work or had issues that prevented a regular use of it
 - ❔: Hasn't been tried/reported yet
 
@@ -27,7 +27,7 @@ The "works" column refers to the overall Kubernetes related functionality when r
 
 ## Tested Browsers
 
-We mostly test with 'modern browsers' defined as the latest version and two older versions. But we try to make Headlamp work with web standards, so it's quite likely other standards conforming browsers will also work.
+We mostly test with 'modern browsers' defined as the latest version and two older versions. But we try to make Headlamp work with web standards, so it's quite likely other standards-conforming browsers will also work.
 
 | Platform             | Works | Comments |
 | -------------------- | :---: | -------- |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,7 +30,7 @@ Folder                                         | Description
 [examples/cluster-chooser](examples/cluster-chooser)   | Override default chooser button.
 [examples/details-view](examples/details-view)         | Custom sections and actions for detail views.
 [examples/dynamic-clusters](examples/dynamic-clusters) | Update cluster configuration dynamically.
-[examples/pod-counter](examples/pod-counter)   | Display number of Pods in title bar.
+[examples/pod-counter](examples/pod-counter)   | Display number of Pods in the title bar.
 [examples/sidebar](examples/sidebar)           | Change the side bar menu.
 [examples/tables](examples/tables)             | Override the tables in list views.
 headlamp-plugin               | headlamp-plugin script which plugins use.


### PR DESCRIPTION
These changes bring accessibility improvements to the docs, as well as minor improvements to wording, clarity, and formatting. The language in the docs was run through the Hemingway app to improve readability for a technical audience, and markdownlint was used for markdown formatting.

Fixes: #1493