### PR TITLE
frontend: EditorDialog: Remove unneeded Monaco override

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -11,11 +11,6 @@ import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import * as yaml from 'js-yaml';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
-import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
-import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
-import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -37,24 +32,6 @@ import Loader from '../Loader';
 import Tabs from '../Tabs';
 import DocsViewer from './DocsViewer';
 import SimpleEditor from './SimpleEditor';
-
-(self as any).MonacoEnvironment = {
-  getWorker(_: unknown, label: string) {
-    if (label === 'json') {
-      return new jsonWorker();
-    }
-    if (label === 'css' || label === 'scss' || label === 'less') {
-      return new cssWorker();
-    }
-    if (label === 'html' || label === 'handlebars' || label === 'razor') {
-      return new htmlWorker();
-    }
-    if (label === 'typescript' || label === 'javascript') {
-      return new tsWorker();
-    }
-    return new editorWorker();
-  },
-};
 
 type KubeObjectIsh = Partial<KubeObjectInterface>;
 


### PR DESCRIPTION
This change addresses a regression where a local MonacoEnvironment override caused conflicts with Monaco-based components like DiffEditor. The Monaco override logic in EditorDialog is now removed to restore the default environment.

Fixes: #2693 

### Testing
- [X] Perform the steps outlined in the issue
- [X] Ensure that the colors are applied as intended

![image](https://github.com/user-attachments/assets/c559f26c-874d-4c78-9b08-c6bcd001ab16)
