### PR TITLE
frontend: Add missing isNamespaced property to Custom Resource class

### DIFF
--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -168,6 +168,7 @@ export function makeCustomResourceClass(
     static apiVersion = apiInfoArgs.map(([group, version]) =>
       group ? `${group}/${version}` : version
     );
+    static isNamespaced = objArgs.isNamespaced;
     static apiEndpoint = apiFunc(...apiInfoArgs);
   };
 }


### PR DESCRIPTION
Fixes a regression introduced in #1967 where namespaced scope was left out when creating Custom Resource class.

Fixes #2613