### PR TITLE
frontend: ClusterChooserPopUp: Fix dark mode visibility

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -291,17 +291,20 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
       {helpers.isElectron() && (
         <>
           <Button
-            sx={{
+            sx={theme => ({
               backgroundColor: theme.palette.sidebarBg,
-              color: theme.palette.primary.contrastText,
+              color:
+                theme.palette.mode === 'dark'
+                  ? theme.palette.text.primary
+                  : theme.palette.primary.contrastText,
               '&:hover': {
-                color: theme.palette.text.primary,
+                color: theme.palette.text.secondary,
               },
               width: '100%',
               borderTopLeftRadius: 0,
               borderTopRightRadius: 0,
               textTransform: 'none',
-            }}
+            })}
             onClick={() => history.push(createRouteURL('loadKubeConfig'))}
           >
             {t('translation|Add Cluster')}


### PR DESCRIPTION
This change fixes a visibility issue with the 'Add Cluster' button in the cluster chooser pop up.

Fixes: #2601 

### Testing
- [X] Open Headlamp in dark mode and go into a cluster
- [X] Open the cluster chooser pop up and ensure that the 'Add Cluster' button is visible

![image](https://github.com/user-attachments/assets/380071a7-1015-44f9-ad32-dad1a7cc9455)