### PR TITLE
readme: Update header image and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# Headlamp <img align="right" width=384 src="docs/headlamp_light.svg"> [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7551/badge)](https://www.bestpractices.dev/projects/7551) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/headlamp-k8s/headlamp/badge)](https://scorecard.dev/viewer/?uri=github.com/headlamp-k8s/headlamp)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fheadlamp-k8s%2Fheadlamp.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fheadlamp-k8s%2Fheadlamp?ref=badge_shield)
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="frontend/src/resources/logo-light.svg">
+    <img src="frontend/src/resources/logo-dark.svg" alt="Headlamp">
+  </picture>
+</h1>
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7551/badge)](https://www.bestpractices.dev/projects/7551)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/headlamp-k8s/headlamp/badge)](https://scorecard.dev/viewer/?uri=github.com/headlamp-k8s/headlamp)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fheadlamp-k8s%2Fheadlamp.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fheadlamp-k8s%2Fheadlamp?ref=badge_shield)
 
 Headlamp is an easy-to-use and extensible Kubernetes web UI.
 
@@ -87,7 +94,6 @@ biggest changes planned so far, as well as a [board](https://github.com/orgs/hea
 ## License
 
 Headlamp is released under the terms of the [Apache 2.0](./LICENSE) license.
-
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/a0bde03a-45a7-43f5-800e-926611844552)

After
![image](https://github.com/user-attachments/assets/eb9301e2-3571-44e7-9cee-17b06db10047)

supports light/dark theme