### PR TITLE
frontend: Fix missing cluster fields in list views for multi cluster

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -151,6 +151,7 @@ function EventsSection() {
           gridTemplate: 1.5,
         },
         'namespace',
+        'cluster',
         {
           label: t('Reason'),
           getValue: event => event.reason,

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -22,6 +22,7 @@ export default function NodeList() {
       resourceClass={Node}
       columns={[
         'name',
+        'cluster',
         {
           id: 'cpu',
           label: t('CPU'),
@@ -143,7 +144,6 @@ export default function NodeList() {
           },
           show: false,
         },
-        'cluster',
         'age',
       ]}
     />

--- a/frontend/src/components/resourceQuota/List.tsx
+++ b/frontend/src/components/resourceQuota/List.tsx
@@ -46,6 +46,7 @@ export function ResourceQuotaRenderer(props: ResourceQuotaProps) {
       columns={[
         'name',
         'namespace',
+        'cluster',
         {
           id: 'requests',
           label: t('translation|Request'),

--- a/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.tsx
+++ b/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.tsx
@@ -11,6 +11,7 @@ export default function ValidatingWebhookConfigurationList() {
       resourceClass={ValidatingWebhookConfiguration}
       columns={[
         'name',
+        'cluster',
         {
           id: 'webhooks',
           label: t('Webhooks'),


### PR DESCRIPTION
In multi cluster mode it adds a few cluster fields to some list views that didn't have it yet.

(in single cluster mode no cluster field is visible)

![image](https://github.com/user-attachments/assets/a0e63edf-75d6-46ff-960d-d36f8073d10e)