### PR TITLE
chart: support deploying additional kubernetes manifests

### DIFF
--- a/charts/headlamp/templates/extra-manifests.yaml
+++ b/charts/headlamp/templates/extra-manifests.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraManifests }}
+{{- range $manifest := .Values.extraManifests }}
+---
+{{- tpl $manifest $ | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -1,0 +1,138 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.25.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.25.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+type: Opaque
+data:
+---
+# Source: headlamp/templates/extra-manifests.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dummy-configmap
+data:
+  key1: value1
+  key2: value2
+---
+# Source: headlamp/templates/extra-manifests.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-with-templated-data
+data:
+  injectedKey: headlamp
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.25.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.25.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.25.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.25.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.25.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.25.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.25.1"
+          imagePullPolicy: IfNotPresent
+
+          env:
+          args:
+            - "-in-cluster"
+            - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -116,7 +116,7 @@ spec:
             runAsUser: 100
           image: "ghcr.io/headlamp-k8s/headlamp:v0.25.1"
           imagePullPolicy: IfNotPresent
-
+          
           env:
           args:
             - "-in-cluster"

--- a/charts/headlamp/tests/test_cases/extra-manifests.yaml
+++ b/charts/headlamp/tests/test_cases/extra-manifests.yaml
@@ -1,0 +1,16 @@
+extraManifests:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: dummy-configmap
+    data:
+      key1: value1
+      key2: value2
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: configmap-with-templated-data
+    data:
+      injectedKey: {{ .Release.Name }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -405,6 +405,13 @@
           }
         }
       }
+    },
+    "extraManifests": {
+      "type": "array",
+      "description": "Extra manifests to apply to the deployment",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -205,3 +205,18 @@ tolerations: []
 
 # -- Affinity settings for pod assignment
 affinity: {}
+
+# -- Additional Kubernetes manifests to be deployed. Include the manifest as nested YAML.
+extraManifests: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: my-config
+#   data:
+#     key: value
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: my-config-too
+#   data:
+#     key: value


### PR DESCRIPTION
This change allows the Helm chart's user to include additional Kubernetes manifests to be deployed along with the chart. The incentive for this change was to allow overriding the default use of cluster-admin cluster role and also deploy a different cluster role and binding. 

This is achievable by including the additional manifests as an array of multiline strings in field `extraManifests`. For example:
```
# values.yaml
extraManifests:
  - |
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: dummy-configmap
    data:
      key1: value1
      key2: value2
  - |
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: configmap-with-templated-data
    data:
      injectedKey: {{ .Release.Name }}
```