### PR TITLE
backend: Fix reloading of clusters in kubeconfig

### DIFF
--- a/backend/pkg/kubeconfig/file_test.go
+++ b/backend/pkg/kubeconfig/file_test.go
@@ -10,6 +10,26 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const clusterConf = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: dGVzdA==
+    server: https://kubernetes.docker.internal:6443
+  name: random-cluster-4
+contexts:
+- context:
+    cluster: random-cluster-4
+    user: random-cluster-4
+  name: random-cluster-4
+current-context: random-cluster-4
+kind: Config
+preferences: {}
+users:
+- name: random-cluster-4
+  user:
+  client-certificate-data: dGVzdA==
+  client-key-data: dGVzdA==`
+
 func TestWriteToFile(t *testing.T) {
 	// create kubeconfig3 file that doesn't exist
 	conf, err := clientcmd.Load([]byte(clusterConf))


### PR DESCRIPTION
When a context was being added and removed from KUBECONFIG file, it was still visible in UI. This removes the cluster from store and returns correct list of clusters.

Fixes #2541