### PR TITLE
frontend: Improve handling of an edgecase in useKubeObject useKubeObjectList hooks

### DIFF
--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -94,7 +94,7 @@ export function useKubeObject<K extends KubeObject>({
   );
 
   const queryKey = useMemo(
-    () => ['object', cluster, endpoint, namespace, name, cleanedUpQueryParams],
+    () => ['object', cluster, endpoint, namespace ?? '', name, cleanedUpQueryParams],
     [endpoint, namespace, name]
   );
 
@@ -221,7 +221,7 @@ function _useKubeObjectList<K extends KubeObject>({
   );
 
   const queryKey = useMemo(
-    () => ['list', cluster, endpoint, namespace, cleanedUpQueryParams],
+    () => ['list', cluster, endpoint, namespace ?? '', cleanedUpQueryParams],
     [endpoint, namespace, cleanedUpQueryParams]
   );
 


### PR DESCRIPTION
So we don't have a different key when a function uses the namespace as `undefined` and another as `''`.
