### PR TITLE
backend: Return after attempt to serve a path using ..

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -91,6 +91,7 @@ type OauthConfig struct {
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.URL.Path, "..") {
 		http.Error(w, "Contains unexpected '..'", http.StatusBadRequest)
+		return
 	}
 
 	// Clean the path to prevent directory traversal

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -109,6 +109,14 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// prepend the path with the path to the static directory
 	path = filepath.Join(absStaticPath, path)
 
+	// This is defensive, for preventing using files outside of the staticPath
+	// if in the future we touch the code.
+	absPath, err := filepath.Abs(path)
+	if err != nil || !strings.HasPrefix(absPath, absStaticPath) {
+		http.Error(w, "Invalid file name (file to serve is outside of the static dir!)", http.StatusBadRequest)
+		return
+	}
+
 	// check whether a file exists at the given path
 	_, err = os.Stat(path)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
For security reasons we don't allow serving paths with .. in them, so we were setting an error but not returning.