### PR TITLE
charts: Fix storageClassName in pvc

### DIFF
--- a/charts/headlamp/templates/pvc.yaml
+++ b/charts/headlamp/templates/pvc.yaml
@@ -21,7 +21,7 @@ spec:
   {{- with .Values.persistentVolumeClaim.volumeMode }}
   volumeMode: {{ . }}
   {{- end }}
-  {{- with .Values.persistentVolumeClaim.storageClass }}
+  {{- with .Values.persistentVolumeClaim.storageClassName }}
   storageClassName: {{ . }}
   {{- end }}
   {{- with .Values.persistentVolumeClaim.selector }}


### PR DESCRIPTION
This fixes binding of storage class to pvc.

Fixes: #2579

### Testing

Done on AKS cluster. Works now

<img width="1792" alt="Screenshot 2024-11-18 at 8 59 52 AM" src="https://github.com/user-attachments/assets/6198899d-fdd9-4baf-a27b-6d0ae229bcf9">
