### PR TITLE
frontend: Add CssBaseline component for improved default styles

### DIFF
--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -204,7 +204,7 @@ export default function Layout({}: LayoutProps) {
       </Link>
       <Box sx={{ display: 'flex', [theme.breakpoints.down('sm')]: { display: 'block' } }}>
         <VersionDialog />
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
         <TopBar />
         <Sidebar />
         <Main id="main" sx={{ flexGrow: 1, marginLeft: 'initial' }}>


### PR DESCRIPTION
It's a "css reset" that comes from mui library.

Makes scrollbars match the theme for example.

Before

![image](https://github.com/user-attachments/assets/b6d3da1f-10a9-493b-b7f3-afc13734d771)

After

![image](https://github.com/user-attachments/assets/d625b050-109c-4c58-8697-c9aa08ee4130)

