### PR TITLE
frontend: k8s: hooks: Fix useKubeObjectList items could contain null

### DIFF
--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -356,7 +356,7 @@ function _useKubeObjectLists<K extends KubeObject>({
     if (items === null) {
       items = clusterResults[cluster].items;
     } else {
-      items = items.concat(clusterResults[cluster].items!);
+      items = items.concat(clusterResults[cluster].items ?? []);
     }
   }
 


### PR DESCRIPTION
When I removed the ! at the end, the type checker complained and helped me find this bug.

If one cluster doesn't have results for something this could result in one null entering the items list.
