### PR TITLE
frontend: AuthChooser: Fix broken cluster settings URL

### DIFF
--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -110,7 +110,7 @@
                 </div>
                 <a
                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
-                  href="/"
+                  href="/settings/cluster"
                 >
                   Cluster settings
                 </a>

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -297,7 +297,7 @@ export function PureAuthChooser({
                         errorMessage: error!.message,
                       })}
                 </Empty>
-                <Link routeName="settingsCluster" params={{ clusterID: clusterName }}>
+                <Link routeName="settingsClusterHomeContext">
                   {t('translation|Cluster settings')}
                 </Link>
               </Box>


### PR DESCRIPTION
This change addresses a regression from unifying the general and cluster settings. Now, when trying to access a missing cluster, clicking on the "Cluster Settings" link should open the cluster settings in the home context.

Fixes: #2404 

### Testing
- [x] Start Headlamp with two clusters running
- [x] Stop one of the clusters and then try to access it in Headlamp
- [x] When it fails to open, click the "Cluster Settings" link and ensure the cluster settings open

![image](https://github.com/user-attachments/assets/a197ae0b-de00-47ea-9f5f-1d3443dedbb2)
