### PR TITLE
frontend: Add cluster getter to KubeObject class

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -384,6 +384,10 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       this._clusterName = cluster || getCluster() || '';
     }
 
+    get cluster() {
+      return this._clusterName;
+    }
+
     static get className(): string {
       return objectName;
     }


### PR DESCRIPTION
Because we are accessing it from the ResourceTable and we have that data but didn't have a way to get it.
See the ResourceTable changes at https://github.com/headlamp-k8s/headlamp/commit/1e78de8ca6df0f9d6fde03743712f4aa323a5cf1 .