### PR TITLE
frontend: k8s: Sort namespaces in UI

### DIFF
--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -157,7 +157,11 @@ function NamespacesFromClusterAutocomplete(
 ) {
   const [namespacesList] = Namespace.useList();
   const namespaceNames = useMemo(
-    () => namespacesList?.map(namespace => namespace.metadata.name) ?? [],
+    () =>
+      namespacesList
+        ?.map(namespace => namespace.metadata.name)
+        .slice()
+        .sort((a, b) => a.localeCompare(b)) ?? [],
     [namespacesList]
   );
 


### PR DESCRIPTION
This change alphabetically sorts namespaces in the UI, addressing the case where namespace lists from k3d/k3s clusters are not sorted by default.

Fixes: #2656 

### Testing
- [X] Create a k3d cluster: `k3d cluster create`
- [X] Open the cluster in Headlamp and navigate to the "Namespaces" page
- [X] Ensure that all the namespaces are sorted alphabetically

![image](https://github.com/user-attachments/assets/f6574d12-e098-4ab1-bb1a-1333583427c7)


- [X] Go back to the cluster home and click on the Namespace filter dropdown menu
- [X] Ensure that all the namespaces are sorted alphabetically

![image](https://github.com/user-attachments/assets/ccc3c3e3-e346-4e1a-a96d-590f0ee5adbe)
