### PR TITLE
frontend: fix websocket logs errors in tests

### DIFF
--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -318,6 +318,7 @@ export const WebSocketManager = {
       // Handle COMPLETE messages
       if (data.type === 'COMPLETE') {
         this.completedPaths.add(key);
+        return;
       }
 
       // Parse and validate update data
@@ -333,7 +334,13 @@ export const WebSocketManager = {
       if (update && typeof update === 'object') {
         const listeners = this.listeners.get(key);
         if (listeners) {
-          listeners.forEach(listener => listener(update));
+          for (const listener of listeners) {
+            try {
+              listener(update);
+            } catch (err) {
+              console.error('Failed to process WebSocket message:', err);
+            }
+          }
         }
       }
     } catch (err) {

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -7,12 +7,12 @@ import { makeUrl } from './makeUrl';
 
 // Constants for WebSocket connection
 export const BASE_WS_URL = BASE_HTTP_URL.replace('http', 'ws');
+export const MULTIPLEXER_ENDPOINT = 'wsMultiplexer';
 
 /**
  * Multiplexer endpoint for WebSocket connections
  * This endpoint allows multiple subscriptions over a single connection
  */
-const MULTIPLEXER_ENDPOINT = 'wsMultiplexer';
 
 /**
  * Message format for WebSocket communication between client and server.
@@ -148,8 +148,8 @@ export const WebSocketManager = {
       socket.onmessage = this.handleWebSocketMessage.bind(this);
 
       socket.onerror = event => {
-        console.error('WebSocket error:', event);
         this.connecting = false;
+        console.error('WebSocket error:', event);
         reject(new Error('WebSocket connection failed'));
       };
 
@@ -297,7 +297,7 @@ export const WebSocketManager = {
     this.connecting = false;
     this.completedPaths.clear();
 
-    // Set reconnecting flag if we have active subscriptions
+    // Only log reconnecting if we have active subscriptions
     this.isReconnecting = this.activeSubscriptions.size > 0;
   },
 


### PR DESCRIPTION
We now mock console logs in tests and do not console errors for tests env.

This:
- Remove unnecessary console logs due to `v2` websocket usage
- Fix some message handling bugs in some error conditions

Part of:
- #2753
- #1802

<details>
  <summary>Click to view Old logs</summary>

```bash
WebSocket error: Event {
  type: 'error',
  timeStamp: 1737091724622,
  target: WebSocket {
    listeners: { open: [Array], message: [Array], error: [Array], close: [Array] },
    _onopen: [Function (anonymous)],
    _onmessage: [Function: bound handleWebSocketMessage],
    _onerror: [Function (anonymous)],
    _onclose: [Function (anonymous)],
    url: 'ws://localhost:4466/wsMultiplexer',
    protocol: '',
    binaryType: 'blob',
    readyState: 3
  },
  srcElement: WebSocket {
    listeners: { open: [Array], message: [Array], error: [Array], close: [Array] },
    _onopen: [Function (anonymous)],
    _onmessage: [Function: bound handleWebSocketMessage],
    _onerror: [Function (anonymous)],
    _onclose: [Function (anonymous)],
    url: 'ws://localhost:4466/wsMultiplexer',
    protocol: '',
    binaryType: 'blob',
    readyState: 3
  },
  returnValue: true,
  isTrusted: false,
  eventPhase: 0,
  defaultPrevented: false,
  currentTarget: WebSocket {
    listeners: { open: [Array], message: [Array], error: [Array], close: [Array] },
    _onopen: [Function (anonymous)],
    _onmessage: [Function: bound handleWebSocketMessage],
    _onerror: [Function (anonymous)],
    _onclose: [Function (anonymous)],
    url: 'ws://localhost:4466/wsMultiplexer',
    protocol: '',
    binaryType: 'blob',
    readyState: 3
  },
  cancelable: false,
  cancelBubble: false,
  bubbles: false
}

stderr | src/lib/k8s/api/v2/webSocket.test.ts > WebSocket Tests > useWebSocket hook > should handle connection errors
WebSocket error: Event {
  type: 'error',
  timeStamp: 1737091724691,
  target: WebSocket {
    listeners: { open: [Array], message: [Array], error: [Array], close: [Array] },
    _onopen: [Function (anonymous)],
    _onmessage: [Function: bound handleWebSocketMessage],
    _onerror: [Function (anonymous)],
    _onclose: [Function (anonymous)],
    url: 'ws://localhost:4466/wsMultiplexer',
    protocol: '',
    binaryType: 'blob',
    readyState: 3
  },
  srcElement: WebSocket {
    listeners: { open: [Array], message: [Array], error: [Array], close: [Array] },
    _onopen: [Function (anonymous)],
    _onmessage: [Function: bound handleWebSocketMessage],
    _onerror: [Function (anonymous)],
    _onclose: [Function (anonymous)],
    url: 'ws://localhost:4466/wsMultiplexer',
    protocol: '',
    binaryType: 'blob',
    readyState: 3
  },
  returnValue: true,
  isTrusted: false,
  eventPhase: 0,
  defaultPrevented: false,
  currentTarget: WebSocket {
    listeners: { open: [Array], message: [Array], error: [Array], close: [Array] },
    _onopen: [Function (anonymous)],
    _onmessage: [Function: bound handleWebSocketMessage],
    _onerror: [Function (anonymous)],
    _onclose: [Function (anonymous)],
    url: 'ws://localhost:4466/wsMultiplexer',
    protocol: '',
    binaryType: 'blob',
    readyState: 3
  },
  cancelable: false,
  cancelBubble: false,
  bubbles: false
}
WebSocket connection failed: Error: WebSocket connection failed
    at WebSocket.socket.onerror [as _onerror] (/Users/kautilya/dev/microsoft/headlamp/frontend/src/lib/k8s/api/v2/webSocket.ts:153:16)
    at /Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:859:16
    at Array.forEach (<anonymous>)
    at WebSocket.dispatchEvent (/Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:855:13)
    at WebSocket.delayCallback (/Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:1530:14)
    at Timeout._onTimeout (/Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:757:58)
    at listOnTimeout (node:internal/timers:575:11)
    at processTimers (node:internal/timers:514:7)

stderr | src/lib/k8s/api/v2/webSocket.test.ts > WebSocket Tests > WebSocket error handling > should handle invalid message format
Failed to process WebSocket message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON
    at JSON.parse (<anonymous>)
    at Object.handleWebSocketMessage (/Users/kautilya/dev/microsoft/headlamp/frontend/src/lib/k8s/api/v2/webSocket.ts:311:25)
    at /Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:859:16
    at Array.forEach (<anonymous>)
    at Proxy.dispatchEvent (/Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:855:13)
    at /Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:2133:16
    at Array.forEach (<anonymous>)
    at Server.emit (/Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:2121:16)
    at file:///Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/vitest-websocket-mock/dist/index.js:133:19
    at act (file:///Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/vitest-websocket-mock/dist/index.js:33:5)

stderr | src/lib/k8s/api/v2/webSocket.test.ts > WebSocket Tests > WebSocket error handling > should handle message callback errors in useWebSocket
Failed to process WebSocket message: Error: Message processing failed
    at /Users/kautilya/dev/microsoft/headlamp/frontend/src/lib/k8s/api/v2/webSocket.test.ts:536:15
    at mockCall (file:///Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/vitest/node_modules/@vitest/spy/dist/index.js:61:17)
    at spy (file:///Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/tinyspy/dist/index.js:45:80)
    at /Users/kautilya/dev/microsoft/headlamp/frontend/src/lib/k8s/api/v2/webSocket.ts:421:9
    at Object.handleWebSocketMessage (/Users/kautilya/dev/microsoft/headlamp/frontend/src/lib/k8s/api/v2/webSocket.ts:339:15)
    at /Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:859:16
    at Array.forEach (<anonymous>)
    at Proxy.dispatchEvent (/Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:855:13)
    at /Users/kautilya/dev/microsoft/headlamp/frontend/node_modules/mock-socket/dist/mock-socket.js:2133:16
    at Array.forEach (<anonymous>)
```
</details>

### Testing

- `cd frontend && npm test webSocket.test.ts`