### PR TITLE
backend: Fix cluster addition

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -120,7 +120,7 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 				key = customObj.CustomName + userID
 			}
 		} else if context.Name != clusterName {
-			contextKey = clusterName
+			// Skip contexts that don't match the requested cluster name
 			continue
 		}
 


### PR DESCRIPTION
This ensures that:

We only store contexts that actually match the requested cluster name. We don't return a context key unless we've successfully stored a context.

Tested and it works now.

Fixes: #2622