### PR TITLE
frontend: Remove unused @types/redux-mock-store

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -118,7 +118,6 @@
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/user-event": "^14.5.2",
         "@types/nock": "^11.1.0",
-        "@types/redux-mock-store": "^1.0.4",
         "@vitest/coverage-istanbul": "^2.1.1",
         "http-proxy-middleware": "^2.0.1",
         "husky": "^4.3.8",
@@ -5456,15 +5455,6 @@
       "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/redux-mock-store": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.6.tgz",
-      "integrity": "sha512-eg5RDfhJTXuoJjOMyXiJbaDb1B8tfTaJixscmu+jOusj6adGC0Krntz09Tf4gJgXeCqCrM5bBMd+B7ez0izcAQ==",
-      "dev": true,
-      "dependencies": {
-        "redux": "^4.0.5"
       }
     },
     "node_modules/@types/resolve": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -205,7 +205,6 @@
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/user-event": "^14.5.2",
     "@types/nock": "^11.1.0",
-    "@types/redux-mock-store": "^1.0.4",
     "@vitest/coverage-istanbul": "^2.1.1",
     "http-proxy-middleware": "^2.0.1",
     "husky": "^4.3.8",


### PR DESCRIPTION
This was added in with a bad git auto-merge, which broke CI.

It was supposed to be removed in this PR that was already merged:
- https://github.com/headlamp-k8s/headlamp/pull/2364