### PR TITLE
frontend: Home: Add label for actions menu

### DIFF
--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -5,6 +5,7 @@ import IconButton from '@mui/material/IconButton';
 import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,17 +53,19 @@ function ContextMenu({ cluster }: { cluster: Cluster }) {
 
   return (
     <>
-      <IconButton
-        size="small"
-        onClick={event => {
-          setAnchorEl(event.currentTarget);
-        }}
-        aria-haspopup="menu"
-        aria-controls={menuId}
-        aria-label={t('Actions')}
-      >
-        <Icon icon="mdi:more-vert" />
-      </IconButton>
+      <Tooltip title={t('Actions')}>
+        <IconButton
+          size="small"
+          onClick={event => {
+            setAnchorEl(event.currentTarget);
+          }}
+          aria-haspopup="menu"
+          aria-controls={menuId}
+          aria-label={t('Actions')}
+        >
+          <Icon icon="mdi:more-vert" />
+        </IconButton>
+      </Tooltip>
       <Menu
         id={menuId}
         anchorEl={anchorEl}


### PR DESCRIPTION
This change adds a label for the actions menu for each cluster on the home page, where there previous was no label.

Fixes: #2526

### Testing
- [X] Open Headlamp with 2+ clusters (not in-cluster)
- [X] Hover over the actions menu for a cluster and ensure that it has a label titled 'Actions'