### PR TITLE
headlamp-plugin: Run npm install in update deps script

### DIFF
--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prepack": "(node -e \"if (! require('fs').existsSync('./lib/components')) {process.exit(1)} \" || (echo 'lib dir is empty. Remember to run `npm run build` before packing' && exit 1))",
     "build": "npx shx rm -rf lib types lib/assets lib/components lib/helpers lib/i18n lib/lib lib/plugin lib/redux lib/resources && npx shx cp -r ../../frontend/src/assets ../../frontend/src/components ../../frontend/src/helpers ../../frontend/src/stateless ../../frontend/src/i18n ../../frontend/src/lib ../../frontend/src/plugin ../../frontend/src/redux ../../frontend/src/resources src/ && tsc --build ./tsconfig.json && npx shx cp -r src/additional.d.ts lib/ && npx shx cp -r ../../frontend/src/assets lib/ && npx shx cp -r ../../frontend/src/resources lib/ && npx shx cp -r ../../frontend/src/i18n/locales lib/i18n",
-    "update-dependencies": "node dependencies-sync.js update",
+    "update-dependencies": "node dependencies-sync.js update && npm install",
     "check-dependencies": "node dependencies-sync.js check",
     "postinstall": "patch-package"
   },


### PR DESCRIPTION
This change adds npm install to the update-dependencies script in headlamp-plugin to update the package-lock.json file to avoid having to do this manually.

Fixes: #2469

### Testing

- [X] Run  `cd ~/headlamp/plugins/headlamp-plugin && npm run update-dependencies`