### PR TITLE
frontend: Fix namespace selection when allowed namespaces is set

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -348,12 +348,13 @@ export function makeListRequests(
   clusters: string[],
   getAllowedNamespaces: (cluster: string | null) => string[],
   isResourceNamespaced: boolean,
-  requestedNamespaces?: string[]
+  requestedNamespaces: string[] = []
 ): Array<{ cluster: string; namespaces?: string[] }> {
   return clusters.map(cluster => {
     const allowedNamespaces = getAllowedNamespaces(cluster);
 
-    let namespaces = requestedNamespaces ?? allowedNamespaces;
+    let namespaces = requestedNamespaces.length > 0 ? requestedNamespaces : allowedNamespaces;
+
     if (allowedNamespaces.length) {
       namespaces = namespaces.filter(ns => allowedNamespaces.includes(ns));
     }


### PR DESCRIPTION
By default if user has 'allowed namespaces' and no namespaces selected in the dropdown, it should load only the 'allowed namespaces'

This case wasn't handled properly and would just pass empty array for namespaces which would load all namespaces.