### PR TITLE
frontend: Add beta label to Gateway

### DIFF
--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -602,7 +602,7 @@
                     tabindex="0"
                   >
                     <div
-                      aria-label="Gateway"
+                      aria-label="Gateway (beta)"
                       class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
                       data-mui-internal-clone-element="true"
                     />

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -645,7 +645,7 @@
                       <span
                         class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
                       >
-                        Gateway
+                        Gateway (beta)
                       </span>
                     </div>
                     <span

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -645,7 +645,7 @@
                       <span
                         class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
                       >
-                        Gateway
+                        Gateway (beta)
                       </span>
                     </div>
                     <span

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -168,7 +168,7 @@ function prepareRoutes(
     },
     {
       name: 'gatewayapi',
-      label: t('glossary|Gateway'),
+      label: t('glossary|Gateway (beta)'),
       icon: 'mdi:lan-connect',
       subList: [
         {

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -174,7 +174,7 @@
   "Persistent Volumes": "Persistent Volumes",
   "Storage Classes": "Speicher-Klassen",
   "Network": "Netzwerk",
-  "Gateway": "",
+  "Gateway (beta)": "",
   "HTTP Routes": "",
   "GRPC Routes": "",
   "Security": "Sicherheit",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -174,7 +174,7 @@
   "Persistent Volumes": "Persistent Volumes",
   "Storage Classes": "Storage Classes",
   "Network": "Network",
-  "Gateway": "Gateway",
+  "Gateway (beta)": "Gateway (beta)",
   "HTTP Routes": "HTTP Routes",
   "GRPC Routes": "GRPC Routes",
   "Security": "Security",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -174,7 +174,7 @@
   "Persistent Volumes": "Persistent Volumes",
   "Storage Classes": "Storage Classes",
   "Network": "Red",
-  "Gateway": "",
+  "Gateway (beta)": "",
   "HTTP Routes": "",
   "GRPC Routes": "",
   "Security": "Seguridad",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -174,7 +174,7 @@
   "Persistent Volumes": "Persistent Volumes",
   "Storage Classes": "Classes de stockage",
   "Network": "Réseau",
-  "Gateway": "",
+  "Gateway (beta)": "",
   "HTTP Routes": "",
   "GRPC Routes": "",
   "Security": "Sécurité",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -174,7 +174,7 @@
   "Persistent Volumes": "Persistent Volumes",
   "Storage Classes": "Storage Classes",
   "Network": "Rede",
-  "Gateway": "",
+  "Gateway (beta)": "",
   "HTTP Routes": "",
   "GRPC Routes": "",
   "Security": "Segurança",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -174,7 +174,7 @@
   "Persistent Volumes": "持續性卷",
   "Storage Classes": "儲存類別",
   "Network": "網路",
-  "Gateway": "",
+  "Gateway (beta)": "",
   "HTTP Routes": "",
   "GRPC Routes": "",
   "Security": "安全",


### PR DESCRIPTION
Changes "Gateway" label in sidebar to "Gateway (beta)".

### How to test

- [x] open headlamp and see Gateway (beta) is in sidebar

![image](https://github.com/user-attachments/assets/cb1f8046-2ba1-4fc4-b212-30ef1192d291)
