### PR TITLE
frontend: TopBar: Hide menu on mobile when empty

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -399,6 +399,12 @@ export const PureTopBar = memo(
         ),
       },
     ];
+
+    const visibleMobileActions = processAppBarActions(
+      allAppBarActionsMobile,
+      appBarActionsProcessors
+    ).filter(action => React.isValidElement(action.action) || typeof action === 'function');
+
     return (
       <>
         <AppBar
@@ -429,16 +435,18 @@ export const PureTopBar = memo(
                 <HeadlampButton open={openSideBar} onToggleOpen={onToggleOpen} />
                 <Box sx={{ flexGrow: 1 }} />
                 <GlobalSearch isIconButton />
-                <IconButton
-                  aria-label={t('show more')}
-                  aria-controls={mobileMenuId}
-                  aria-haspopup="true"
-                  onClick={handleMobileMenuOpen}
-                  color="inherit"
-                  size="medium"
-                >
-                  <Icon icon="mdi:more-vert" />
-                </IconButton>
+                {visibleMobileActions.length > 0 && (
+                  <IconButton
+                    aria-label={t('show more')}
+                    aria-controls={mobileMenuId}
+                    aria-haspopup="true"
+                    onClick={handleMobileMenuOpen}
+                    color="inherit"
+                    size="medium"
+                  >
+                    <Icon icon="mdi:more-vert" />
+                  </IconButton>
+                )}
               </>
             ) : (
               <>


### PR DESCRIPTION
This change hides the top bar menu on mobile when there are no actions to display.

Fixes: #2066

### Testing
- [X] Open Headlamp in the mobile view
- [X] Ensure that the top bar menu shows up only when there are available actions

![image](https://github.com/user-attachments/assets/3db7bb94-c9c8-4ac5-9a13-0c4e17f7a3f0)