### PR TITLE
frontend: Refactor labels for create namespace button

### DIFF
--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -143,7 +143,6 @@ export default function CreateNamespaceButton() {
         </DialogContent>
         <DialogActions>
           <Button
-            aria-label="Cancel"
             onClick={() => {
               setNamespaceDialogOpen(false);
             }}
@@ -151,7 +150,6 @@ export default function CreateNamespaceButton() {
             {t('translation|Cancel')}
           </Button>
           <Button
-            aria-label="Create"
             disabled={!isValidNamespaceName}
             onClick={() => {
               createNewNamespace();

--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -99,7 +99,7 @@ export default function CreateNamespaceButton() {
     <AuthVisible item={Namespace} authVerb="create">
       <ActionButton
         color="primary"
-        description={t('translation|Create')}
+        description={t('translation|Create Namespace')}
         icon={'mdi:plus-circle'}
         onClick={() => {
           setNamespaceDialogOpen(true);

--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -98,6 +98,7 @@ export default function CreateNamespaceButton() {
   return (
     <AuthVisible item={Namespace} authVerb="create">
       <ActionButton
+        data-testid="create-namespace-button"
         color="primary"
         description={t('translation|Create Namespace')}
         icon={'mdi:plus-circle'}
@@ -143,6 +144,7 @@ export default function CreateNamespaceButton() {
         </DialogContent>
         <DialogActions>
           <Button
+            data-testid="create-namespace-dialog-cancel-button"
             onClick={() => {
               setNamespaceDialogOpen(false);
             }}
@@ -150,6 +152,7 @@ export default function CreateNamespaceButton() {
             {t('translation|Cancel')}
           </Button>
           <Button
+            data-testid="create-namespace-dialog-create-button"
             disabled={!isValidNamespaceName}
             onClick={() => {
               createNewNamespace();

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -21,7 +21,7 @@
               class="MuiBox-root css-ldp2l3"
             >
               <button
-                aria-label="Create"
+                aria-label="Create Namespace"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"
                 tabindex="0"


### PR DESCRIPTION
# Refactor labels for create namespace button

## Description

This PR refactors the labels and attributes associated with the **Create Namespace** functionality to enhance accessibility and testing efficiency.

## Changes

1. **Removed Unneeded `aria-label`s**:
   - Eliminated redundant `aria-label` attributes from the **Create** and **Cancel** buttons within the Create Namespace modal/dialog.
   - These labels were unnecessary as the button text already conveys the action to screen readers.

2. **Updated `aria-label` for Create Namespace Action Button**:
   - Changed the `aria-label` of the Create Namespace action button to provide a more descriptive and specific label.

3. **Added `data-testid` Attributes**:
   - Introduced `data-testid` attributes to all buttons in the Create Namespace component.
   - Facilitates more precise and maintainable selectors in automated testing suites.

