### PR TITLE
backend: Add test coverage reports into the PR coverage bot comment

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -64,9 +64,13 @@ jobs:
           set -x
           cd backend
           go test ./... -coverprofile=coverage.out -covermode=atomic -coverpkg=./...
+          testcoverage_full=$(go tool cover -func=coverage.out)
           testcoverage=$(go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+')
+          testcoverage_full_base64=$(echo "$testcoverage_full" | base64 -w 0)
           echo "Code coverage: $testcoverage"
+          echo "$testcoverage_full"
           echo "coverage=$testcoverage" >> $GITHUB_ENV
+          echo "testcoverage_full_base64=$testcoverage_full_base64" >> $GITHUB_ENV
           echo "cleaning up..."
           rm ~/.config/Headlamp/kubeconfigs/config
         shell: bash
@@ -125,8 +129,12 @@ jobs:
             exit 0
           fi
           testcoverage="${{ env.coverage }}"
+          testcoverage_full_base64="${{ env.testcoverage_full_base64 }}"
+          testcoverage_full=$(echo "$testcoverage_full_base64" | base64 --decode)
+
           base_coverage="${{ env.base_coverage }}"
           coverage_diff="${{ env.coverage_diff }}"
+
           if (( $(echo "$coverage_diff < 0" | bc -l) )); then
             emoji="😞" # Decreased coverage
           else
@@ -135,6 +143,21 @@ jobs:
 
           comment="Backend Code coverage changed from $base_coverage% to $testcoverage%. Change: $coverage_diff% $emoji."
           echo "$comment"
+
+          # Add the full coverage report as a collapsible section
+          comment="${comment}
+
+          <details>
+            <summary>See full coverage report</summary>
+
+          \`\`\`
+          $testcoverage_full
+          \`\`\`
+
+          </details>"
+
+          echo "$comment"
+
           if [[ "${{github.event.pull_request.head.repo.full_name}}" == "${{github.repository}}" ]]; then
             # Forks (like dependabot ones) do not have permission to comment on the PR,
             #   so do not fail the action if this fails.

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -64,6 +64,7 @@ jobs:
           set -x
           cd backend
           go test ./... -coverprofile=coverage.out -covermode=atomic -coverpkg=./...
+          go tool cover -html=coverage.out -o backend_coverage.html
           testcoverage_full=$(go tool cover -func=coverage.out)
           testcoverage=$(go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+')
           testcoverage_full_base64=$(echo "$testcoverage_full" | base64 -w 0)
@@ -74,6 +75,13 @@ jobs:
           echo "cleaning up..."
           rm ~/.config/Headlamp/kubeconfigs/config
         shell: bash
+
+      - name: Upload coverage report as artifact
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-report
+          path: ./backend/backend_coverage.html
 
       - name: Get base branch code coverage
         if: ${{ github.event_name }} == 'pull_request'
@@ -134,6 +142,7 @@ jobs:
 
           base_coverage="${{ env.base_coverage }}"
           coverage_diff="${{ env.coverage_diff }}"
+          artifact_url=${{ steps.upload-artifact.outputs.artifact-url }}
 
           if (( $(echo "$coverage_diff < 0" | bc -l) )); then
             emoji="😞" # Decreased coverage
@@ -148,13 +157,16 @@ jobs:
           comment="${comment}
 
           <details>
-            <summary>See full coverage report</summary>
+            <summary>Coverage report</summary>
 
           \`\`\`
           $testcoverage_full
           \`\`\`
 
-          </details>"
+          </details>
+
+          [Html coverage report download]($artifact_url)
+          "
 
           echo "$comment"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 backend/headlamp-server
 backend/headlamp-server.exe
 backend/tools
+backend/coverage.out
 app/electron/src/*
 docs/development/storybook/
 .plugins

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,16 @@ backend:
 backend-test:
 	cd backend && go test -v -p 1 ./...
 
+.PHONY: backend-coverage
+backend-coverage:
+	cd backend && go test -v -p 1 -coverprofile=coverage.out ./...
+	cd backend && go tool cover -func=coverage.out
+
+.PHONY: backend-coverage-html
+backend-coverage-html:
+	cd backend && go test -v -p 1 -coverprofile=coverage.out ./...
+	cd backend && go tool cover -html=coverage.out
+
 .PHONY: backend-format
 backend-format:
 	cd backend && go fmt ./cmd/ ./pkg/**


### PR DESCRIPTION
This is useful to check the test coverage of backend code changes.

- Makefile: Add backend-coverage and backend-coverage-html
- .github/workflows/backend-test: Add coverage report to PR comment
- .github/workflows/backend-test: Add coverage html report as artifact and provide link to it


## How to test

- `make backend-coverage` to see report in terminal.
- `make backend-coverage-html` to see report in browser.
- See bot comment: click toggle arrow to see text report
- See bot comment: Follow html link to download artifact locally to view html report (it is more advanced showing which lines/branches are not covered)
- After `make backend-coverage` doing a `git status` does not show `backend/coverage.out` file because it is .gitignore'd.
