### PR TITLE
frontend: PluginSettings: Fix non responsive enable toggle

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -240,6 +240,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
             },
             {
               header: t('translation|Enable'),
+              accessorFn: (plugin: PluginInfo) => plugin.isEnabled,
               Cell: ({ row: { original: plugin } }: { row: MRT_Row<PluginInfo> }) => {
                 if (!plugin.isCompatible || !helpers.isElectron()) {
                   return null;
@@ -247,15 +248,13 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                 return (
                   <EnableSwitch
                     aria-label={`Toggle ${plugin.name}`}
-                    checked={plugin.isEnabled}
+                    checked={!!plugin.isEnabled}
                     onChange={() => switchChangeHanlder(plugin)}
                     color="primary"
                     name={plugin.name}
                   />
                 );
               },
-              sort: (a: PluginInfo, b: PluginInfo) =>
-                a.isEnabled === b.isEnabled ? 0 : a.isEnabled ? -1 : 1,
             },
           ]
             // remove the enable column if we're not in app mode


### PR DESCRIPTION
## Description

fixes issue #2666 

This PR fixes a UI issue in the plugin settings page when running Headlamp in `app mode`. Previously, toggling the enable/disable switches for plugins did not visually reflect the updated state. The switches remained in their original positions until the save button was clicked and the page reloaded. This issue was limited to the UI, as the save functionality correctly updated the plugin state on reload.

### Key Changes

1. **Real-Time Switch Updates**:
   - Fixed the UI behavior to ensure that the enable/disable switches visually reflect the updated state immediately after being toggled.
   - The switches now display the correct position without requiring a page reload.

2. **Enhanced State Handling**:
   - Updated the component logic to synchronize the UI state with the underlying plugin state upon toggle.

---

## Steps to Test

1. Open Headlamp in `app mode` and navigate to the plugin settings page.
2. Ensure you have at least one plugin installed.
3. Toggle the enable/disable switch for a plugin and verify:
   - The switch visually updates to the correct position immediately after toggling.
   - The save functionality still works as expected, correctly persisting the state across reloads.

4. Reload the page and confirm that the plugin state matches the toggled positions.

