### PR TITLE
frontend: Remove usage of defaultProps which is deprecated

### DIFF
--- a/frontend/src/components/common/EmptyContent.tsx
+++ b/frontend/src/components/common/EmptyContent.tsx
@@ -2,13 +2,17 @@ import Box from '@mui/material/Box';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import React from 'react';
 
-export default function Empty(props: React.PropsWithChildren<{ color: TypographyProps['color'] }>) {
+type EmptyProps = React.PropsWithChildren<{
+  color?: TypographyProps['color'];
+}>;
+
+export default function Empty({ color = 'textSecondary', children }: EmptyProps) {
   return (
     <Box padding={2}>
-      {React.Children.map(props.children, child => {
+      {React.Children.map(children, child => {
         if (typeof child === 'string') {
           return (
-            <Typography color={props.color} align="center">
+            <Typography color={color} align="center">
               {child}
             </Typography>
           );
@@ -18,5 +22,3 @@ export default function Empty(props: React.PropsWithChildren<{ color: Typography
     </Box>
   );
 }
-
-Empty.defaultProps = { color: 'textSecondary' };

--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
@@ -22,9 +22,13 @@ export interface UpdatePopupProps {
   skipUpdateHandler: () => void;
 }
 
-function UpdatePopup(props: UpdatePopupProps) {
+function UpdatePopup({
+  releaseDownloadURL,
+  fetchingRelease,
+  releaseFetchFailed,
+  skipUpdateHandler,
+}: UpdatePopupProps) {
   const [show, setShow] = React.useState(true);
-  const { releaseDownloadURL, fetchingRelease, releaseFetchFailed, skipUpdateHandler } = props;
   const { t } = useTranslation();
   const [closeSnackError, setCloseSnackError] = React.useState(false);
 
@@ -199,9 +203,5 @@ function UpdatePopup(props: UpdatePopupProps) {
     />
   );
 }
-
-UpdatePopup.defaultProps = {
-  open: true,
-};
 
 export default UpdatePopup;


### PR DESCRIPTION
- **frontend: EmptyContent: Remove defaultProps usage**
- **frontend: UpdatePopup: Remove usage of defaultProps**

Stops some warnings appearing in dev console/test runner.
