### PR TITLE
app: container: Bump static plugin versions

### DIFF
--- a/app/app-build-manifest.json
+++ b/app/app-build-manifest.json
@@ -3,15 +3,15 @@
   "plugins": [
     {
       "name": "app-catalog",
-      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/app-catalog-0.3.0/app-catalog-0.3.0.tar.gz"
+      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/app-catalog-0.3.1/app-catalog-0.3.1.tar.gz"
     },
     {
       "name": "plugin-catalog",
-      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/plugin-catalog-0.1.0/headlamp-k8s-plugin-catalog-0.1.0.tar.gz"
+      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/plugin-catalog-0.1.1/headlamp-k8s-plugin-catalog-0.1.1.tar.gz"
     },
     {
       "name": "prometheus",
-      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/prometheus-0.2.0/prometheus-0.2.0.tar.gz"
+      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/prometheus-0.2.2/prometheus-0.2.2.tar.gz"
     }
   ]
 }

--- a/container/build-manifest.json
+++ b/container/build-manifest.json
@@ -2,7 +2,7 @@
   "plugins": [
     {
       "name": "prometheus",
-      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/prometheus-0.2.0/prometheus-0.2.0.tar.gz"
+      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/prometheus-0.2.2/prometheus-0.2.2.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
These plugins were updated:

- [app-catalog 0.3.1](https://github.com/headlamp-k8s/plugins/releases/tag/app-catalog-0.3.1)
- [prometheus 0.2.2](https://github.com/headlamp-k8s/plugins/releases/tag/prometheus-0.2.2)
- [plugin-catalog 0.1.1](https://github.com/headlamp-k8s/plugins/releases/tag/plugin-catalog-0.1.1)



