### PR TITLE
docs: Add new contributors guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,21 +33,122 @@ The next Community Call will be held on October 24th, 2024 at [5:00 PM CEST](htt
 Please use the [project's issue tracker](https://github.com/headlamp-k8s/headlamp/issues) for filing any bugs you find or features
 you think are useful.
 
+### Guidelines for Submitting an Issue
+
+When submitting an issue, follow these guidelines to help maintainers address it efficiently:
+
+**Search for Existing Issues:**
+
+- Use the issue tracker to see if your issue already exists. If it does, consider adding your input to the existing issue instead of opening a new one.
+- If the issue doesn't exist, please create a new issue using one of the templates available:
+  - [For bug related issues](https://github.com/headlamp-k8s/headlamp/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=)
+  - [For feature requests](https://github.com/headlamp-k8s/headlamp/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=)
+
 ### Security issues
 
 For filing security issues that are sensitive and should not be public, please
 send an email to <security@headlamp.dev> .
 
-## Translations
+## Submitting a Pull Request (PR)
 
-If you want to contribute to the internationalization of Headlamp, please refer to the
-dedicated [i18n docs](./development/).
+Follow these steps when submitting a PR to ensure it meets the project’s standards.
 
-### Complex contributions
+### 1. Run Tests and Format Your Code
 
-If you have a complex contribution in mind (meaning changes in the architecture
-or a lot of LOC changed), it is advisable to first file a GitHub issue and
-discuss the implementation with the project's maintainers.
+Navigate to the `frontend` folder and run the following commands:
+
+- `cd frontend`
+- `make frontend-test` - Run the test suite
+- `make frontend-lint` - Format your code to match the project
+
+These steps ensure your code is functional, well-typed, and formatted consistently.
+
+---
+
+### 2. Follow Commit Guidelines
+
+Use **atomic commits** to keep each commit focused on a single change. Follow this structure for your commit messages:
+
+`<area>: <description of changes>`
+
+- Both the title and the body of the commit message shoud not exceed
+  72 characters in length.
+  i.e. Please keep the title length under 72
+  characters, and the wrap the body of the message at 72 characters.
+
+- Commits should be atomic and self-contained. Divide logically separate changes
+  to separate commits. This principle is best explained in the the Linux Kernel
+  [submitting patches](https://www.kernel.org/doc/html/v4.17/process/submitting-patches.html#separate-your-changes) guide.
+
+- Commit messages should explain the intention, _why_ something is done. This,
+  too, is best explained in [this section](https://www.kernel.org/doc/html/v4.17/process/submitting-patches.html#describe-your-changes) from the Linux
+  Kernel patch submission guide.
+
+- Commit titles (the first line in a commit) should be meaningful and describe
+  _what_ the commit does.
+
+- Don't add code you will change in a later commit (it makes it pointless to
+  review that commit), nor create a commit to add code an earlier commit should
+  have added. Consider squashing the relevant commits instead.
+
+- It's not important to retain your development history when contributing a
+  change. Use `git rebase` to squash and order commits in a way that makes them easy to
+  review. Keep the final, well-structured commits and not your development history
+  that led to the final state.
+
+- Consider reviewing the changes yourself before opening a PR. It is likely
+  you will catch errors when looking at your code critically and thus save the
+  reviewers (and yourself) time.
+
+- Use the PR's description as a "cover letter" and give the context you think
+  reviewers might need. Use the PR's description to explain why you are
+  proposing the change, give an overview, raise questions about yet-unresolved
+  issues in your PR, list TODO items etc.
+
+#### Examples:
+
+**Good**
+
+- `frontend: HomeButton: Fix so it navigates to home`
+- `backend: config: Add enable-dynamic-clusters flag`
+
+**Bad**
+
+- `updates the manifest`
+- `Init feature added.`
+- `this adds new colors to the dashboard`
+
+For more detailed commit practices, see Kinvolk's [Git contribution guidelines](https://github.com/kinvolk/contribution/tree/master/topics/git.md).
+
+---
+
+### 3. Write a Descriptive PR Description
+
+When opening a PR, make sure to:
+
+- **Summarize your changes** and **why** they are needed.
+- **Link to the related issue** via `fixes #ISSUE_NUMBER`, if applicable.
+- **Provide steps to test** the changes.
+
+Example:
+
+**This PR fixes the home button bug where the button did not navigate back to the homepage.**
+
+**Steps to Test:**
+
+1. Click on the 'Home' button in the sidebar.
+2. Verify that it navigates to the main screen.
+
+---
+
+### 4. Use Labels for Organization
+
+Add relevant labels to your PR to help with triaging and prioritization:
+
+Example:
+
+- enhancement
+- documentation
 
 ## Coding style
 
@@ -70,6 +171,17 @@ tested for compliance with the coding style.
 
 To speed up a review from the project's maintainers, please make sure that
 the CI checks are passing for your PR.
+
+## Complex contributions
+
+If you have a complex contribution in mind (meaning changes in the architecture
+or a lot of LOC changed), it is advisable to first file a GitHub issue and
+discuss the implementation with the project's maintainers via [#headlamp](https://kubernetes.slack.com/messages/headlamp) Slack channel.
+
+## Translations
+
+If you want to contribute to the internationalization of Headlamp, please refer to the
+dedicated [i18n docs](./development/i18n).
 
 ## Commit guidelines
 


### PR DESCRIPTION
This PR introduces a new contributor guide to the docs directory. The guide provides essential steps for first-time contributors, covering how to submit Pull Requests (PRs) and report Issues effectively.

The goal of this document is to streamline the onboarding process for new contributors and ensure consistency in submissions.

For now, the guide is added to the docs folder, but we are considering alternative locations, such as:

Moving it to the Discussions tab for easy community access.
Integrating it into the README to provide visibility to all contributors.