### PR TITLE
fix the cluster info for headlamp_info to inlcude originalName

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1170,6 +1170,16 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			continue
 		}
 
+		contextSouce := context.SourceStr()
+
+		// this function handles the non dynamic clusters that need to have headlamp_info created or updated
+		if contextSouce == "kubeconfig" {
+			if err := c.handleHeadlampInfo(context); err != nil {
+				logger.Log(logger.LevelError, map[string]string{"cluster": context.Name},
+					err, "handling headlamp_info")
+			}
+		}
+
 		clusters = append(clusters, Cluster{
 			Name:     context.Name,
 			Server:   context.Cluster.Server,
@@ -1183,6 +1193,72 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 	}
 
 	return clusters
+}
+
+// handleHeadlampInfo this function handles the clusters that need to have headlamp_info created or updated.
+func (c *HeadlampConfig) handleHeadlampInfo(context *kubeconfig.Context) error {
+	// the headlamp_info is stored in the extensions of the kubeconfig context
+	headlampInfo := context.KubeContext.Extensions["headlamp_info"]
+
+	// if the headlamp_info is not present we create it and keep the original cluster name
+	// else the headlamp_info extension exists we must update it with the original name
+	if headlampInfo == nil {
+		err := c.handleMissingHeadlampInfo(context)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": context.Name},
+				err, "handle missing headlamp_info")
+
+			return err
+		}
+	} else {
+		err := c.handleUpdateHeadlampInfo(context)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": context.Name},
+				err, "handle update headlamp_info")
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// handleUpdateHeadlampInfo this function handles the clusters that need to have headlamp_info updated.
+func (c *HeadlampConfig) handleUpdateHeadlampInfo(context *kubeconfig.Context) error {
+	// the headlamp_info is stored in the extensions of the kubeconfig context
+	headlampInfo := context.KubeContext.Extensions["headlamp_info"]
+
+	existingObj, marshalErr := MarshalCustomObject(headlampInfo, context.Name)
+	if marshalErr != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": context.Name},
+			marshalErr, "unmarshal headlamp_info")
+		return marshalErr
+	}
+
+	// if original name is not present and the custom name is, update the headlamp_info with the original name.
+	if existingObj.OriginalName == "" && existingObj.CustomName != "" {
+		keepErr := c.keepOriginalClusterName(context.Name, context.SourceStr(), context, UpdateLegacy)
+		if keepErr != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": context.Name},
+				keepErr, "update original cluster name and custom name on headlamp_info")
+			return keepErr
+		}
+	}
+
+	return nil
+}
+
+// handleMissingHeadlampInfo function handles the clusters that need to have headlamp_info created.
+func (c *HeadlampConfig) handleMissingHeadlampInfo(context *kubeconfig.Context) error {
+	// if the headlamp_info is not present we create it and keep the original cluster name
+	err := c.keepOriginalClusterName(context.Name, context.SourceStr(), context, CreateNew)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": context.Name},
+			err, "keep original cluster name")
+		return err
+	}
+
+	return nil
 }
 
 // parseCustomNameClusters parses the custom name clusters from the kubeconfig.
@@ -1499,6 +1575,54 @@ func (c *HeadlampConfig) handleStatelessClusterRename(w http.ResponseWriter, r *
 	c.getConfig(w, r)
 }
 
