### PR TITLE
backend: Fix two races

### DIFF
--- a/backend/pkg/cache/cache.go
+++ b/backend/pkg/cache/cache.go
@@ -126,13 +126,13 @@ func (c *cache[T]) cleanUp() {
 	for {
 		<-ticker.C
 
+		c.lock.Lock()
 		for key, value := range c.store {
 			if !value.expiresAt.IsZero() && value.expiresAt.Before(time.Now()) {
-				c.lock.Lock()
 				delete(c.store, key)
-				c.lock.Unlock()
 			}
 		}
+		c.lock.Unlock()
 	}
 }
 


### PR DESCRIPTION
- **backend: cache: Fix race condition in cleanUp**
- **backend: multiplexer_test: Fix data race**

Fixes #2734


# How to test

Run this:
`cd backend && go test -race -v -p 1 ./...`

There should be no races detected.