### PR TITLE
charts: fix: allow env vars to be set when reading others from secrets

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
           envFrom:
           - secretRef:
               name: {{ $oidc.externalSecret.name }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           {{- else }}
           env:
             {{- if $oidc.secret.create }}


### PR DESCRIPTION
There is currently no way of setting arbitrary environment variables when reading OIDC config from secrets, this PR allows it.