### PR TITLE
frontend: lib/util: Add getClusterGroup

### DIFF
--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -166,6 +166,17 @@ export function useFilterFunc<
   };
 }
 
+/**
+ * Gets clusters.
+ *
+ * @param returnWhenNoClusters return this value when no clusters are found.
+ * @returns the cluster group from the URL.
+ */
+export function getClusterGroup(returnWhenNoClusters: string[] = []): string[] {
+  const clusterFromURL = getCluster();
+  return clusterFromURL?.split('+') || returnWhenNoClusters;
+}
+
 export function useErrorState(dependentSetter?: (...args: any) => void) {
   const [error, setError] = React.useState<ApiError | null>(null);
 


### PR DESCRIPTION
Gets the active group of clusters.

Tiny PR... This is not used in headlamp at the moment, but is a prerequisite for further multi cluster work.
