### PR TITLE
docs: Add Flatpak to platforms with comment about external tools

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -47,6 +47,7 @@ We test on MacOS, various flavours of Linux, and Windows. Headlamp runs in the b
 | MacOS (arm, x86)                   |  ✔️   |
 | Ubuntu 20.04, 22.04, 22.10         |  ✔️   |
 | Fedora                             |  ✔️   |
+| Flatpak                            |  ✔️   | When using external tools like `az`, `aws`, `gcloud`, etc., please run `sudo flatpak override --talk-name=org.freedesktop.Flatpak io.kinvolk.Headlamp` before running Headlamp, so those tools can be called from within the sandbox. |
 
 
 ## CNCF and Kubernetes Integrations


### PR DESCRIPTION
The external tools running from Flatpak have been reported to be working, but there's a prior command that needs to be run by the user. So this PR adds a mention of that to the docs:

fixes #1885