### PR TITLE
frontend: EditorDialog: Add optional actions property

### DIFF
--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -1241,45 +1241,52 @@
           class="MuiDialogContent-root css-erhy6c-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-l256j9"
+            class="MuiBox-root css-1jpm9pd"
           >
             <div
-              class="MuiBox-root css-hpgf8j"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1xu1mzw-MuiGrid-root"
             >
               <div
-                class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
                 >
-                  <span
-                    class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                   >
                     <span
-                      class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                     >
-                      <input
-                        class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                        name="useSimpleEditor"
-                        type="checkbox"
-                      />
                       <span
-                        class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-                      />
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          name="useSimpleEditor"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
                       />
                     </span>
                     <span
-                      class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
-                  >
-                    Use minimal editor
-                  </span>
-                </label>
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Use minimal editor
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -1299,45 +1299,52 @@
           class="MuiDialogContent-root css-erhy6c-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-l256j9"
+            class="MuiBox-root css-1jpm9pd"
           >
             <div
-              class="MuiBox-root css-hpgf8j"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1xu1mzw-MuiGrid-root"
             >
               <div
-                class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
                 >
-                  <span
-                    class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                   >
                     <span
-                      class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                     >
-                      <input
-                        class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                        name="useSimpleEditor"
-                        type="checkbox"
-                      />
                       <span
-                        class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-                      />
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          name="useSimpleEditor"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
                       />
                     </span>
                     <span
-                      class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
-                  >
-                    Use minimal editor
-                  </span>
-                </label>
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Use minimal editor
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -1299,45 +1299,52 @@
           class="MuiDialogContent-root css-erhy6c-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-l256j9"
+            class="MuiBox-root css-1jpm9pd"
           >
             <div
-              class="MuiBox-root css-hpgf8j"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1xu1mzw-MuiGrid-root"
             >
               <div
-                class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
                 >
-                  <span
-                    class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                   >
                     <span
-                      class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                     >
-                      <input
-                        class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                        name="useSimpleEditor"
-                        type="checkbox"
-                      />
                       <span
-                        class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-                      />
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          name="useSimpleEditor"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
                       />
                     </span>
                     <span
-                      class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
-                  >
-                    Use minimal editor
-                  </span>
-                </label>
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Use minimal editor
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/common/Resource/EditorDialog.stories.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.stories.tsx
@@ -1,3 +1,6 @@
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import Switch from '@mui/material/Switch';
 import { Meta, StoryFn } from '@storybook/react';
 import { EditorDialog, EditorDialogProps } from '..';
 
