### PR TITLE
charts: Fix pvc storage requirement

### DIFF
--- a/charts/headlamp/templates/pvc.yaml
+++ b/charts/headlamp/templates/pvc.yaml
@@ -17,7 +17,7 @@ spec:
   {{- end}}
   resources:
     requests:
-      storage: {{ .Values.persistentVolumeClaim.size }}
+      storage: {{ required "A valid .Values.persistentVolumeClaim.size entry required!" .Values.persistentVolumeClaim.size }}
   {{- with .Values.persistentVolumeClaim.volumeMode }}
   volumeMode: {{ . }}
   {{- end }}


### PR DESCRIPTION
Added validation to ensure required fields are provided. This will fail chart installation if size is not specified when PVC is enabled.

### Testing

Keep the size value empty in values.yaml for persistentVolumeClaim.

```yaml
persistentVolumeClaim:
  # -- Enable Persistent Volume Claim
  enabled: true
  size: ""
```

- Run `helm template headlamp charts/headlamp` to see the error.