+/*
+* nameToExtensions writes or updates the original name to the Extensions map in the kubeconfig.
+ */
+func nameToExtensions(context *kubeconfig.Context, contextName string, path string, updateMode infoUpdateMode) error {
+	// get the context with the given cluster name
+	headlampInfo := context.KubeContext.Extensions["headlamp_info"]
+
+	switch updateMode {
+	case CreateNew:
+		if headlampInfo == nil {
+			customObj := &kubeconfig.CustomObject{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "HeadlampInfo",
+					APIVersion: "v1",
+				},
+				ObjectMeta:   v1.ObjectMeta{},
+				OriginalName: contextName,
+				SourcePath:   path,
+			}
+
+			context.KubeContext.Extensions["headlamp_info"] = customObj
+
+			return nil
+		}
+	case UpdateLegacy:
+		if headlampInfo != nil {
+			existingObj, err := MarshalCustomObject(headlampInfo, contextName)
+			if err != nil {
+				logger.Log(logger.LevelError, map[string]string{"cluster": contextName},
+					err, "unmarshaling headlamp_info")
+				return err
+			}
+
+			existingObj.OriginalName = contextName
+			existingObj.SourcePath = path
+
+			context.KubeContext.Extensions["headlamp_info"] = &existingObj
+
+			return nil
+		}
+
+	default:
+		return nil
+	}
+
+	return nil
+}
+
 // customNameToExtenstions writes the custom name to the Extensions map in the kubeconfig.
 func customNameToExtenstions(config *api.Config, contextName, newClusterName, path string) error {
 	var err error
@@ -1586,6 +1710,42 @@ func (c *HeadlampConfig) getPathAndLoadKubeconfig(source, clusterName string) (s
 	}
 
 	return path, config, nil
+}
+
+// UpdateMode specifies how the headlamp_info extension should be handled.
+type infoUpdateMode int
+
+const (
+	// CreateNew creates a new headlamp_info extension if none exists.
+	CreateNew infoUpdateMode = iota
+	// UpdateLegacy updates existing headlamp_info for legacy clusters.
+	UpdateLegacy
+)
+
+/* handler to keep the original name for a cluster.*/
+func (c *HeadlampConfig) keepOriginalClusterName(
+	contextName string,
+	source string,
+	context *kubeconfig.Context,
+	updateMode infoUpdateMode,
+) error {
+	// // get path of kubeconfig from source
+	path, err := c.getKubeConfigPath(source)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": contextName},
+			err, "getting kubeconfig file")
+
+		return err
+	}
+
+	if err := nameToExtensions(context, contextName, path, updateMode); err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": contextName},
+			err, fmt.Sprintf("writing custom extension to kubeconfig %s: %v", contextName, context.Extensions["headlamp_info"]))
+
+		return err
+	}
+
+	return nil
 }
 
 // Handler for renaming a cluster.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/headlamp-k8s/headlamp/backend/pkg/cache"
@@ -23,6 +25,7 @@ import (
 	"github.com/headlamp-k8s/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -633,6 +636,8 @@ func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
 	assert.Equal(t, "OK", rr.Body.String())
 }
 
