### PR TITLE
frontend: Sidebar: Filter out hidden routes

### DIFF
--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -295,13 +295,14 @@ function prepareRoutes(
   const defaultRoutes: SidebarItemProps[] = sidebars[DefaultSidebars.IN_CLUSTER];
   for (const route of defaultRoutes) {
     const routeFiltered =
-      filters.length > 0 && filters.filter(f => f(route)).length !== filters.length;
+      !route.hide && filters.length > 0 && filters.filter(f => f(route)).length !== filters.length;
     if (routeFiltered) {
       continue;
     }
 
     const newSubList = route.subList?.filter(
       subRoute =>
+        !subRoute.hide &&
         !(filters.length > 0 && filters.filter(f => f(subRoute)).length !== filters.length)
     );
     route.subList = newSubList;


### PR DESCRIPTION
This change filters out routes with the optional `hide` property from propagating in the route list.

Fixes: #2663 

### Testing
- [X] Open Headlamp via the browser and open a cluster
- [X] Navigate to the network tab and collapse the sidebar
- [X] Ensure that "Port Forwarding" is not visible in the top bar 
- [X] Click on "Network Policies" and ensure that the correct page opens

![image](https://github.com/user-attachments/assets/c2dd7dca-65ef-4c97-bf1a-6831af143023)

- [X] Now, follow the same steps in the Headlamp app but ensure "Port Forwarding" is an option and takes you to the correct page

![image](https://github.com/user-attachments/assets/ee25002b-6f79-4e25-8f70-4f744f1526a5)
