### PR TITLE
backend: Disable websocket multiplexer

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1604,11 +1604,11 @@ func (c *HeadlampConfig) addClusterSetupRoute(r *mux.Router) {
 	// Delete a cluster
 	r.HandleFunc("/cluster/{name}", c.deleteCluster).Methods("DELETE")
 
+	// Websocket connections
+	// r.HandleFunc("/wsMutliplexer", c.multiplexer.HandleClientWebSocket)
+
 	// Rename a cluster
 	r.HandleFunc("/cluster/{name}", c.renameCluster).Methods("PUT")
-
-	// Websocket connections
-	r.HandleFunc("/wsMutliplexer", c.multiplexer.HandleClientWebSocket)
 }
 
 /*


### PR DESCRIPTION
This should not be enabled in a release.

I'd like this disabled now, so it isn't enabled in the next release accidentally before it's ready.

related:
- https://github.com/headlamp-k8s/headlamp/pull/2563