### PR TITLE
frontend: plugin: Sync plugin version with backend

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -221,7 +221,10 @@ export function updateSettingsPackages(
         isEnabled: true,
       };
     }
-    return settingsPlugins[index];
+    return {
+      ...settingsPlugins[index],
+      ...plugin,
+    };
   });
 }
 


### PR DESCRIPTION
This change allows the frontend to update plugin fields from the backend, avoiding the case where a plugin is updated but the version number does not reflect this.

Fixes: #2535 

### Testing
#### Using the prometheus plugin as an example:
- [X] Open Headlamp and navigate to the plugin settings. Ensure the latest prometheus plugin version is installed (currently 0.2.2)
- [X] Downgrade the prometheus plugin version by changing the version in `package.json` to 0.0.1 and run `rm -rf node_modules package-lock.json dist` in the prometheus folder
- [X] Install the prometheus plugin at this downgraded version: `npm install prometheus@0.0.1`
- [X] Refresh the page and ensure that the prometheus plugin version now reads as `0.0.1` without being disabled