### PR TITLE
frontend: ActionsNotifier: Adjust keys for snackbars

### DIFF
--- a/frontend/src/components/common/ActionsNotifier.tsx
+++ b/frontend/src/components/common/ActionsNotifier.tsx
@@ -51,16 +51,20 @@ function PureActionsNotifier({ dispatch, clusterActions }: PureActionsNotifierPr
     }
 
     const prevKey = snackbarRefs.current[clusterAction.id];
-    const uniqueKey = clusterAction.key || clusterAction.id;
+    const uniqueKey = `${clusterAction.key || clusterAction.id}-${Date.now()}`;
 
     if (prevKey && prevKey !== uniqueKey) {
       closeSnackbar(prevKey);
     }
 
     if (clusterAction.message) {
-      // Check for completed actions
+      // Check for success or error states
       const refKey =
-        clusterAction.state === 'complete' ? `${clusterAction.id}-complete` : clusterAction.id;
+        clusterAction.state === 'complete'
+          ? `${clusterAction.id}-complete`
+          : clusterAction.state === 'error'
+          ? `${clusterAction.id}-error`
+          : clusterAction.id;
 
       if (!snackbarRefs.current[refKey]) {
         snackbarRefs.current[refKey] = uniqueKey;


### PR DESCRIPTION
This change adds a unique refKey for error states, separate from success states, and creates a unique key for every snackbar. This addresses a regression where failure notifications would not appear in the UI.

Fixes: #2655 

### Testing
- [X] Click on the "Create" button in Headlamp (either the one in the sidebar or for a resource like ConfigMap) and try to create a resource with an invalid name. Here's some sample YAML:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: configmap!
data: {}
```

- [X] Ensure that before the editor reopens with the error message, a failure notification appears in the bottom left corner

![image](https://github.com/user-attachments/assets/d09c1e6e-8804-48d8-aaa6-b73d7ca011d5)
