### PR TITLE
Add option to list plugins

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -60,6 +60,22 @@ const startUrl = (
   .replace(/\\/g, '/');
 
 const args = yargs(hideBin(process.argv))
+  .command(
+    'list-plugins',
+    'List all static and user-added plugins.',
+    () => {},
+    () => {
+      try {
+        const backendPath = path.join(process.resourcesPath, 'headlamp-server');
+        const stdout = execSync(`${backendPath} list-plugins`);
+        process.stdout.write(stdout);
+        process.exit(0);
+      } catch (error) {
+        console.error(`Error listing plugins: ${error}`);
+        process.exit(1);
+      }
+    }
+  )
   .options({
     headless: {
       describe: 'Open Headlamp in the default web browser instead of its app window',

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -8,9 +8,24 @@ import (
 	"github.com/headlamp-k8s/headlamp/backend/pkg/config"
 	"github.com/headlamp-k8s/headlamp/backend/pkg/kubeconfig"
 	"github.com/headlamp-k8s/headlamp/backend/pkg/logger"
+	"github.com/headlamp-k8s/headlamp/backend/pkg/plugins"
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "list-plugins" {
+		conf, err := config.Parse(os.Args[2:])
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "fetching config:%v")
+			os.Exit(1)
+		}
+
+		if err := plugins.ListPlugins(conf.StaticDir, conf.PluginsDir); err != nil {
+			logger.Log(logger.LevelError, nil, err, "listing plugins")
+		}
+
+		return
+	}
+
 	conf, err := config.Parse(os.Args)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "fetching config:%v")


### PR DESCRIPTION
This change creates a CLI subcommand in the backend + desktop to list all plugins, with a distinction between static/shipped plugins and user-added ones.

Fixes: #2161

### Testing
#### Backend
- [x] Run `make backend`
- [x] Run `cd backend && ./headlamp-server list-plugins` and ensure that the list of plugins shows up

#### Desktop
- [x] Run `cd app && npm run build`
- [x] Run `cd dist/linux-unpacked && ./headlamp list-plugins` and ensure that the list of plugins shows up