### PR TITLE
CI: disable test plugins steps

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run frontend-i18n-check
         run: |
           make frontend-i18n-check
-  
+
   build:
     name: build
     runs-on: ${{ matrix.os }}
@@ -110,6 +110,8 @@ jobs:
 
   testplugins:
     name: test plugins
+    # TODO: This is currently broken. Reenable after #2549 #2560 is fixed
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Since our CI has been broken for more than a month this PR disables the step that fails

I personally missed a couple of actual ci errors by assuming it's just 'test plugin' step that's failing 

Related #2549 #2560