### PR TITLE
frontend: Put apiVersion for individual items from list when fetching

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -73,7 +73,11 @@ export function kubeObjectListQuery<K extends KubeObject>(
           }
         ).then(it => it.json());
         list.items = list.items.map(item => {
-          const itm = new kubeObjectClass({ ...item, kind: list.kind.replace('List', '') });
+          const itm = new kubeObjectClass({
+            ...item,
+            kind: list.kind.replace('List', ''),
+            apiVersion: list.apiVersion,
+          });
           itm.cluster = cluster;
           return itm;
         });


### PR DESCRIPTION
Fixes #2719 
This adds apiVersion field for the individual items in the list.

When fetching a list apiVersion is only present on the root object but when fetching a single item apiVersion is present in the item itself, this discrepancy caused some issues.

