### PR TITLE
frontend: RoleList: Make multi cluster aware

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -76,7 +76,7 @@ export type ResourceTableColumn<RowItem> = {
     }
 );
 
-type ColumnType = 'age' | 'name' | 'namespace' | 'type' | 'kind' | 'cluster';
+export type ColumnType = 'age' | 'name' | 'namespace' | 'type' | 'kind' | 'cluster';
 
 export interface ResourceTableProps<RowItem> {
   /** The columns to be rendered, like used in Table, or by name. */


### PR DESCRIPTION
In single cluster mode the RoleList is the same.

The ColumnType is exported needed here to keep the typechecker happy.

### How to test
- [x] this fix needs to be merged first https://github.com/headlamp-k8s/headlamp/pull/2479
- [x] check Role list is the same as before (without a cluster column)
- [x] Add extra cluster to the URL and see Role List has a cluster column. Example of adding an extra cluster: `minikube+minikube2`