### PR TITLE
frontend: Job: Add sort function for job durations

### DIFF
--- a/frontend/src/components/job/List.tsx
+++ b/frontend/src/components/job/List.tsx
@@ -111,14 +111,13 @@ export function JobsListRenderer(props: JobsListRendererProps) {
           id: 'duration',
           label: t('translation|Duration'),
           getValue: job => {
-            const startTime = job.status?.startTime;
-            const completionTime = job.status?.completionTime;
-            if (!!startTime && !!completionTime) {
-              const duration = new Date(completionTime).getTime() - new Date(startTime).getTime();
+            const duration = job.getDuration();
+            if (duration > 0) {
               return formatDuration(duration, { format: 'mini' });
             }
             return '-';
           },
+          sort: (job1, job2) => job1.getDuration() - job2.getDuration(),
           gridTemplate: 0.6,
         },
         {


### PR DESCRIPTION
This change adds a sort function for job duration times. Previously, sorting by duration would show the list of jobs out of order, but this should no longer be the case.

Fixes: #2564 

### Testing
- [X] Open Headlamp with multiple jobs of varying durations
- [X] Sort by duration and ensure that the jobs are properly sorted

![image](https://github.com/user-attachments/assets/2e0daaad-78c1-47c2-92b4-c659b5f5b8ea)
