### PR TITLE
backend: Prevent sending refresh signal before the app is ready

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -303,6 +303,12 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 		}
 		if err := json.NewEncoder(w).Encode(pluginsList); err != nil {
 			logger.Log(logger.LevelError, nil, err, "encoding plugins base paths list")
+		} else {
+			// Notify that the client has requested the plugins list. So we can start sending
+			// refresh requests.
+			if err := config.cache.Set(context.Background(), plugins.PluginCanSendRefreshKey, true); err != nil {
+				logger.Log(logger.LevelError, nil, err, "setting plugin-can-send-refresh key")
+			}
 		}
 	}).Methods("GET")
 


### PR DESCRIPTION
The backend was sending a refresh signal to the frontend very early due to reading the plugins folders, and this resulted in a refresh right after the UI was loaded (desktop only).

It is only interesting for the app to refresh after a plugin change if it already has the list of plugins, so these changes prevent that refresh until the app requests the plugins list.

fixes #2182 