### PR TITLE
ci: Use Ubuntu 22 for build-container workflow

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: build discover and deploy
     permissions:
       actions: write # needed to upload artifacts


### PR DESCRIPTION
ubuntu-latest now resolves to 24 
playwright install fails on 24
so in this PR pinning the version to 22