### PR TITLE
github: pr-to-update-winget: Use npm ci to pin deps

### DIFF
--- a/.github/workflows/pr-to-update-winget.yml
+++ b/.github/workflows/pr-to-update-winget.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install winget dependencies
         run: |
           cd $GITHUB_WORKSPACE/app
-          npm install
+          npm ci
 
       # We set the latest tag as an environment variable before we use it in the next steps
       # note that we have to echo the variable to the environment file to make it available in the next steps


### PR DESCRIPTION
This fixes a security issue where dependencies are not pinned.