### PR TITLE
frontend: Render links for CR's columns that point to k8s resources

### DIFF
--- a/frontend/src/components/crd/CustomResourceDetails.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.tsx
@@ -72,6 +72,20 @@ function getExtraInfo(extraInfoSpec: AdditionalPrinterColumns, item: KubeCRD) {
     if (spec.jsonPath === '.metadata.creationTimestamp') {
       return;
     }
+    if (spec.jsonPath.toLowerCase().includes('secret')) {
+      const name = JSONPath({ path: '$' + spec.jsonPath, json: item })[0];
+      const secret = (
+        <Link routeName={'Secret'} params={{ namespace: item.metadata.namespace, name: name }}>
+          {name}
+        </Link>
+      );
+      extraInfo.push({
+        name: spec.name,
+        value: secret,
+        hide: false,
+      });
+      return;
+    }
 
     let value: string | undefined;
     try {


### PR DESCRIPTION
These changes render any references that look like k8s kinds as links to their details page in Headlamp.

Based on #2278 .

@gberche-orange , this new PR actually shows the links to a resource's details view for any columns that look like they match a K8s kind. **However,** implementing this made me think whether this enough a common use-case. E.g. we may have an implementation of a CRD that has an additional printer col that may mention a secret/configmap/pod and another col that mentions this pod's namespace, different from the CR's for some reason... And this code would be wrong in that case.

So I wonder if this should rather be part of a plugin instead of being in the core.

cc/ @illume for getting your opinion too.