### PR TITLE
frontend: Fix useKubeObjectLists when deselecting namespaces

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -306,6 +306,19 @@ export function useKubeObjectList<K extends KubeObject>({
     setListsToWatch([...listsToWatch, ...listsNotYetWatched]);
   }
 
+  const listsToStopWatching = listsToWatch.filter(
+    watching =>
+      requests.find(request =>
+        watching.cluster === request?.cluster && request.namespaces && watching.namespace
+          ? request.namespaces?.includes(watching.namespace)
+          : true
+      ) === undefined
+  );
+
+  if (listsToStopWatching.length > 0) {
+    setListsToWatch(listsToWatch.filter(it => !listsToStopWatching.includes(it)));
+  }
+
   useWatchKubeObjectLists({
     lists: shouldWatch ? listsToWatch : [],
     endpoint,


### PR DESCRIPTION
Found a bug with useKubeObjectLists when selecting fewer namespaces than before

Steps to reproduce 

1. Go to Pods
2. Select at least 2 namespaces
3. Observe correct amount of websocket connections (same as amount of namespaces)
4. Deselect some namespaces 
5. More websocket connections are recreated than needed