### PR TITLE
frontend: Update vite to 5.4.14

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15151,9 +15151,10 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
-      "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION

## Description

This PR updates the Vite package to 5.4.14 to address an issue found in `npm audit`

[Related link](https://github.com/advisories/GHSA-vg6x-rcgg-rjx6)

![image](https://github.com/user-attachments/assets/e1b46644-4baa-4ba1-b986-3c337d999ad4)