+// test for keeping the original name of a cluster
+
 func TestRenameCluster(t *testing.T) {
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
 	require.NoError(t, err)
@@ -1060,6 +1065,130 @@ func TestHandleClusterHelm(t *testing.T) {
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, tc.expectedStatus, w.Code)
+		})
+	}
+}
+
+// test for handleHeadlampInfo, currently checks for headlamp_info field and headlamp_info.originalName field.
+//
+//nolint:funlen
+func TestHandleHeadlampInfo(t *testing.T) {
+	// Define test cases
+	tests := []struct {
+		name          string
+		configFile    string
+		expectedError bool
+		validateFunc  func(*testing.T, *kubeconfig.Context)
+	}{
+		{
+			name:       "Empty headlamp_info",
+			configFile: "kubeconfig_headlampinfo",
+			validateFunc: func(t *testing.T, ctx *kubeconfig.Context) {
+				assert.NotNil(t, ctx.KubeContext.Extensions["headlamp_info"], "headlamp_info field should be present")
+			},
+		},
+		{
+			name:       "Existing valid headlamp_info original name",
+			configFile: "kubeconfig_headlampinfo",
+			validateFunc: func(t *testing.T, ctx *kubeconfig.Context) {
+				ext, ok := ctx.KubeContext.Extensions["headlamp_info"]
+				require.True(t, ok, "headlamp_info not found in Extensions")
+
+				// Convert the runtime.Object to a map
+				unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ext)
+				require.NoError(t, err, "failed to convert runtime.Object to map")
+
+				headlampInfo := unstructuredMap
+
+				// Check the originalName field
+				originalName, ok := headlampInfo["originalName"].(string)
+				require.True(t, ok, "headlamp_info.originalName missing or invalid")
+				assert.NotEmpty(t, originalName, "headlamp_info.originalName should not be empty")
+			},
+		},
+		{
+			name:       "Existing valid headlamp_info source path",
+			configFile: "kubeconfig_headlampinfo",
+			validateFunc: func(t *testing.T, ctx *kubeconfig.Context) {
+				ext, ok := ctx.KubeContext.Extensions["headlamp_info"]
+				require.True(t, ok, "headlamp_info not found in Extensions")
+
+				// Convert the runtime.Object to a map
+				unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ext)
+				require.NoError(t, err, "failed to convert runtime.Object to map")
+
+				headlampInfo := unstructuredMap
+
+				// Check the sourcePath field
+				sourcePath, ok := headlampInfo["sourcePath"].(string)
+				require.True(t, ok, "headlamp_info.sourcePath missing or invalid")
+				assert.NotEmpty(t, sourcePath, "headlamp_info.sourcePath should not be empty")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create a temp directory for our test kubeconfig
+			tmpDir := t.TempDir()
+			mockConfigFile := filepath.Join(tmpDir, "config")
+
+			// copy test data to the temp directory
+			testDataPath := filepath.Join("headlamp_testdata", tt.configFile)
+			testData, err := os.ReadFile(testDataPath)
+			require.NoError(t, err, "failed to read test data for '%s'", tt.configFile)
+
+			err = os.WriteFile(mockConfigFile, testData, 0o600)
+			require.NoError(t, err, "failed to write test kubeconfig")
+
+			// load the kubeconfig file
+			config, err := clientcmd.LoadFromFile(mockConfigFile)
+			require.NoError(t, err, "failed to load kubeconfig")
+
+			// Create a HeadlampConfig object
+			c := &HeadlampConfig{
+				useInCluster:    false,
+				cache:           cache.New[interface{}](),
+				kubeConfigStore: kubeconfig.NewContextStore(),
+				kubeConfigPath:  mockConfigFile,
+			}
+
+			// create a slice to hold the kubeconfig.Context objects
+			kubeContexts := make([]*kubeconfig.Context, 0, len(config.Contexts))
+
+			// loop through each context and push the kubeContext object into the slice
+			for contextName, context := range config.Contexts {
+				kubeContext := &kubeconfig.Context{
+					Name:        contextName,
+					KubeContext: context,
+					Source:      1,
+					Cluster:     config.Clusters[context.Cluster],
+					AuthInfo:    config.AuthInfos[context.AuthInfo],
+				}
+				kubeContexts = append(kubeContexts, kubeContext)
+			}
+
+			// use the kubeContexts slice for further processing
+			for _, ctx := range kubeContexts {
+				// Call handleHeadlampInfo
+				err = c.handleHeadlampInfo(ctx)
+				if err != nil {
+					fmt.Println("Error:", err)
+				}
+			}
+
+			// use the kubeContexts slice for further processing
+			for _, ctx := range kubeContexts {
+				if tt.expectedError {
+					require.Error(t, err, "expected an error but got none")
+				} else {
+					require.NoError(t, err, "failed to handle headlamp_info")
+
+					if tt.validateFunc != nil {
+						tt.validateFunc(t, ctx)
+					}
+				}
+			}
 		})
 	}
 }

