### PR TITLE
storybook: Add workaround for the circular dependecy crash

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -5,6 +5,11 @@ import '../src/index.css';
 import { Title, Subtitle, Description, Primary, Controls } from '@storybook/blocks';
 import { baseMocks } from './baseMocks';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from '../src/App';
+
+// App import will load the whole app dependency tree
+// And assigning it to a value will make sure it's not tree-shaken and removed
+const DontDeleteMe = App;
 
 // https://github.com/mswjs/msw-storybook-addon
 initialize({

--- a/frontend/src/components/gateway/ClassDetails.stories.tsx
+++ b/frontend/src/components/gateway/ClassDetails.stories.tsx
@@ -24,6 +24,10 @@ export default {
           http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gatewayclasses', () =>
             HttpResponse.error()
           ),
+          http.get(
+            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses',
+            () => HttpResponse.error()
+          ),
           http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
             HttpResponse.json({
               kind: 'EventList',

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -49,6 +49,7 @@ const options = {
 vi.mock('@iconify/react', () => ({
   Icon: () => null,
   InlineIcon: () => null,
+  addCollection: () => {},
 }));
 
 vi.mock('@monaco-editor/react', () => ({


### PR DESCRIPTION
Fixes #2450

When storybook renders a single story it only loads the relevant files which is nice and efficient, but we have some complicated circular dependencies that cause crashes.

Forcing the import of the root App component will also load the whole dependency tree for the App and fix the crash