### PR TITLE
headlamp-plugin: Use npm ci to pin deps

### DIFF
--- a/plugins/headlamp-plugin/install-dependencies.sh
+++ b/plugins/headlamp-plugin/install-dependencies.sh
@@ -6,7 +6,7 @@ set -o xtrace
 for i in * ; do
   if [ -d "$i" ]; then
     cd "$i"
-    npm install
+    npm ci
     cd ..
   fi
 done

--- a/plugins/headlamp-plugin/test-plugins-examples.sh
+++ b/plugins/headlamp-plugin/test-plugins-examples.sh
@@ -13,7 +13,7 @@ for i in * ; do
   if [ -d "$i" ]; then
     cd "$i"
     # Test changes to headlamp-plugin in the PR/repo that released version might not have.
-    npm install `ls -t ../../headlamp-plugin/kinvolk-headlamp-plugin-*.tgz | head -1`
+    npm ci `ls -t ../../headlamp-plugin/kinvolk-headlamp-plugin-*.tgz | head -1`
     npm run lint
     npm run format
     npm run build


### PR DESCRIPTION
This change addresses a security issue where dependencies are not pinned. 

Fixes: #2084