### PR TITLE
plugins: Fix vitest placeholder type

### DIFF
--- a/plugins/headlamp-plugin/vite-types.d.ts
+++ b/plugins/headlamp-plugin/vite-types.d.ts
@@ -7,9 +7,7 @@ declare module '*.svg?react' {
   export default content;
 }
 
-declare global {
-  const vi: any;
-}
+declare const vi: any;
 
 interface ImportMeta {
   env: any;


### PR DESCRIPTION
This fixes CI fail when typechecking headlamp-plugin