### PR TITLE
frontend: headlamp-plugin: Update react-dropzone to 14.2.9

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -72,7 +72,7 @@
         "process": "^0.11.10",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-dropzone": "^14.2.3",
+        "react-dropzone": "^14.2.9",
         "react-hotkeys-hook": "^4.5.1",
         "react-i18next": "^15.0.2",
         "react-jwt": "^1.1.6",
@@ -15323,9 +15323,9 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.9.tgz",
+      "integrity": "sha512-jRZsMC7h48WONsOLHcmhyn3cRWJoIPQjPApvt/sJVfnYaB3Qltn025AoRTTJaj4WdmmgmLl6tUQg1s0wOhpodQ==",
       "dependencies": {
         "attr-accept": "^2.2.2",
         "file-selector": "^0.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "process": "^0.11.10",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-dropzone": "^14.2.3",
+    "react-dropzone": "^14.2.9",
     "react-hotkeys-hook": "^4.5.1",
     "react-i18next": "^15.0.2",
     "react-jwt": "^1.1.6",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -119,7 +119,7 @@
         "process": "^0.11.10",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-dropzone": "^14.2.3",
+        "react-dropzone": "^14.2.9",
         "react-hotkeys-hook": "^4.5.1",
         "react-i18next": "^15.0.2",
         "react-jwt": "^1.1.6",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -123,7 +123,7 @@
     "process": "^0.11.10",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-dropzone": "^14.2.3",
+    "react-dropzone": "^14.2.9",
     "react-hotkeys-hook": "^4.5.1",
     "react-i18next": "^15.0.2",
     "react-jwt": "^1.1.6",


### PR DESCRIPTION
https://github.com/react-dropzone/react-dropzone/releases


