### PR TITLE
frontend: vitest.config: Add html coverage report

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -19,7 +19,7 @@ export default mergeConfig(viteConfig, defineConfig({
 
     coverage: {
       provider: 'istanbul',
-      reporter: [['text', { maxCols: 200 }]],
+      reporter: [['text', { maxCols: 200 }], ['html']],
       exclude: [
         ...coverageConfigDefaults.exclude,
         'node_modules/**',


### PR DESCRIPTION
This change adds an html coverage report to vitest.config.ts.

Fixes: #2466 

### Testing

```shell
cd frontend
npm test -- --coverage
cd coverage
python3 -m html.server # runs a local static webserver
```

The coverage report should be in `frontend/coverage/`. To open the report, run `cd frontend/coverage && python3 -m html.server`.


You can also do:

```shell
make test # runs --coverage by default
cd frontend/coverage
python3 -m html.server
```
