### PR TITLE
frontend: LogViewer: Fix log not expanding on full screen

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -129,7 +129,17 @@ export function LogViewer(props: LogViewerProps) {
   }
 
   return (
-    <Dialog title={title} withFullScreen onClose={onClose} {...other}>
+    <Dialog
+      title={title}
+      onFullScreenToggled={() => {
+        setTimeout(() => {
+          fitAddonRef.current!.fit();
+        }, 1);
+      }}
+      withFullScreen
+      onClose={onClose}
+      {...other}
+    >
       <DialogContent
         sx={theme => ({
           height: '80%',


### PR DESCRIPTION
fixes issue #2640

## Description

This PR fixes an issue with the `LogViewer` component where log lines did not expand to the full width when in full-screen mode. This issue impacts user experience, especially for users relying on the full-screen view to read long log lines.

### Key Changes

1. **Full-Width Expansion**:
   - Updated the `LogViewer` component's logic allowing render handlers to run resizes to ensure log lines expand to utilize the full width in full-screen mode.

---

## Steps to Test

1. Open the `LogViewer` component in the pods details view.
2. Switch to full-screen mode.
3. Verify:
   - Log lines expand to the full width of the screen in full-screen mode.
   - Log lines remain readable and aligned correctly in both standard and full-screen modes.

4. Test on various screen sizes to ensure responsiveness and compatibility.
