### PR TITLE
backend: Use token only if present in PortForward

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -183,7 +183,9 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 		return fmt.Errorf("failed to create portforward request: %v", err)
 	}
 
-	rConf.BearerToken = token
+	if token != "" {
+		rConf.BearerToken = token
+	}
 
 	roundTripper, upgrader, err := spdy.RoundTripperFor(rConf)
 	if err != nil {


### PR DESCRIPTION
this patch uses the token in startPortForward only if the token from the API request is not empty.

fixes #1834 

before:

https://github.com/user-attachments/assets/e40a708b-7ccc-4fd9-bc4c-c92b470a0dcb

after:

https://github.com/user-attachments/assets/398c7aba-958f-4ef0-90cf-d6df83624a45


