### PR TITLE
frontend: AuthVisible: Validate verb before auth check

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -3,6 +3,18 @@ import React, { useEffect } from 'react';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
 
+/** List of valid request verbs. See https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb. */
+const VALID_AUTH_VERBS = [
+  'create',
+  'get',
+  'list',
+  'watch',
+  'update',
+  'patch',
+  'delete',
+  'deletecollection',
+];
+
 export interface AuthVisibleProps extends React.PropsWithChildren<{}> {
   /** The item for which auth will be checked or a resource class (e.g. Job). */
   item: KubeObject | KubeObjectClass | null;
@@ -27,6 +39,12 @@ export interface AuthVisibleProps extends React.PropsWithChildren<{}> {
  */
 export default function AuthVisible(props: AuthVisibleProps) {
   const { item, authVerb, subresource, namespace, onError, onAuthResult, children } = props;
+
+  if (!VALID_AUTH_VERBS.includes(authVerb)) {
+    console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
+    return null;
+  }
+
   const { data } = useQuery<any>({
     enabled: !!item,
     queryKey: ['authVisible', item, authVerb, subresource, namespace],


### PR DESCRIPTION
This change validates the authVerb passed into the AuthVisible component before calling `getAuthorization()`, which prevents components from rendering with an invalid verb.

Fixes: #2147 

### Testing
- [X] Open a cluster in Headlamp and navigate to the Namespaces page
- [X] Open `frontend/src/components/namespace/CreateNamespaceButton.tsx` and set the authVerb to something random (e.g. '1234')
- [X] Reload the page and ensure that the create button does not show up
- [X] Ensure that you see the following warning in the console:

![image](https://github.com/user-attachments/assets/758e8792-3d14-4659-8865-b8b22ba50e11)