### PR TITLE
Dockerfile: Use npm ci so lockfile is used

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -59,11 +59,11 @@ jobs:
       run: |
         echo "Extract pod-counter plugin into .plugins folder, which will be copied into image later by 'make image'."
         cd plugins/examples/pod-counter
-        npm install
+        npm ci
         npm run build
         cd ../../../
         cd plugins/headlamp-plugin
-        npm install
+        npm ci
         node bin/headlamp-plugin.js extract ../examples/pod-counter ../../.plugins/
         cd ../../
         ls -laR .plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY app/package.json /headlamp/app/package.json
 # Keep npm install separated so source changes don't trigger install
 COPY frontend/package*.json /headlamp/frontend/
 WORKDIR /headlamp
-RUN cd ./frontend && npm install --only=prod
+RUN cd ./frontend && npm ci --only=prod
 
 FROM frontend-build as frontend
 COPY ./frontend /headlamp/frontend


### PR DESCRIPTION
Npm install uses package.json, and npm ci uses package-lock.json.
Fixes a security issue where packages were not pinned.

