### PR TITLE
frontend: util: Add flattenClusterListItems for cluster objects

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -1,0 +1,31 @@
+import { flattenClusterListItems } from './util';
+
+describe('flattenClusterListItems', () => {
+  it('should return a flattened list of items', () => {
+    const result = flattenClusterListItems(
+      { cluster1: [1, 2, 3], cluster2: [4, 5] },
+      { cluster3: [6, 7], cluster4: null },
+      null
+    );
+    expect(result).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('should return null if all clusters are null', () => {
+    const result = flattenClusterListItems({ cluster1: null }, { cluster2: null }, null);
+    expect(result).toBeNull();
+  });
+
+  it('should return null if there are no items', () => {
+    const result = flattenClusterListItems({ cluster1: [] }, { cluster2: [] });
+    expect(result).toBeNull();
+  });
+
+  it('should handle mixed null and non-null clusters', () => {
+    const result = flattenClusterListItems(
+      { cluster1: [1, 2], cluster2: null },
+      { cluster3: [3, 4] },
+      null
+    );
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -183,6 +183,22 @@ export function useErrorState(dependentSetter?: (...args: any) => void) {
   return [error, setError as any];
 }
 
+/**
+ * This function joins a list of items per cluster into a single list of items.
+ *
+ * @param args The list of objects per cluster to join.
+ * @returns The joined list of items, or null if there are no items.
+ */
+export function flattenClusterListItems<T>(
+  ...args: ({ [cluster: string]: T[] | null } | null)[]
+): T[] | null {
+  const flatItems = args
+    .filter(Boolean)
+    .flatMap(clusterItems => Object.values(clusterItems ?? {}).flatMap(items => items ?? []));
+
+  return flatItems.length > 0 ? flatItems : null;
+}
+
 type URLStateParams<T> = {
   /** The defaultValue for the URL state. */
   defaultValue: T;


### PR DESCRIPTION
Sometimes we need to convert the objects per cluster into a flat list
of objects.

This is for multi cluster, it's not used yet.
