### PR TITLE
frontend: Add missing base url in useWebSocket hook

### DIFF
--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -429,7 +429,7 @@ export function useWebSocket<T>({
 
     const connectWebSocket = async () => {
       try {
-        const parsedUrl = new URL(url);
+        const parsedUrl = new URL(url, BASE_WS_URL);
         cleanup = await WebSocketManager.subscribe(
           cluster,
           parsedUrl.pathname,


### PR DESCRIPTION
This fixes watching individual kubernetes objects.
 
How to fix:

1. Go to any resource details (Pods > any pod, for example)
2. Make sure there are no errors in console and websocket connection is established

Fixes: #2736 