### PR TITLE
Fix home constant update

### DIFF
--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -175,18 +175,14 @@ interface HomeComponentProps {
   clusters: { [name: string]: Cluster };
 }
 
-function HomeComponent(props: HomeComponentProps) {
-  const { clusters } = props;
-  const [customNameClusters, setCustomNameClusters] = React.useState(getClusterNames());
-  const { t } = useTranslation(['translation', 'glossary']);
-  const [versions, errors] = useClustersVersion(Object.values(clusters));
+function useWarningSettingsPerCluster(clusterNames: string[]) {
+  const warningsMap = Event.useWarningList(clusterNames);
+  const [warningLabels, setWarningLabels] = React.useState<{ [cluster: string]: string }>({});
   const maxWarnings = 50;
-  const warningsMap = Event.useWarningList(Object.values(customNameClusters).map(c => c.name));
 
-  function renderWarningsText(clusterName: string) {
+  function renderWarningsText(warnings: typeof warningsMap, clusterName: string) {
     const numWarnings =
-      (!!warningsMap[clusterName]?.error && -1) ||
-      (warningsMap[clusterName]?.warnings?.length ?? -1);
+      (!!warnings[clusterName]?.error && -1) || (warnings[clusterName]?.warnings?.length ?? -1);
 
     if (numWarnings === -1) {
       return '⋯';
@@ -194,17 +190,33 @@ function HomeComponent(props: HomeComponentProps) {
     if (numWarnings >= maxWarnings) {
       return `${maxWarnings}+`;
     }
-    return numWarnings;
+    return numWarnings.toString();
   }
 
-  function getClusterNames() {
-    return Object.values(clusters)
-      .map(c => ({
-        ...c,
-        name: c.meta_data?.extensions?.headlamp_info?.customName || c.name,
-      }))
-      .sort();
-  }
+  React.useEffect(() => {
+    setWarningLabels(currentWarningLabels => {
+      const newWarningLabels: { [cluster: string]: string } = {};
+      for (const cluster of clusterNames) {
+        newWarningLabels[cluster] = renderWarningsText(warningsMap, cluster);
+      }
+      if (!isEqual(newWarningLabels, currentWarningLabels)) {
+        return newWarningLabels;
+      }
+      return currentWarningLabels;
+    });
+  }, [warningsMap]);
+
+  return warningLabels;
+}
+
+function HomeComponent(props: HomeComponentProps) {
+  const { clusters } = props;
+  const [customNameClusters, setCustomNameClusters] = React.useState(getClusterNames());
+  const { t } = useTranslation(['translation', 'glossary']);
+  const [versions, errors] = useClustersVersion(Object.values(clusters));
+  const warningLabels = useWarningSettingsPerCluster(
+    Object.values(customNameClusters).map(c => c.name)
+  );
 
   React.useEffect(() => {
     setCustomNameClusters(currentNames => {
@@ -215,59 +227,73 @@ function HomeComponent(props: HomeComponentProps) {
     });
   }, [customNameClusters]);
 
-  return (
-    <PageGrid>
-      <SectionBox headerProps={{ headerStyle: 'main' }} title={t('Home')}>
-        <RecentClusters clusters={Object.values(customNameClusters)} onButtonClick={() => {}} />
-      </SectionBox>
-      <SectionBox
-        title={
-          <SectionFilterHeader
-            title={t('All Clusters')}
-            noNamespaceFilter
-            headerStyle="subsection"
-          />
-        }
-      >
-        <ResourceTable<any>
-          defaultSortingColumn={{ id: 'name', desc: false }}
-          columns={[
-            {
-              id: 'name',
-              label: t('Name'),
-              getValue: cluster => cluster.name,
-              render: ({ name }) => (
-                <Link routeName="cluster" params={{ cluster: name }}>
-                  {name}
-                </Link>
-              ),
-            },
-            {
-              label: t('Status'),
-              getValue: cluster => cluster.name,
-              render: ({ name }) => <ClusterStatus error={errors[name]} />,
-            },
-            {
-              label: t('Warnings'),
-              getValue: ({ name }) => renderWarningsText(name),
-            },
-            {
-              label: t('glossary|Kubernetes Version'),
-              getValue: ({ name }) => versions[name]?.gitVersion || '⋯',
-            },
-            {
-              label: '',
-              getValue: () => '',
-              cellProps: {
-                align: 'right',
+  function getClusterNames() {
+    return Object.values(clusters)
+      .map(c => ({
+        ...c,
+        name: c.meta_data?.extensions?.headlamp_info?.customName || c.name,
+      }))
+      .sort();
+  }
+
+  const memoizedComponent = React.useMemo(
+    () => (
+      <PageGrid>
+        <SectionBox headerProps={{ headerStyle: 'main' }} title={t('Home')}>
+          <RecentClusters clusters={Object.values(customNameClusters)} onButtonClick={() => {}} />
+        </SectionBox>
+        <SectionBox
+          title={
+            <SectionFilterHeader
+              title={t('All Clusters')}
+              noNamespaceFilter
+              headerStyle="subsection"
+            />
+          }
+        >
+          <ResourceTable<any>
+            defaultSortingColumn={{ id: 'name', desc: false }}
+            columns={[
+              {
+                id: 'name',
+                label: t('Name'),
+                getValue: cluster => cluster.name,
+                render: ({ name }) => (
+                  <Link routeName="cluster" params={{ cluster: name }}>
+                    {name}
+                  </Link>
+                ),
               },
-              render: cluster => <ContextMenu cluster={cluster} />,
-            },
-          ]}
-          data={Object.values(customNameClusters)}
-          id="headlamp-home-clusters"
-        />
-      </SectionBox>
-    </PageGrid>
+              {
+                label: t('Status'),
+                getValue: cluster => cluster.name,
+                render: ({ name }) => <ClusterStatus error={errors[name]} />,
+              },
+              {
+                label: t('Warnings'),
+                getValue: ({ name }) => warningLabels[name],
+              },
+              {
+                label: t('glossary|Kubernetes Version'),
+                getValue: ({ name }) => versions[name]?.gitVersion || '⋯',
+              },
+              {
+                label: '',
+                getValue: () => '',
+                cellProps: {
+                  align: 'right',
+                },
+                render: cluster => <ContextMenu cluster={cluster} />,
+              },
+            ]}
+            data={Object.values(customNameClusters)}
+            id="headlamp-home-clusters"
+          />
+        </SectionBox>
+      </PageGrid>
+    ),
+    [customNameClusters, errors, versions, warningLabels]
   );
+
+  return memoizedComponent;
 }

--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -6,6 +6,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
+import { isEqual } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -176,10 +177,7 @@ interface HomeComponentProps {
 
 function HomeComponent(props: HomeComponentProps) {
   const { clusters } = props;
-  const customNameClusters = Object.values(clusters).map(c => ({
-    ...c,
-    name: c.meta_data?.extensions?.headlamp_info?.customName || c.name,
-  }));
+  const [customNameClusters, setCustomNameClusters] = React.useState(getClusterNames());
   const { t } = useTranslation(['translation', 'glossary']);
   const [versions, errors] = useClustersVersion(Object.values(clusters));
   const maxWarnings = 50;
@@ -198,6 +196,24 @@ function HomeComponent(props: HomeComponentProps) {
     }
     return numWarnings;
   }
+
+  function getClusterNames() {
+    return Object.values(clusters)
+      .map(c => ({
+        ...c,
+        name: c.meta_data?.extensions?.headlamp_info?.customName || c.name,
+      }))
+      .sort();
+  }
+
+  React.useEffect(() => {
+    setCustomNameClusters(currentNames => {
+      if (isEqual(currentNames, getClusterNames())) {
+        return currentNames;
+      }
+      return getClusterNames();
+    });
+  }, [customNameClusters]);
 
   return (
     <PageGrid>

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import _ from 'lodash';
+import React, { useMemo } from 'react';
 import { ResourceClasses } from '.';
 import { ApiError, QueryParameters } from './apiProxy';
 import { request } from './apiProxy';
@@ -238,7 +239,19 @@ class Event extends KubeObject<KubeEvent> {
       options?.queryParams ?? {}
     );
 
-    return this.useListForClusters(clusters, { queryParams: queryParameters });
+    const newWarningsList = this.useListForClusters(clusters, { queryParams: queryParameters });
+    const [warningList, setWarningList] = React.useState<typeof newWarningsList>(newWarningsList);
+
+    // Only update the warnings if they actually differ
+    React.useEffect(() => {
+      if (_.isEqual(warningList, newWarningsList)) {
+        return;
+      }
+
+      setWarningList(newWarningsList);
+    }, [newWarningsList]);
+
+    return warningList;
   }
 }
 


### PR DESCRIPTION
This PR fixes the useWarningsList and useClustersVersion so they do not update whenever there's new data from the server but instead when the data differs from what we returned the last time. (Same goal as #2514)

how to test
- [ ] You can either use dev tools or add a console.log into the HomePure component to see how often it is rendered. With this change it should only rerender when something changes.
- [x] stop a cluster, and start a cluster... the home page should update to show the correct cluster active status