### PR TITLE
frontend: Fix memoization for Head cell when selecting all rows

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -369,13 +369,7 @@ export default function Table<RowItem extends Record<string, any>>({
                 isFiltered={header.column.getIsFiltered()}
                 sorting={header.column.getIsSorted()}
                 showColumnFilters={table.getState().showColumnFilters}
-                selected={
-                  table.getIsAllRowsSelected()
-                    ? 'all'
-                    : table.getIsSomeRowsSelected()
-                    ? 'some'
-                    : 'none'
-                }
+                selected={table.getSelectedRowModel().flatRows.length}
               />
             ))}
           </StyledHeadRow>
@@ -400,7 +394,7 @@ const MemoHeadCell = memo(
     header: MRT_Header<any>;
     sorting: string | false;
     isFiltered: boolean;
-    selected: any;
+    selected: number;
     showColumnFilters: boolean;
   }) => {
     return (


### PR DESCRIPTION
Fixes #2669

This bug only occurs when the table has more than one page.

Steps to reproduce

1. Go to the page with a bunch of items (>1 page)
2. Select one item
3. Then click on select all checkbox