### PR TITLE
headlamp-plugin: Fix extract/package to copy all in dist/

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -173,25 +173,12 @@ function extract(pluginPackagesPath, outputPlugins, logSteps = true) {
     fs.mkdirSync(outputPlugins);
   }
 
-  function copyFiles(plugName, inputMainJs, mainjs) {
-    if (!fs.existsSync(plugName)) {
-      if (logSteps) {
-        console.log(`Making output folder "${plugName}".`);
-      }
-      fs.mkdirSync(plugName);
-    }
-
-    if (logSteps) {
-      console.log(`Copying "${inputMainJs}" to "${mainjs}".`);
-    }
-    fs.copyFileSync(inputMainJs, mainjs);
-  }
-
   /**
    * pluginPackagesPath is a package folder, not a folder of packages.
    */
   function extractPackage() {
     if (fs.existsSync(path.join(pluginPackagesPath, 'dist', 'main.js'))) {
+      const distPath = path.join(pluginPackagesPath, 'dist');
       const trimmedPath =
         pluginPackagesPath.slice(-1) === path.sep
           ? pluginPackagesPath.slice(0, -1)
@@ -199,9 +186,15 @@ function extract(pluginPackagesPath, outputPlugins, logSteps = true) {
       const folderName = trimmedPath.split(path.sep).splice(-1)[0];
       const plugName = path.join(outputPlugins, folderName);
 
-      const inputMainJs = path.join(pluginPackagesPath, 'dist', 'main.js');
-      const outputMainjs = path.join(plugName, 'main.js');
-      copyFiles(plugName, inputMainJs, outputMainjs);
+      fs.ensureDirSync(plugName);
+
+      const files = fs.readdirSync(distPath);
+      files.forEach(file => {
+        const srcFile = path.join(distPath, file);
+        const destFile = path.join(plugName, file);
+        console.log(`Copying "${srcFile}" to "${destFile}".`);
+        fs.copyFileSync(srcFile, destFile);
+      });
 
       const inputPackageJson = path.join(pluginPackagesPath, 'package.json');
       const outputPackageJson = path.join(plugName, 'package.json');
@@ -222,11 +215,18 @@ function extract(pluginPackagesPath, outputPlugins, logSteps = true) {
     });
 
     folders.forEach(folder => {
+      const distPath = path.join(pluginPackagesPath, folder.name, 'dist');
       const plugName = path.join(outputPlugins, folder.name);
 
-      const inputMainJs = path.join(pluginPackagesPath, folder.name, 'dist', 'main.js');
-      const outputMainjs = path.join(plugName, 'main.js');
-      copyFiles(plugName, inputMainJs, outputMainjs);
+      fs.ensureDirSync(plugName);
+
+      const files = fs.readdirSync(distPath);
+      files.forEach(file => {
+        const srcFile = path.join(distPath, file);
+        const destFile = path.join(plugName, file);
+        console.log(`Copying "${srcFile}" to "${destFile}".`);
+        fs.copyFileSync(srcFile, destFile);
+      });
 
       const inputPackageJson = path.join(pluginPackagesPath, folder.name, 'package.json');
       const outputPackageJson = path.join(plugName, 'package.json');

--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -42,10 +42,14 @@ function testHeadlampPlugin() {
   run(`node bin/headlamp-plugin.js build ${PACKAGE_NAME}`);
   checkFileExists(join(PACKAGE_NAME, 'dist', 'main.js'));
 
+  fs.writeFileSync(join(PACKAGE_NAME, 'dist', 'extra.txt'), 'All dist/ files will be copied.');
+
   // test extraction works
   run(`node bin/headlamp-plugin.js extract . .plugins`);
   checkFileExists(join('.plugins', PACKAGE_NAME, 'main.js'));
   checkFileExists(join('.plugins', PACKAGE_NAME, 'package.json'));
+  // make sure extra files in dist/ folder are copied too
+  checkFileExists(join('.plugins', PACKAGE_NAME, 'extra.txt'));
 
   // test packing works
   const tmpDir = fs.mkdtempSync('headlamp-plugin-test-');


### PR DESCRIPTION
All files made in the dist/ folder are copied in.


So plugins can add extra files if they need in the build step.

For example:

```
  "scripts": {
    "build": "headlamp-plugin build && npx shx cp main.wasm dist/main.wasm",
```

Needed for:
- https://github.com/headlamp-k8s/plugins/issues/13