### PR TITLE
frontend: plugins: Remove unused @types/nock pkg

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -114,7 +114,6 @@
         "@storybook/theming": "^8.3.5",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/user-event": "^14.5.2",
-        "@types/nock": "^11.1.0",
         "@vitest/coverage-istanbul": "^2.1.1",
         "husky": "^4.3.8",
         "i18next-parser": "^9.0.2",
@@ -3591,16 +3590,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/nock": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
-      "integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
-      "deprecated": "This is a stub types definition. nock provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "nock": "*"
       }
     },
     "node_modules/@types/node": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -202,7 +202,6 @@
     "@storybook/theming": "^8.3.5",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/user-event": "^14.5.2",
-    "@types/nock": "^11.1.0",
     "@vitest/coverage-istanbul": "^2.1.1",
     "husky": "^4.3.8",
     "i18next-parser": "^9.0.2",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -57,7 +57,6 @@
         "@types/js-yaml": "^4.0.3",
         "@types/json-patch": "0.0.30",
         "@types/lodash": "4.17.7",
-        "@types/nock": "^11.1.0",
         "@types/node": "^20.12.11",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -7934,15 +7933,6 @@
       "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/nock": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
-      "integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
-      "deprecated": "This is a stub types definition. nock provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "nock": "*"
       }
     },
     "node_modules/@types/node": {

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -61,7 +61,6 @@
     "@types/js-yaml": "^4.0.3",
     "@types/json-patch": "0.0.30",
     "@types/lodash": "4.17.7",
-    "@types/nock": "^11.1.0",
     "@types/node": "^20.12.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
This package isn't necessary to have installed as per the message in #1992.