@@ -33,4 +36,17 @@ EditorDialogWithResource.args = {
 export const EditorDialogWithResourceClosed = Template.bind({});
 EditorDialogWithResourceClosed.args = {
   open: false,
+};
+
+export const ExtraActions = Template.bind({});
+ExtraActions.args = {
+  open: true,
+  actions: [
+    <FormGroup row>
+      <FormControlLabel
+        control={<Switch checked onChange={() => {}} />}
+        label="Extra Action Switch"
+      />
+    </FormGroup>,
+  ],
 };

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -6,6 +6,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
+import Grid from '@mui/material/Grid';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import * as yaml from 'js-yaml';
@@ -62,11 +63,22 @@ export interface EditorDialogProps extends DialogProps {
   errorMessage?: string;
   /** The dialog title. */
   title?: string;
+  /** Extra optional actions. */
+  actions?: React.ReactNode[];
 }
 
 export default function EditorDialog(props: EditorDialogProps) {
-  const { item, onClose, onSave, onEditorChanged, saveLabel, errorMessage, title, ...other } =
-    props;
+  const {
+    item,
+    onClose,
+    onSave,
+    onEditorChanged,
+    saveLabel,
+    errorMessage,
+    title,
+    actions = [],
+    ...other
+  } = props;
   const editorOptions = {
     selectOnLineNumbers: true,
     readOnly: isReadOnly(),
@@ -330,21 +342,34 @@ export default function EditorDialog(props: EditorDialogProps) {
               overflowY: 'hidden',
             }}
           >
-            <Box display="flex" flexDirection="row-reverse">
-              <Box p={1}>
-                <FormGroup row>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={useSimpleEditor}
-                        onChange={() => setUseSimpleEditor(!useSimpleEditor)}
-                        name="useSimpleEditor"
-                      />
-                    }
-                    label={t('Use minimal editor')}
-                  />
-                </FormGroup>
-              </Box>
+            <Box py={1}>
+              <Grid container spacing={2} justifyContent="space-between">
+                {
+                  actions.length > 0 ? (
+                    actions.map((action, i) => (
+                      <Grid item key={`editor_action_${i}`}>
+                        {action}
+                      </Grid>
+                    ))
+                  ) : (
+                    <Grid item></Grid>
+                  ) // Just to keep the layout consistent.
+                }
+                <Grid item>
+                  <FormGroup row>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={useSimpleEditor}
+                          onChange={() => setUseSimpleEditor(!useSimpleEditor)}
+                          name="useSimpleEditor"
+                        />
+                      }
+                      label={t('Use minimal editor')}
+                    />
+                  </FormGroup>
+                </Grid>
+              </Grid>
             </Box>
             {isReadOnly() ? (
               makeEditor()

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -81,45 +81,52 @@
           class="MuiDialogContent-root css-erhy6c-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-l256j9"
+            class="MuiBox-root css-1jpm9pd"
           >
             <div
-              class="MuiBox-root css-hpgf8j"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1xu1mzw-MuiGrid-root"
             >
               <div
-                class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
                 >
-                  <span
-                    class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                   >
                     <span
-                      class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                     >
-                      <input
-                        class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                        name="useSimpleEditor"
-                        type="checkbox"
-                      />
                       <span
-                        class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-                      />
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          name="useSimpleEditor"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
                       />
                     </span>
                     <span
-                      class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
-                  >
-                    Use minimal editor
-                  </span>
-                </label>
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Use minimal editor
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -1,24 +1,25 @@
 <body>
-  <div />
+  <div
+    aria-hidden="true"
+  />
   <div
     aria-busy="false"
-    aria-hidden="true"
-    class="MuiDialog-root MuiModal-root MuiModal-hidden css-ew73zq-MuiModal-root-MuiDialog-root"
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
       class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
-      style="opacity: 0; visibility: hidden;"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
     <div
       data-testid="sentinelStart"
-      tabindex="-1"
+      tabindex="0"
     />
     <div
       class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
       role="presentation"
-      style="opacity: 0; visibility: hidden;"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
       tabindex="-1"
     >
       <div
@@ -87,7 +88,43 @@
             >
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-              />
+              >
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                >
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                  >
+                    <span
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                    >
+                      <span
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          checked=""
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
+                      <span
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Extra Action Switch
+                    </span>
+                  </label>
+                </div>
+              </div>
               <div
                 class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
@@ -248,7 +285,7 @@
     </div>
     <div
       data-testid="sentinelEnd"
-      tabindex="-1"
+      tabindex="0"
     />
   </div>
 </body>

--- a/frontend/src/components/common/Resource/__snapshots__/ViewButton.View.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ViewButton.View.stories.storyshot
@@ -92,45 +92,52 @@
           class="MuiDialogContent-root css-erhy6c-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-l256j9"
+            class="MuiBox-root css-1jpm9pd"
           >
             <div
-              class="MuiBox-root css-hpgf8j"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1xu1mzw-MuiGrid-root"
             >
               <div
-                class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
                 >
-                  <span
-                    class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                   >
                     <span
-                      class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                     >
-                      <input
-                        class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                        name="useSimpleEditor"
-                        type="checkbox"
-                      />
                       <span
-                        class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-                      />
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          name="useSimpleEditor"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
                       />
                     </span>
                     <span
-                      class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
-                  >
-                    Use minimal editor
-                  </span>
-                </label>
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Use minimal editor
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/common/Resource/__snapshots__/ViewButton.ViewOpen.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ViewButton.ViewOpen.stories.storyshot
@@ -93,45 +93,52 @@
           class="MuiDialogContent-root css-erhy6c-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-l256j9"
+            class="MuiBox-root css-1jpm9pd"
           >
             <div
-              class="MuiBox-root css-hpgf8j"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1xu1mzw-MuiGrid-root"
             >
               <div
-                class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              />
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
               >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+                <div
+                  class="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
                 >
-                  <span
-                    class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                   >
                     <span
-                      class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
                     >
-                      <input
-                        class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                        name="useSimpleEditor"
-                        type="checkbox"
-                      />
                       <span
-                        class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-                      />
+                        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1nsozxe-MuiButtonBase-root-MuiSwitch-switchBase"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                          name="useSimpleEditor"
+                          type="checkbox"
+                        />
+                        <span
+                          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                        />
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
                       />
                     </span>
                     <span
-                      class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
-                  >
-                    Use minimal editor
-                  </span>
-                </label>
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                    >
+                      Use minimal editor
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
So users can add their own actions.

This will be used later by Resource/CreateButton to add a cluster selector to the EditorDialog.

### How to test

Check the storybook Extra Actions state has the extra action, and the other states do not have any visible changes.

`npm run storybook`

![image](https://github.com/user-attachments/assets/fb567bd0-7840-407e-8975-b7a80f4b6b81)


