### PR TITLE
backend: refactor listing all contexts and error

### DIFF
--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -9,6 +9,7 @@ type Cluster struct {
 	Server   string                 `json:"server,omitempty"`
 	AuthType string                 `json:"auth_type"`
 	Metadata map[string]interface{} `json:"meta_data"`
+	Error    string                 `json:"error,omitempty"`
 }
 
 type ClusterReq struct {

--- a/backend/pkg/kubeconfig/test_data/kubeconfig_partialcontextvalid
+++ b/backend/pkg/kubeconfig/test_data/kubeconfig_partialcontextvalid
@@ -4,15 +4,23 @@ clusters:
 - name: test-cluster
   cluster:
     server: https://test-server:6443
+- name: invalid-cluster
+  cluster:
+    server: https://test-server:6443
+    certificate-authority-data: abc
 contexts:
-- name: invalid-context
-  context:
-    cluster: test-cluster
-    user: invalid-user
 - context:
     cluster: test-cluster
     user: valid-user
   name: valid-context
+- name: invalid-context
+  context:
+    cluster: test-cluster
+    user: invalid-user
+- name: invalid-cluster
+  context:
+    cluster: invalid-cluster
+    user: invalid-user
 users:
 - name: invalid-user
   user:

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -51,12 +51,13 @@ func TestStartPortForward(t *testing.T) {
 
 	// load kubeconfig
 	kubeConfigPath := getDefaultKubeConfigPath(t)
-	kContexts, errs := kubeconfig.LoadContextsFromFile(kubeConfigPath, kubeconfig.KubeConfig)
-	require.Empty(t, errs)
+	kContexts, contextErrors, err := kubeconfig.LoadContextsFromFile(kubeConfigPath, kubeconfig.KubeConfig)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
 	require.NotEmpty(t, kContexts)
 
 	kc := kContexts[0]
-	err := kubeConfigStore.AddContext(&kc)
+	err = kubeConfigStore.AddContext(&kc)
 	require.NoError(t, err)
 
 	// find a pod to portforward to


### PR DESCRIPTION
This removes the dependacy of manually parsing of k8s resources. It was a problem as we had to be in sync with k8s API changes, which is not a good way. This change removes that and it splits kubeconfig into seperate contexts and validates them.

### Testing

- In your kubeconfig add some context with partial validity. For reference please check [here](https://github.com/headlamp-k8s/headlamp/blob/e13376a49d4191032926373e11d30a1a6c5ff4f7/backend/pkg/kubeconfig/test_data/kubeconfig_partialcontextvalid)
- Run backend `cd backend && go run ./cmd -dev`
- Run frontend `cd frontend && npm start`
- You should see errors in backend and all clusters in frontend.
- You can try with different kubeconfig and check.

### Reference

https://github.com/headlamp-k8s/headlamp/pull/2289#issuecomment-2343545934