### PR TITLE
frontend: cluster: hooks: Make useList multi cluster aware

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -377,7 +377,7 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
     static apiEndpoint: ReturnType<typeof apiFactoryWithNamespace | typeof apiFactory>;
     jsonData: T | null = null;
     public static readOnlyFields: JsonPath<T>[];
-    private readonly _clusterName: string;
+    private _clusterName: string;
 
     constructor(json: T, cluster?: string) {
       this.jsonData = json;
@@ -386,6 +386,10 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
 
     get cluster() {
       return this._clusterName;
+    }
+
+    set cluster(cluster: string) {
+      this._clusterName = cluster;
     }
 
     static get className(): string {


### PR DESCRIPTION
Adds these keyed by cluster name to the return of useList():
- `clusterResults`, valued by result of useList on a single one.
- `clusterErrors`, valued by the error if any, otherwise null.

Adds the cluster field for the results from each cluster. So that the tables can display the cluster if needed.

The new useList is backwards compatible and works with one cluster too.

People can now also do this to get the results for cluster groups:
```ts
{ clusterErrors, clusterResults } = useList()
const error = clusterErrors[cluster]
clusterResults[cluster].items[0].cluster // this cluster field is now in each row
```

Another example of usage:
```ts
const { 
  items, // in multiple clusters mode items has .cluster field.
  error, // in single cluster mode this is a single error or null. In multi cluster it's the first error.
  clusterErrors // this is null if no errors, or a Record keyed by cluster name, with a value of the error.
} = resourceClass.useList();
``
```

### Testing

Note: for single clusters it uses the same function as before.

- [ ] in single mode the cluster list views work
- [ ] in multi mode the cluster list views show results from multiple clusters and there is a 'cluster' column in the results.