--- a/backend/cmd/headlamp_testdata/kubeconfig_headlampinfo
+++ b/backend/cmd/headlamp_testdata/kubeconfig_headlampinfo
@@ -1,0 +1,114 @@
+apiVersion: v1
+clusters:
+  - cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg== # Example base64-encoded data
+      extensions:
+        - extension:
+            last-update: Mon, 26 Dec 2022 20:33:03 IST
+            provider: testkubex.sigs.k8s.io
+            version: v1.28.0
+          name: cluster_info
+      server: PLACEHOLDER_SERVER_URL_X
+    name: testkubex
+  - cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg== # Example base64-encoded data
+      extensions:
+        - extension:
+            last-update: Tue, 27 Dec 2022 20:33:03 IST
+            provider: testkubey.sigs.k8s.io
+            version: v1.28.0
+          name: cluster_info
+      server: PLACEHOLDER_SERVER_URL_Y
+    name: testkubey
+  - cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg== # Example base64-encoded data
+      extensions:
+        - extension:
+            last-update: Wed, 28 Dec 2022 20:33:03 IST
+            provider: testkubez.sigs.k8s.io
+            version: v1.28.0
+          name: cluster_info
+      server: PLACEHOLDER_SERVER_URL_Z
+    name: testkubez
+contexts:
+  - context:
+      cluster: testkubex
+      extensions:
+        - extension:
+            last-update: Mon, 26 Dec 2022 20:33:03 IST
+            provider: testkubex.sigs.k8s.io
+            version: v1.28.0
+          name: context_info
+        - extension:
+            creationTimestamp: null
+            customName: testkubexworks
+          name: headlamp_info
+      namespace: default
+      user: testkubex
+    name: testkubex
+  - context:
+      cluster: testkubey
+      extensions:
+        - extension:
+            last-update: Tue, 27 Dec 2022 20:33:03 IST
+            provider: testkubey.sigs.k8s.io
+            version: v1.28.0
+          name: context_info
+        - extension:
+            creationTimestamp: null
+            customName: testkubeyworks
+          name: headlamp_info
+      namespace: default
+      user: testkubey
+    name: testkubey
+  - context:
+      cluster: testkubez
+      extensions:
+        - extension:
+            last-update: Wed, 28 Dec 2022 20:33:03 IST
+            provider: testkubez.sigs.k8s.io
+            version: v1.28.0
+          name: context_info
+      namespace: default
+      user: testkubez
+    name: testkubez
+current-context: testkubex
+kind: Config
+preferences: {}
+users:
+  - name: testkubex
+    user:
+      client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg== # Example base64-encoded data
+      client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQo= # Example base64-encoded data
+      auth-provider:
+        config:
+          client-id: example-client-id
+          client-secret: example-client-secret
+          idp-issuer-url: https://example.com
+          refresh-token: example-refresh-token
+          id-token: example-id-token
+          expiry: example-expiry
+  - name: testkubey
+    user:
+      client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg== # Example base64-encoded data
+      client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQo= # Example base64-encoded data
+      auth-provider:
+        config:
+          client-id: example-client-id
+          client-secret: example-client-secret
+          idp-issuer-url: https://example.com
+          refresh-token: example-refresh-token
+          id-token: example-id-token
+          expiry: example-expiry
+  - name: testkubez
+    user:
+      client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg== # Example base64-encoded data
+      client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQo= # Example base64-encoded data
+      auth-provider:
+        config:
+          client-id: example-client-id
+          client-secret: example-client-secret
+          idp-issuer-url: https://example.com
+          refresh-token: example-refresh-token
+          id-token: example-id-token
+          expiry: example-expiry

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -59,6 +59,10 @@ type CustomObject struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 	CustomName string `json:"customName"`
+	// originalName is the name the cluster was created with.
+	OriginalName string `json:"originalName"`
+	// sourcePath is the path to the source file.
+	SourcePath string `json:"sourcePath"`
 }
 
 // DeepCopyObject returns a copy of the CustomObject.

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -45,6 +45,7 @@ type Context struct {
 	proxy       *httputil.ReverseProxy `json:"-"`
 	Internal    bool                   `json:"internal"`
 	Error       string                 `json:"error"`
+	Extensions  map[string]interface{} `json:"extensions"`
 }
 
 type OidcConfig struct {


### PR DESCRIPTION
Fixes issue #2750 


### Description

This PR aims to expands the current implementation of the `headlamp_info` extension that is created to provide additional information about a cluster within the kubeconfig. 

### Changes
- the `headlamp_info` extension is now created at the home view of the app (it used to only be created if we rename a cluster)
- the `headlamp_info` extension now includes a field for storing the original name of a cluster `originalName`
- for clusters that have been renamed before these changes were introduced, the `headlamp_info` is now updated to include the `originalName` field and correct val
- prepares the `headlamp_info` field for future cluster renaming by introducing the `customName` field along with `originalName`

### How to test

⚠️  IMPORTANT ⚠️ :  please be aware that this PR changes config data within the kubeconfig, I recommend copying any local kubeconfig files or have the undo button ready with your kubeconfig pulled up in your IDE

- locate kubeconfig file
- open headlamp app and navigate to the home view where all clusters are visible
- in kubeconfig, observe that all existing clusters now have `headlamp_info` field and `originalName` field containing the clusters name
- create a new cluster
- let app load new cluster to home view
- view changes for the new cluster

Context notes:

**Non dynamic clusters**
- I think its best to keep the changes in the home view where we use getCluster func from the backend (this is called on the home view of the app) since this would then populate the headlamp_info field and append the original name field, this would make it so that we can use the original name field along with the custom name field to delete a cluster from the home view