### PR TITLE
frontend: Use multiple queries in useKubeObjectList and add support for allowedNamespaces

### DIFF
--- a/frontend/src/helpers/testHelpers.ts
+++ b/frontend/src/helpers/testHelpers.ts
@@ -1,4 +1,4 @@
-import { useKubeObjectList } from '../lib/k8s/api/v2/hooks';
+import { KubeObject } from '../lib/k8s/KubeObject';
 
 export const useMockListQuery = {
   noData: () =>
@@ -10,7 +10,7 @@ export const useMockListQuery = {
         yield null;
         yield null;
       },
-    } as any as typeof useKubeObjectList),
+    } as any as typeof KubeObject.useList),
   error: () =>
     ({
       data: null,
@@ -20,7 +20,7 @@ export const useMockListQuery = {
         yield null;
         yield 'Phony error is phony!';
       },
-    } as any as typeof useKubeObjectList),
+    } as any as typeof KubeObject.useList),
   data: (items: any[]) =>
     (() => ({
       data: { kind: 'List', items },
@@ -30,5 +30,5 @@ export const useMockListQuery = {
         yield items;
         yield null;
       },
-    })) as any as typeof useKubeObjectList,
+    })) as any as typeof KubeObject.useList,
 };

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -4,7 +4,7 @@ import { getCluster } from '../../../cluster';
 import { ApiError, QueryParameters } from '../../apiProxy';
 import { KubeObject, KubeObjectInterface } from '../../KubeObject';
 import { clusterFetch } from './fetch';
-import { KubeList, KubeListUpdateEvent } from './KubeList';
+import { KubeListUpdateEvent } from './KubeList';
 import { KubeObjectEndpoint } from './KubeObjectEndpoint';
 import { makeUrl } from './makeUrl';
 import { useWebSocket } from './webSocket';
