### PR TITLE
frontend GraphView: Fix duplicate edges on the map and add unit test

### DIFF
--- a/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
@@ -1,7 +1,7 @@
 import { KubeMetadata } from '../../../lib/k8s/KubeMetadata';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { groupGraph } from './graphGrouping';
-import { GraphEdge, KubeObjectNode } from './graphModel';
+import { GraphEdge, GroupNode, KubeObjectNode } from './graphModel';
 
 describe('groupGraph', () => {
   const nodes: KubeObjectNode[] = [
@@ -92,9 +92,11 @@ describe('groupGraph', () => {
       {}
     );
     const instances = groupedGraph.data.nodes.map(node => node.id);
+    const edgeIds = (groupedGraph.data.nodes[0] as GroupNode).data.edges.map(edge => edge.id);
 
     // Nodes 2 and 4 are connected by the egde and so are grouped together
     // group-2 takes has 2 in it because it's the ID of the first node
     expect(instances).toEqual(['group-2', '1', '3']);
+    expect(edgeIds).toEqual(['e2']);
   });
 });

--- a/frontend/src/components/resourceMap/graph/graphGrouping.tsx
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.tsx
@@ -70,7 +70,6 @@ const getConnectedComponents = (nodes: KubeObjectNode[], edges: GraphEdge[]): Gr
 
       const targetNode = graphLookup.getNode(edge.target);
       if (targetNode) {
-        componentEdges.push(edge);
         findConnectedComponent(targetNode, componentNodes, componentEdges);
       }
     });
@@ -85,7 +84,6 @@ const getConnectedComponents = (nodes: KubeObjectNode[], edges: GraphEdge[]): Gr
 
       const sourceNode = graphLookup.getNode(edge.source);
       if (sourceNode) {
-        componentEdges.push(edge);
         findConnectedComponent(sourceNode, componentNodes, componentEdges);
       }
     });


### PR DESCRIPTION
This is a regression caused by some previous optimizations. Added a unit test that would fail without this fix