### PR TITLE
frontend: stateless: Fix error when clusters is null

### DIFF
--- a/frontend/src/stateless/index.ts
+++ b/frontend/src/stateless/index.ts
@@ -368,9 +368,11 @@ export async function fetchStatelessClusterKubeConfigs(dispatch: any) {
   )
     .then((config: ParsedConfig) => {
       const clustersToConfig: ConfigState['statelessClusters'] = {};
-      config?.clusters.forEach((cluster: Cluster) => {
-        clustersToConfig[cluster.name] = cluster;
-      });
+      if (config?.clusters && Array.isArray(config.clusters)) {
+        config?.clusters.forEach((cluster: Cluster) => {
+          clustersToConfig[cluster.name] = cluster;
+        });
+      }
 
       const configToStore = {
         statelessClusters: clustersToConfig,


### PR DESCRIPTION
There was no checking in the case where clusters is null.

This is the traceback in the dev console. You need to have no "stateless clusters" (which is the default).
![image](https://github.com/user-attachments/assets/83e8c74c-17d6-4859-b511-e7e5b81753b5)