@@ -159,9 +159,13 @@ export function useKubeObject<K extends KubeObject>({
  * @throws Error
  * When no endpoints are working
  */
-const getWorkingEndpoint = async (endpoints: KubeObjectEndpoint[], cluster: string) => {
+const getWorkingEndpoint = async (
+  endpoints: KubeObjectEndpoint[],
+  cluster: string,
+  namespace?: string
+) => {
   const promises = endpoints.map(endpoint => {
-    return clusterFetch(KubeObjectEndpoint.toUrl(endpoint), {
+    return clusterFetch(KubeObjectEndpoint.toUrl(endpoint, namespace), {
       method: 'GET',
       cluster: cluster ?? getCluster() ?? '',
     }).then(it => {
@@ -179,225 +183,22 @@ const getWorkingEndpoint = async (endpoints: KubeObjectEndpoint[], cluster: stri
  *
  * @params endpoints - List of possible endpoints
  */
-const useEndpoints = (endpoints: KubeObjectEndpoint[], cluster: string) => {
+export const useEndpoints = (
+  endpoints: KubeObjectEndpoint[],
+  cluster?: string,
+  namespace?: string
+) => {
   const { data: endpoint } = useQuery({
-    enabled: endpoints.length > 1,
+    enabled: endpoints.length > 1 && cluster !== undefined,
     queryKey: ['endpoints', endpoints],
     queryFn: () =>
-      getWorkingEndpoint(endpoints, cluster)
+      getWorkingEndpoint(endpoints, cluster!, namespace)
         .then(endpoints => endpoints)
         .catch(() => null),
   });
 
+  if (cluster === null || cluster === undefined) return undefined;
   if (endpoints.length === 1) return endpoints[0];
 
   return endpoint;
 };
-
-/**
- * Returns a list of Kubernetes objects and watches for changes
- *
- * @private please use useKubeObjectList.
- */
-function _useKubeObjectList<K extends KubeObject>({
-  kubeObjectClass,
-  namespace,
-  cluster: maybeCluster,
-  queryParams,
-}: {
-  /** Class to instantiate the object with */
-  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
-  /** Object list namespace */
-  namespace?: string;
-  /** Object list cluster */
-  cluster?: string;
-  queryParams?: QueryParameters;
-}): [Array<K> | null, ApiError | null] & QueryListResponse<KubeList<K>, K, ApiError> {
-  const cluster = maybeCluster ?? getCluster() ?? '';
-  const endpoint = useEndpoints(kubeObjectClass.apiEndpoint.apiInfo, cluster);
-
-  const cleanedUpQueryParams = Object.fromEntries(
-    Object.entries(queryParams ?? {}).filter(([, value]) => value !== undefined && value !== '')
-  );
-
-  const queryKey = useMemo(
-    () => ['list', cluster, endpoint, namespace ?? '', cleanedUpQueryParams],
-    [endpoint, namespace, cleanedUpQueryParams]
-  );
-
-  const client = useQueryClient();
-  const query = useQuery<KubeList<any> | null | undefined, ApiError>({
-    enabled: !!endpoint,
-    placeholderData: null,
-    queryKey,
-    queryFn: async () => {
-      if (!endpoint) return;
-      const list: KubeList<any> = await clusterFetch(
-        makeUrl([KubeObjectEndpoint.toUrl(endpoint!, namespace)], cleanedUpQueryParams),
-        {
-          cluster,
-        }
-      ).then(it => it.json());
-      list.items = list.items.map(item => {
-        const itm = new kubeObjectClass({ ...item, kind: list.kind.replace('List', '') });
-        itm.cluster = cluster;
-        return itm;
-      });
-
-      return list;
-    },
-  });
-
-  const items: Array<K> | null = query.error ? null : query.data?.items ?? null;
-  const data: KubeList<K> | null = query.error ? null : query.data ?? null;
-
-  useWebSocket<KubeListUpdateEvent<K>>({
-    url: () =>
-      makeUrl([KubeObjectEndpoint.toUrl(endpoint!)], {
-        ...cleanedUpQueryParams,
-        watch: 1,
-        resourceVersion: data!.metadata.resourceVersion,
-      }),
-    cluster,
-    enabled: !!endpoint && !!data,
-    onMessage(update) {
-      client.setQueryData(queryKey, (oldList: any) => {
-        const newList = KubeList.applyUpdate(oldList, update, kubeObjectClass);
-        return newList;
-      });
-    },
-  });
-
-  // @ts-ignore
-  return {
-    items,
-    data,
-    error: query.error,
-    isError: query.isError,
-    isLoading: query.isLoading,
-    isFetching: query.isFetching,
-    isSuccess: query.isSuccess,
-    status: query.status,
-    *[Symbol.iterator](): ArrayIterator<ApiError | K[] | null> {
-      yield items;
-      yield query.error;
-    },
-  };
-}
-
-/**
- * Returns a combined list of Kubernetes objects and watches for changes from the clusters given.
- */
-export function useKubeObjectList<K extends KubeObject>({
-  kubeObjectClass,
-  namespace,
-  cluster,
-  clusters,
-  queryParams,
-}: {
-  /** Class to instantiate the object with */
-  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
-  /** Object list namespace */
-  namespace?: string;
-  cluster?: string;
-  /** Object list clusters */
-  clusters?: string[];
-  queryParams?: QueryParameters;
-}): [Array<K> | null, ApiError | null] & QueryListResponse<KubeList<K>, K, ApiError> {
-  if (clusters && clusters.length > 0) {
-    return _useKubeObjectLists({
-      kubeObjectClass,
-      namespace,
-      clusters: clusters,
-      queryParams,
-    });
-  } else {
-    return _useKubeObjectList({
-      kubeObjectClass,
-      namespace,
-      cluster: cluster,
-      queryParams,
-    });
-  }
-}
-
-/**
- * Returns a combined list of Kubernetes objects and watches for changes from the clusters given.
- *
- * @private please use useKubeObjectList
- */
-function _useKubeObjectLists<K extends KubeObject>({
-  kubeObjectClass,
-  namespace,
-  clusters,
-  queryParams,
-}: {
-  /** Class to instantiate the object with */
-  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
-  /** Object list namespace */
-  namespace?: string;
-  /** Object list clusters */
-  clusters: string[];
-  queryParams?: QueryParameters;
-}): [Array<K> | null, ApiError | null] & QueryListResponse<KubeList<K>, K, ApiError> {
-  const clusterResults: Record<string, ReturnType<typeof useKubeObjectList<K>>> = {};
-
-  for (const cluster of clusters) {
-    clusterResults[cluster] = _useKubeObjectList({
-      kubeObjectClass,
-      namespace,
-      cluster: cluster || undefined,
-      queryParams,
-    });
-  }
-
-  let items = null;
-  for (const cluster of clusters) {
-    if (items === null) {
-      items = clusterResults[cluster].items;
-    } else {
-      items = items.concat(clusterResults[cluster].items ?? []);
-    }
-  }
-
-  // data makes no sense really for multiple clusters, but useful for single cluster?
-  const data =
-    clusters.map(cluster => clusterResults[cluster].data).find(it => it !== null) ?? null;
-  const error =
-    clusters.map(cluster => clusterResults[cluster].error).find(it => it !== null) ?? null;
-  const isError = clusters.some(cluster => clusterResults[cluster].isError);
-  const isLoading = clusters.some(cluster => clusterResults[cluster].isLoading);
-  const isFetching = clusters.some(cluster => clusterResults[cluster].isFetching);
-  const isSuccess = clusters.every(cluster => clusterResults[cluster].isSuccess);
-  // status makes no sense really for multiple clusters, but maybe useful for single cluster?
-  const status =
-    clusters.map(cluster => clusterResults[cluster].status).find(it => it !== null) ?? 'pending';
-
-  let clusterErrors: Record<string, ApiError | null> | null = {};
-  clusters.forEach(cluster => {
-    if (clusterErrors && clusterResults[cluster]?.error !== null) {
-      clusterErrors[cluster] = clusterResults[cluster].error;
-    }
-  });
-  if (Object.keys(clusterErrors).length === 0) {
-    clusterErrors = null;
-  }
-
-  // @ts-ignore
-  return {
-    items,
-    data,
-    error,
-    isError,
-    isLoading,
-    isFetching,
-    isSuccess,
-    status,
-    *[Symbol.iterator](): ArrayIterator<ApiError | K[] | null> {
-      yield items;
-      yield error;
-    },
-    clusterResults,
-    clusterErrors,
-  };
-}

--- a/frontend/src/lib/k8s/api/v2/makeUrl.test.ts
+++ b/frontend/src/lib/k8s/api/v2/makeUrl.test.ts
@@ -51,4 +51,10 @@ describe('makeUrl', () => {
     const result = makeUrl(urlParts);
     expect(result).toBe('http://example.com/123/true/resource');
   });
+
+  it('should create a url from a single string', () => {
+    expect(makeUrl('http://example.com/some/path', { watch: 1 })).toBe(
+      'http://example.com/some/path?watch=1'
+    );
+  });
 });

--- a/frontend/src/lib/k8s/api/v2/makeUrl.ts
+++ b/frontend/src/lib/k8s/api/v2/makeUrl.ts
@@ -12,11 +12,14 @@
  *
  * @returns Formatted URL path
  */
-export function makeUrl(urlParts: any[], query: Record<string, any> = {}) {
-  const url = urlParts
-    .map(it => (typeof it === 'string' ? it : String(it)))
-    .filter(Boolean)
-    .join('/');
+export function makeUrl(urlParts: any[] | string, query: Record<string, any> = {}) {
+  const url =
+    typeof urlParts === 'string'
+      ? urlParts
+      : urlParts
+          .map(it => (typeof it === 'string' ? it : String(it)))
+          .filter(Boolean)
+          .join('/');
   const queryString = new URLSearchParams(query).toString();
   const fullUrl = queryString ? `${url}?${queryString}` : url;
 

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.ts
@@ -1,0 +1,70 @@
+import { makeListRequests } from './useKubeObjectList';
+
+describe('makeListRequests', () => {
+  describe('for non namespaced resource', () => {
+    it('should not include namespace in requests', () => {
+      const requests = makeListRequests(['default'], () => ['namespace-a'], false, [
+        'namepspace-a',
+        'namespace-b',
+      ]);
+      expect(requests).toEqual([{ cluster: 'default', namespaces: undefined }]);
+    });
+  });
+  describe('for namespaced resource', () => {
+    it('should make request with no namespaces provided', () => {
+      const requests = makeListRequests(['default'], () => [], true);
+      expect(requests).toEqual([{ cluster: 'default', namespaces: [] }]);
+    });
+
+    it('should make requests for allowed namespaces only', () => {
+      const requests = makeListRequests(['default'], () => ['namespace-a'], true);
+      expect(requests).toEqual([{ cluster: 'default', namespaces: ['namespace-a'] }]);
+    });
+
+    it('should make requests for allowed namespaces only, even when requested other', () => {
+      const requests = makeListRequests(['default'], () => ['namespace-a'], true, [
+        'namespace-a',
+        'namespace-b',
+      ]);
+      expect(requests).toEqual([{ cluster: 'default', namespaces: ['namespace-a'] }]);
+    });
+
+    it('should make requests for allowed namespaces per cluster', () => {
+      const requests = makeListRequests(
+        ['cluster-a', 'cluster-b'],
+        (cluster: string | null) => (cluster === 'cluster-a' ? ['namespace-a'] : ['namespace-b']),
+        true
+      );
+      expect(requests).toEqual([
+        { cluster: 'cluster-a', namespaces: ['namespace-a'] },
+        { cluster: 'cluster-b', namespaces: ['namespace-b'] },
+      ]);
+    });
+
+    it('should make requests for allowed namespaces per cluster, even if requested other', () => {
+      const requests = makeListRequests(
+        ['cluster-a', 'cluster-b'],
+        (cluster: string | null) => (cluster === 'cluster-a' ? ['namespace-a'] : ['namespace-b']),
+        true,
+        ['namespace-a', 'namespace-b', 'namespace-c']
+      );
+      expect(requests).toEqual([
+        { cluster: 'cluster-a', namespaces: ['namespace-a'] },
+        { cluster: 'cluster-b', namespaces: ['namespace-b'] },
+      ]);
+    });
+
+    it('should make requests for allowed namespaces per cluster, with one cluster without allowed namespaces', () => {
+      const requests = makeListRequests(
+        ['cluster-a', 'cluster-b'],
+        (cluster: string | null) => (cluster === 'cluster-a' ? ['namespace-a'] : []),
+        true,
+        ['namespace-a', 'namespace-b', 'namespace-c']
+      );
+      expect(requests).toEqual([
+        { cluster: 'cluster-a', namespaces: ['namespace-a'] },
+        { cluster: 'cluster-b', namespaces: ['namespace-a', 'namespace-b', 'namespace-c'] },
+      ]);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -1,0 +1,330 @@
+import { QueryObserverOptions, useQueries, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { KubeObject, KubeObjectClass } from '../../KubeObject';
+import { ApiError } from '../v1/clusterRequests';
+import { QueryParameters } from '../v1/queryParameters';
+import { clusterFetch } from './fetch';
+import { QueryListResponse, useEndpoints } from './hooks';
+import { KubeList, KubeListUpdateEvent } from './KubeList';
+import { KubeObjectEndpoint } from './KubeObjectEndpoint';
+import { makeUrl } from './makeUrl';
+import { useWebSockets } from './webSocket';
+
+/**
+ * Object representing a List of Kube object
+ * with information about which cluster and namespace it came from
+ */
+export interface ListResponse<K extends KubeObject> {
+  /** KubeList with items */
+  list: KubeList<K>;
+  /** Cluster of the list */
+  cluster: string;
+  /** If the list only has items from one namespace */
+  namespace?: string;
+}
+
+/**
+ * Error thrown when listing Kube objects
+ * Contains information about the cluster and namespace
+ */
+class ListError extends Error {
+  constructor(public message: any, public cluster: string, public namespace?: string) {
+    super(message);
+  }
+}
+
+/**
+ * Query to list Kube objects from a cluster and namespace(optional)
+ *
+ * @param kubeObjectClass - Class to instantiate the object with
+ * @param endpoint - API endpoint
+ * @param namespace - namespace to list objects from(optional)
+ * @param cluster - cluster name
+ * @param queryParams - query parameters
+ * @returns query options for getting a single list of kube resources
+ */
+export function kubeObjectListQuery<K extends KubeObject>(
+  kubeObjectClass: KubeObjectClass,
+  endpoint: KubeObjectEndpoint,
+  namespace: string | undefined,
+  cluster: string,
+  queryParams: QueryParameters
+): QueryObserverOptions<ListResponse<K> | undefined | null, ListError> {
+  return {
+    placeholderData: null,
+    queryKey: [
+      'kubeObject',
+      'list',
+      kubeObjectClass.apiVersion,
+      kubeObjectClass.apiName,
+      cluster,
+      namespace ?? '',
+      queryParams,
+    ],
+    queryFn: async () => {
+      // If no valid endpoint is passed, don't make the request
+      if (!endpoint) return;
+
+      try {
+        const list: KubeList<any> = await clusterFetch(
+          makeUrl([KubeObjectEndpoint.toUrl(endpoint!, namespace)], queryParams),
+          {
+            cluster,
+          }
+        ).then(it => it.json());
+        list.items = list.items.map(item => {
+          const itm = new kubeObjectClass({ ...item, kind: list.kind.replace('List', '') });
+          itm.cluster = cluster;
+          return itm;
+        });
+
+        const response: ListResponse<K> = {
+          list: list as KubeList<K>,
+          cluster,
+          namespace,
+        };
+
+        return response;
+      } catch (e) {
+        // Rethrow error with cluster and namespace information
+        throw new ListError(e, cluster, namespace);
+      }
+    },
+  };
+}
+
+/**
+ * Accepts a list of lists to watch.
+ * Upon receiving update it will modify query data for list query
+ */
+function useWatchKubeObjectLists<K extends KubeObject>({
+  kubeObjectClass,
+  endpoint,
+  lists,
+  queryParams,
+}: {
+  /** KubeObject class of the watched resource list */
+  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
+  /** Query parameters for the WebSocket connection URL */
+  queryParams?: QueryParameters;
+  /** Kube resource API endpoint information */
+  endpoint?: KubeObjectEndpoint | null;
+  /** Which clusters and namespaces to watch */
+  lists: Array<{ cluster: string; namespace?: string; resourceVersion: string }>;
+}) {
+  const client = useQueryClient();
+
+  const connections = useMemo(() => {
+    if (!endpoint) return [];
+
+    return lists.map(({ cluster, namespace, resourceVersion }) => {
+      const url = makeUrl([KubeObjectEndpoint.toUrl(endpoint!, namespace)], {
+        ...queryParams,
+        watch: 1,
+        resourceVersion,
+      });
+
+      return {
+        cluster,
+        url,
+        onMessage(update: KubeListUpdateEvent<K>) {
+          const key = kubeObjectListQuery<K>(
+            kubeObjectClass,
+            endpoint,
+            namespace,
+            cluster,
+            queryParams ?? {}
+          ).queryKey;
+          client.setQueryData(key, (oldResponse: ListResponse<any> | undefined | null) => {
+            if (!oldResponse) return oldResponse;
+
+            const newList = KubeList.applyUpdate(oldResponse.list, update, kubeObjectClass);
+            return { ...oldResponse, list: newList };
+          });
+        },
+      };
+    });
+  }, [lists, kubeObjectClass, endpoint]);
+
+  useWebSockets<KubeListUpdateEvent<K>>({
+    enabled: !!endpoint,
+    connections,
+  });
+}
+
+/**
+ * Creates multiple requests to list Kube objects
+ * Handles multiple clusters, namespaces and allowed namespaces
+ *
+ * @param clusters - list of clusters
+ * @param getAllowedNamespaces -  function to get allowed namespaces for a cluster
+ * @param isResourceNamespaced - if the resource is namespaced
+ * @param requestedNamespaces - requested namespaces(optional)
+ *
+ * @returns list of requests for clusters and appropriate namespaces
+ */
+export function makeListRequests(
+  clusters: string[],
+  getAllowedNamespaces: (cluster: string | null) => string[],
+  isResourceNamespaced: boolean,
+  requestedNamespaces?: string[]
+): Array<{ cluster: string; namespaces?: string[] }> {
+  return clusters.map(cluster => {
+    const allowedNamespaces = getAllowedNamespaces(cluster);
+
+    let namespaces = requestedNamespaces ?? allowedNamespaces;
+    if (allowedNamespaces.length) {
+      namespaces = namespaces.filter(ns => allowedNamespaces.includes(ns));
+    }
+
+    return { cluster, namespaces: isResourceNamespaced ? namespaces : undefined };
+  });
+}
+
+/**
+ * Returns a combined list of Kubernetes objects and watches for changes from the clusters given.
+ *
+ * @param param - request paramaters
+ * @returns Combined list of Kubernetes resources
+ */
+export function useKubeObjectList<K extends KubeObject>({
+  requests,
+  kubeObjectClass,
+  queryParams,
+  watch = true,
+}: {
+  requests: Array<{ cluster: string; namespaces?: string[] }>;
+  /** Class to instantiate the object with */
+  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
+  queryParams?: QueryParameters;
+  /** Watch for updates @default true */
+  watch?: boolean;
+}): [Array<K> | null, ApiError | null] &
+  QueryListResponse<Array<ListResponse<K> | undefined | null>, K, ApiError> {
+  const maybeNamespace = requests.find(it => it.namespaces)?.namespaces?.[0];
+
+  // Get working endpoint from the first cluster
+  // Now if clusters have different apiVersions for the same resource for example, this will not work
+  const endpoint = useEndpoints(
+    kubeObjectClass.apiEndpoint.apiInfo,
+    requests[0]?.cluster,
+    maybeNamespace
+  );
+
+  const cleanedUpQueryParams = Object.fromEntries(
+    Object.entries(queryParams ?? {}).filter(([, value]) => value !== undefined && value !== '')
+  );
+
+  const queries = useMemo(
+    () =>
+      endpoint
+        ? requests.flatMap(({ cluster, namespaces }) =>
+            namespaces && namespaces.length > 0
+              ? namespaces.map(namespace =>
+                  kubeObjectListQuery<K>(
+                    kubeObjectClass,
+                    endpoint,
+                    namespace,
+                    cluster,
+                    cleanedUpQueryParams
+                  )
+                )
+              : kubeObjectListQuery<K>(
+                  kubeObjectClass,
+                  endpoint,
+                  undefined,
+                  cluster,
+                  cleanedUpQueryParams
+                )
+          )
+        : [],
+    [requests, kubeObjectClass, endpoint, cleanedUpQueryParams]
+  );
+
+  const query = useQueries({
+    queries,
+    combine(results) {
+      return {
+        data: results.map(result => result.data),
+        clusterResults: results.reduce((acc, result) => {
+          if (result.data && result.data.cluster) {
+            acc[result.data.cluster] = {
+              data: result.data,
+              error: result.error as any as ApiError | null,
+              isError: result.isError,
+              isFetching: result.isFetching,
+              isLoading: result.isLoading,
+              isSuccess: result.isSuccess,
+              items: result?.data?.list?.items ?? null,
+              status: result.status,
+            };
+          }
+          return acc;
+        }, {} as Record<string, QueryListResponse<any, K, ApiError>>),
+        items: results.every(result => result.data === null)
+          ? null
+          : results.flatMap(result => result?.data?.list?.items ?? []),
+        errors: results.map(result => result.error),
+        clusterErrors: results
+          .filter(result => result.error)
+          .reduce((acc, result) => {
+            if (result.error) {
+              acc[result.error.cluster] = result.error as any as ApiError;
+            }
+            return acc;
+          }, {} as Record<string, ApiError>),
+        isError: results.some(result => result.isError),
+        isLoading: results.some(result => result.isLoading),
+        isFetching: results.some(result => result.isFetching),
+        isSuccess: results.every(result => result.isSuccess),
+      };
+    },
+  });
+
+  const shouldWatch = watch && !query.isLoading;
+
+  const [listsToWatch, setListsToWatch] = useState<
+    { cluster: string; namespace?: string; resourceVersion: string }[]
+  >([]);
+
+  const listsNotYetWatched = query.data
+    .filter(Boolean)
+    .filter(
+      data =>
+        listsToWatch.find(
+          // resourceVersion is intentionally omitted to avoid recreating WS connection when list is updated
+          watching => watching.cluster === data?.cluster && watching.namespace === data.namespace
+        ) === undefined
+    )
+    .map(data => ({
+      cluster: data!.cluster,
+      namespace: data!.namespace,
+      resourceVersion: data!.list.metadata.resourceVersion,
+    }));
+
+  if (listsNotYetWatched.length > 0) {
+    setListsToWatch([...listsToWatch, ...listsNotYetWatched]);
+  }
+
+  useWatchKubeObjectLists({
+    lists: shouldWatch ? listsToWatch : [],
+    endpoint,
+    kubeObjectClass,
+    queryParams: cleanedUpQueryParams,
+  });
+
+  // @ts-ignore - TS compiler gets confused with iterators
+  return {
+    items: query.items,
+    clusterResults: query.clusterResults,
+    clusterErrors: query.clusterErrors,
+    isError: query.isError,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isSuccess: query.isSuccess,
+    *[Symbol.iterator](): ArrayIterator<ApiError | K[] | null> {
+      yield query.items;
+      yield query.errors[0] as any as ApiError;
+    },
+  };
+}


### PR DESCRIPTION
Create a kubeObjectListQuery, for a singular request 
useKubeObjectList can handle multiple clusters and namespaces by using multiple queries

_useKubeObjectList and _useKubeObjectLists are no longer neccessary since useKubeObjectList can handle 1 and more lists

Manual testing done:

- [x] No allowedNamespaces, loads /pods
- [x] two working allowedNamespaces
- [x] one working and one non existing allowedNamespaces 
- [x] token auth with access to only one namespace, no allowedNamespaces (fails as expected)
- [x] token auth with access to only one namespace, one allowedNamespaces (works)
- [x] token auth with access to only one namespace, one working and one non existing (works, shows error)
- [x] multi cluster, one cluster with allowedNamespaces[a,b], second cluster with token auth with allowedNamespaces[c] (works)
