### PR TITLE
frontend: RouteSwitcher: Fix multicluster mode, no token check

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -12,7 +12,7 @@ import {
   NotFoundRoute,
   Route as RouteType,
 } from '../../lib/router';
-import { getCluster } from '../../lib/util';
+import { getCluster, getClusterGroup } from '../../lib/util';
 import { setHideAppBar } from '../../redux/actions/actions';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { useSidebarItem } from '../Sidebar';
@@ -119,7 +119,13 @@ function AuthRoute(props: AuthRouteProps) {
     }
 
     if (requiresCluster) {
+      if (getClusterGroup().length > 1) {
+        // In multi-cluster mode, we do not know if one of them requires a token.
+        return children;
+      }
+
       const clusterName = getCluster();
+
       if (!!clusterName) {
         if (!!getToken(clusterName) || !requiresToken()) {
           return children;


### PR DESCRIPTION
Do not check if cluster needs a token when in multi-cluster mode.

Because we do not know which cluster needs a token or not.

