### PR TITLE
OLD - frontend: PluginSettings: Rework plugin settings local storage usage

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.stories.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react';
+import { PluginInfo } from '../../../plugin/pluginsSlice';
 import { TestContext } from '../../../test';
 import { PluginSettingsPure, PluginSettingsPureProps } from './PluginSettings';
 
@@ -41,6 +42,18 @@ function createDemoData(arrSize: number, useHomepage?: boolean) {
 }
 
 /**
+ * createDemoEnabledList function will create a list of plugin objects with a boolean value to enable/disable the plugin.
+ * The function will return an object of plugin names with a boolean value.
+ */
+function createDemoEnabledList(arr: PluginInfo[]): Record<string, boolean> {
+  const enabledList = arr.reduce((acc, p) => {
+    acc[p.name] = !!p.isEnabled;
+    return acc;
+  }, {} as Record<string, boolean>);
+  return enabledList;
+}
+
+/**
  * Creation of data arrays ranging from 0 to 50 to demo state of empty, few, many, and large numbers of data objects.
  * NOTE: The numbers used are up to the users preference.
  */
@@ -55,6 +68,7 @@ const demoEmpty = createDemoData(0);
 export const FewItems = Template.bind({});
 FewItems.args = {
   plugins: demoFew,
+  pluginsEnabledMap: createDemoEnabledList(demoFew),
   onSave: plugins => {
     console.log('demo few', plugins);
   },
@@ -63,12 +77,14 @@ FewItems.args = {
 export const Empty = Template.bind({});
 Empty.args = {
   plugins: demoEmpty,
+  pluginsEnabledMap: createDemoEnabledList(demoEmpty),
 };
 
 /** NOTE: The save button will load by default on plugin page regardless of data */
 export const DefaultSaveEnable = Template.bind({});
 DefaultSaveEnable.args = {
   plugins: demoFewSaveEnable,
+  pluginsEnabledMap: createDemoEnabledList(demoFewSaveEnable),
   onSave: plugins => {
     console.log('demo few', plugins);
   },
@@ -78,6 +94,7 @@ DefaultSaveEnable.args = {
 export const ManyItems = Template.bind({});
 ManyItems.args = {
   plugins: demoMany,
+  pluginsEnabledMap: createDemoEnabledList(demoMany),
   onSave: plugins => {
     console.log('demo many', plugins);
   },
@@ -86,6 +103,7 @@ ManyItems.args = {
 export const MoreItems = Template.bind({});
 MoreItems.args = {
   plugins: demoMore,
+  pluginsEnabledMap: createDemoEnabledList(demoMore),
   onSave: plugins => {
     console.log('demo more', plugins);
   },
@@ -94,6 +112,7 @@ MoreItems.args = {
 export const EmptyHomepageItems = Template.bind({});
 EmptyHomepageItems.args = {
   plugins: demoHomepageEmpty,
+  pluginsEnabledMap: createDemoEnabledList(demoHomepageEmpty),
   onSave: (plugins: any) => {
     console.log('Empty Homepage', plugins);
   },

--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
@@ -54,7 +54,7 @@ const PluginSettingsDetailsInitializer = (props: { plugin: PluginInfo }) => {
 };
 
 export default function PluginSettingsDetails() {
-  const pluginSettings = useTypedSelector(state => state.plugins.pluginSettings);
+  const pluginSettings = useTypedSelector(state => state.plugins.pluginData);
   const { name } = useParams<{ name: string }>();
 
   const plugin = useMemo(() => {

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -579,19 +579,5 @@
         </div>
       </div>
     </div>
-    <div
-      class="MuiBox-root css-ova7y8"
-    >
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-wlshgd-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
-      >
-        Save & Apply
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
-    </div>
   </div>
 </body>

--- a/frontend/src/plugin/Plugins.tsx
+++ b/frontend/src/plugin/Plugins.tsx
@@ -8,7 +8,7 @@ import helpers from '../helpers';
 import { UI_INITIALIZE_PLUGIN_VIEWS } from '../redux/actions/actions';
 import { useTypedSelector } from '../redux/reducers/reducers';
 import { fetchAndExecutePlugins } from './index';
-import { pluginsLoaded, setPluginSettings } from './pluginsSlice';
+import { pluginsLoaded, setPluginData } from './pluginsSlice';
 
 /**
  * For discovering and executing plugins.
@@ -26,7 +26,8 @@ export default function Plugins() {
   const history = useHistory();
   const { t } = useTranslation();
 
-  const settingsPlugins = useTypedSelector(state => state.plugins.pluginSettings);
+  const settingsPlugins = useTypedSelector(state => state.plugins.pluginData);
+  const enabledPlugins = useTypedSelector(state => state.plugins.enabledPlugins);
 
   // only run on first load
   useEffect(() => {
@@ -34,8 +35,9 @@ export default function Plugins() {
 
     fetchAndExecutePlugins(
       settingsPlugins,
+      enabledPlugins,
       updatedSettingsPackages => {
-        dispatch(setPluginSettings(updatedSettingsPackages));
+        dispatch(setPluginData(updatedSettingsPackages));
       },
       incompatiblePlugins => {
         const pluginList = Object.values(incompatiblePlugins)

--- a/frontend/src/plugin/filterSources.test.ts
+++ b/frontend/src/plugin/filterSources.test.ts
@@ -5,15 +5,15 @@ describe('filterSources', () => {
   test('when sources is empty, it also returns an empty array', () => {
     const sources: string[] = [];
     const packageInfos: PluginInfo[] = [];
-    const settingsPackages = undefined;
+    const enabledPlugins: Record<string, boolean> = {};
     const appMode = false;
 
     const { sourcesToExecute } = filterSources(
       sources,
       packageInfos,
+      enabledPlugins,
       appMode,
-      '>=0.8.0-alpha.3',
-      settingsPackages
+      '>=0.8.0-alpha.3'
     );
     expect(sourcesToExecute.length).toBe(0);
   });
@@ -32,15 +32,15 @@ describe('filterSources', () => {
         },
       },
     ];
-    const settingsPackages = undefined;
+    const enabledPlugins: Record<string, boolean> = {};
     const appMode = false;
 
     const { sourcesToExecute, incompatiblePlugins } = filterSources(
       sources,
       packageInfos,
+      enabledPlugins,
       appMode,
-      '>=0.8.0-alpha.3',
-      settingsPackages
+      '>=0.8.0-alpha.3'
     );
     expect(Object.keys(incompatiblePlugins).length).toBe(0);
     expect(sourcesToExecute[0]).toBe('source1');
@@ -67,10 +67,14 @@ describe('filterSources', () => {
         isEnabled: false,
       },
     ];
+    const enabledPlugins: Record<string, boolean> = {
+      ourplugin1: false,
+    };
     const appMode = true;
     const { sourcesToExecute } = filterSources(
       sources,
       packageInfos,
+      enabledPlugins,
       appMode,
       '>=0.8.0-alpha.3',
       settingsPackages
@@ -121,10 +125,15 @@ describe('filterSources', () => {
         isEnabled: false,
       },
     ];
+    const enabledPlugins: Record<string, boolean> = {
+      ourplugin1: true,
+      ourplugin2: false,
+    };
     const appMode = true;
     const { sourcesToExecute } = filterSources(
       sources,
       packageInfos,
+      enabledPlugins,
       appMode,
       '>=0.8.0-alpha.3',
       settingsPackages
@@ -176,10 +185,15 @@ describe('filterSources', () => {
         isEnabled: true,
       },
     ];
+    const enabledPlugins: Record<string, boolean> = {
+      ourplugin1: true,
+      ourplugin2: true,
+    };
     const appMode = true;
     const { sourcesToExecute, incompatiblePlugins } = filterSources(
       sources,
       packageInfos,
+      enabledPlugins,
       appMode,
       '>=0.8.0-alpha.3',
       settingsPackages
@@ -193,6 +207,7 @@ describe('filterSources', () => {
     const disabledCompatCheck = filterSources(
       sources,
       packageInfos,
+      enabledPlugins,
       appMode,
       '', // empty string disables compatibility check
       settingsPackages

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -137,6 +137,7 @@ export async function initializePlugins() {
 export function filterSources(
   sources: string[],
   packageInfos: PluginInfo[],
+  enabledPlugins: Record<string, boolean>,
   appMode: boolean,
   compatibleVersion: string,
   settingsPackages?: PluginInfo[]
@@ -161,9 +162,8 @@ export function filterSources(
 
     // settingsPackages might have a different order or length than packageInfos
     // If it's not in the settings don't enable the plugin.
-    const enabledInSettings =
-      settingsPackages[settingsPackages.findIndex(x => x.name === packageInfo.name)]?.isEnabled ===
-      true;
+
+    const enabledInSettings = enabledPlugins[packageInfo.name];
     return enabledInSettings;
   });
 
@@ -242,6 +242,7 @@ export function updateSettingsPackages(
  */
 export async function fetchAndExecutePlugins(
   settingsPackages: PluginInfo[],
+  enabledPlugins: Record<string, boolean>,
   onSettingsChange: (plugins: PluginInfo[]) => void,
   onIncompatible: (plugins: Record<string, PluginInfo>) => void
 ) {
@@ -298,6 +299,7 @@ export async function fetchAndExecutePlugins(
   const { sourcesToExecute, incompatiblePlugins } = filterSources(
     sources,
     packageInfos,
+    enabledPlugins,
     helpers.isElectron(),
     compatibleHeadlampPluginVersion,
     updatedSettingsPackages

--- a/frontend/src/plugin/pluginSlice.test.tsx
+++ b/frontend/src/plugin/pluginSlice.test.tsx
@@ -11,7 +11,8 @@ const initialState: PluginsState = {
   /** Once the plugins have been fetched and executed. */
   loaded: false,
   /** If plugin settings are saved use those. */
-  pluginSettings: JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]'),
+  enabledPlugins: JSON.parse(localStorage.getItem('headlampPluginSettings') || '{}'),
+  pluginData: [],
 };
 
 // Mock React component for testing
@@ -24,7 +25,7 @@ describe('pluginsSlice reducers', () => {
     const existingPluginName = 'test-plugin';
     const initialStateWithPlugin: PluginsState = {
       ...initialState,
-      pluginSettings: [
+      pluginData: [
         {
           name: existingPluginName,
           settingsComponent: undefined,
@@ -41,15 +42,15 @@ describe('pluginsSlice reducers', () => {
 
     const newState = pluginsSlice.reducer(initialStateWithPlugin, action);
 
-    expect(newState.pluginSettings[0].settingsComponent).toBeDefined();
-    expect(newState.pluginSettings[0].displaySettingsComponentWithSaveButton).toBe(true);
+    expect(newState.pluginData[0].settingsComponent).toBeDefined();
+    expect(newState.pluginData[0].displaySettingsComponentWithSaveButton).toBe(true);
   });
 
   test('should not modify state when plugin name does not match any existing plugin', () => {
     const nonExistingPluginName = 'non-existing-plugin';
     const initialStateWithPlugin: PluginsState = {
       ...initialState,
-      pluginSettings: [
+      pluginData: [
         {
           name: 'existing-plugin',
           settingsComponent: undefined,

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -90,14 +90,17 @@ export type PluginInfo = {
 export interface PluginsState {
   /** Have plugins finished executing? */
   loaded: boolean;
+  /** Map where key is plugin's name and value is whether it is enabled */
+  enabledPlugins: Record<string, boolean>;
   /** Information stored by settings about plugins. */
-  pluginSettings: PluginInfo[];
+  pluginData: PluginInfo[];
 }
 const initialState: PluginsState = {
   /** Once the plugins have been fetched and executed. */
   loaded: false,
   /** If plugin settings are saved use those. */
-  pluginSettings: JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]'),
+  enabledPlugins: JSON.parse(localStorage.getItem('enabledPluginsList') || '[]'),
+  pluginData: [],
 };
 
 export const pluginsSlice = createSlice({
@@ -107,12 +110,16 @@ export const pluginsSlice = createSlice({
     pluginsLoaded(state) {
       state.loaded = true;
     },
-    /**
-     * Save the plugin settings. To both the store, and localStorage.
-     */
-    setPluginSettings(state, action: PayloadAction<PluginInfo[]>) {
-      state.pluginSettings = action.payload;
-      localStorage.setItem('headlampPluginSettings', JSON.stringify(action.payload));
+
+    /** Updates the local storage for plugin enable settings */
+    setEnablePlugin(state, action: PayloadAction<Record<string, boolean>>) {
+      state.enabledPlugins = action.payload;
+      localStorage.setItem('enabledPluginsList', JSON.stringify(action.payload));
+    },
+
+    /** Sets the plugin data */
+    setPluginData(state, action: PayloadAction<PluginInfo[]>) {
+      state.pluginData = action.payload;
     },
     /** Reloads the browser page */
     reloadPage() {
@@ -130,7 +137,7 @@ export const pluginsSlice = createSlice({
       }>
     ) {
       const { name, component, displaySaveButton } = action.payload;
-      state.pluginSettings = state.pluginSettings.map(plugin => {
+      state.pluginData = state.pluginData.map(plugin => {
         if (plugin.name === name) {
           return {
             ...plugin,
@@ -144,7 +151,12 @@ export const pluginsSlice = createSlice({
   },
 });
 
-export const { pluginsLoaded, setPluginSettings, setPluginSettingsComponent, reloadPage } =
-  pluginsSlice.actions;
+export const {
+  pluginsLoaded,
+  setEnablePlugin,
+  setPluginData,
+  setPluginSettingsComponent,
+  reloadPage,
+} = pluginsSlice.actions;
 
 export default pluginsSlice.reducer;


### PR DESCRIPTION
## Description

resolves issue #2595

This PR refactors the way Headlamp handles plugin settings stored in local storage, focusing on simplifying and improving the management of plugin states. Previously, the project stored the entire JSON data of plugin information in `headlampPluginSettings`, which included unnecessary details. This refactor reduces complexity by saving only the essential state information, improving performance and maintainability.

### Key Changes

1. **Simplified Storage**:
   - Replaced the old `headlampPluginSettings` structure with `enabledPluginsList` in local storage.
   - The new structure saves only the plugin name and its `on/off` state, eliminating the need to store complete JSON data.

2. **State Management Updates**:
   - Introduced the `pluginData` slice in the plugin state to store plugin information.
   - Added `enabledPlugins` to maintain a list of plugins currently in use.

3. **Backward Compatibility**:
   - The project now detects the existence of the old `headlampPluginSettings` in local storage.
   - If detected, it converts and migrates the old settings into the new `enabledPluginsList` format automatically upon visiting the plugin settings page.

---

## Steps to Test

To verify the changes and ensure backward compatibility:

1. **Setup**:
   - Start on the `main` branch with multiple plugins installed.
   - Disable one plugin while keeping others enabled, and save the settings.
   - Open the browser’s local storage and confirm that the disabled plugin’s state is saved in the `headlampPluginSettings` JSON.

2. **Switch to this Branch**:
   - Checkout this branch and navigate to the plugin settings page.

3. **Observe Migration**:
   - Confirm that the page detects the `headlampPluginSettings` in local storage, migrates the settings into a new `enabledPluginsList` object, deletes the old `headlampPluginSettings`, and reloads the page.
   - Verify that the plugin states from the previous settings are preserved in the new format.

4. **Post-Migration**:
   - Ensure that plugin settings updates are correctly saved in the new `enabledPluginsList` structure.
   - Confirm that enabling/disabling plugins reflects accurately on subsequent reloads.

---

## Notes

- It improves the performance and clarity of plugin state management by reducing storage overhead.
- The migration process ensures a seamless transition for users upgrading from previous versions.
