### PR TITLE
github: backend-test: Pin dependency to hash

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload coverage report as artifact
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
         with:
           name: backend-coverage-report
           path: ./backend/backend_coverage.html


### PR DESCRIPTION
To fix a security warning with scorecard.

