### PR TITLE
frontend: util: Add combineClusterListErrors

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -1,4 +1,4 @@
-import { flattenClusterListItems } from './util';
+import { combineClusterListErrors, flattenClusterListItems } from './util';
 
 describe('flattenClusterListItems', () => {
   it('should return a flattened list of items', () => {
@@ -27,5 +27,44 @@ describe('flattenClusterListItems', () => {
       null
     );
     expect(result).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('combineClusterListErrors', () => {
+  it('should return null if there are no errors', () => {
+    const result = combineClusterListErrors(null, null);
+    expect(result).toBeNull();
+  });
+
+  it('should combine errors from multiple clusters', () => {
+    const error1 = { message: 'Error 1', status: 500, name: 'InternalServerError' };
+    const error2 = { message: 'Error 2', status: 404, name: 'NotFoundError' };
+    const clusterErrors1 = { clusterA: error1 };
+    const clusterErrors2 = { clusterB: error2 };
+
+    const result = combineClusterListErrors(clusterErrors1, clusterErrors2);
+    expect(result).toEqual({
+      clusterA: error1,
+      clusterB: error2,
+    });
+  });
+
+  it('should ignore null errors', () => {
+    const error1 = { message: 'Error 1', status: 500, name: 'InternalServerError' };
+    const clusterErrors1 = { clusterA: error1 };
+    const clusterErrors2 = { clusterB: null };
+
+    const result = combineClusterListErrors(clusterErrors1, clusterErrors2);
+    expect(result).toEqual({
+      clusterA: error1,
+    });
+  });
+
+  it('should return null if all errors are null', () => {
+    const clusterErrors1 = { clusterA: null };
+    const clusterErrors2 = { clusterB: null };
+
+    const result = combineClusterListErrors(clusterErrors1, clusterErrors2);
+    expect(result).toBeNull();
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -1,4 +1,5 @@
 import humanizeDuration from 'humanize-duration';
+import merge from 'lodash/merge';
 import React from 'react';
 import { useHistory } from 'react-router';
 import { filterGeneric, filterResource } from '../redux/filterSlice';
@@ -208,6 +209,28 @@ export function flattenClusterListItems<T>(
     .flatMap(clusterItems => Object.values(clusterItems ?? {}).flatMap(items => items ?? []));
 
   return flatItems.length > 0 ? flatItems : null;
+}
+
+/**
+ * Combines errors per cluster.
+ *
+ * @param args The list of errors per cluster to join.
+ * @returns The joint list of errors, or null if there are no errors.
+ */
+export function combineClusterListErrors(
+  ...args: ({ [cluster: string]: ApiError | null } | null)[]
+): { [cluster: string]: ApiError | null } | null {
+  const filteredArgs = args.map(clusterErrors => {
+    if (clusterErrors === null) {
+      return {};
+    }
+    return Object.fromEntries(Object.entries(clusterErrors).filter(([, error]) => error !== null));
+  });
+
+  const errors = merge({}, ...filteredArgs);
+  const hasErrors = Object.values(errors).some(error => error !== null);
+
+  return hasErrors ? errors : null;
 }
 
 type URLStateParams<T> = {


### PR DESCRIPTION
For errors, we may need to combine several cluster->errors
objects into a single object.

This is in preparation for multi cluster.

