### PR TITLE
frontend: RestartButton: Use proper event type

### DIFF
--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -106,7 +106,7 @@ interface RestartDialogProps {
 function RestartDialog(props: RestartDialogProps) {
   const { resource, open, onClose, onSave } = props;
   const { t } = useTranslation();
-  const dispatchRestartEvent = useEventCallback(HeadlampEventType.DELETE_RESOURCE);
+  const dispatchRestartEvent = useEventCallback(HeadlampEventType.RESTART_RESOURCE);
 
   return (
     <Dialog


### PR DESCRIPTION
This ensures that the event performed by the restart button is recognized by Headlamp as a restart rather than a delete.