### PR TITLE
frontend: Update vite to 5.4.14

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -95,7 +95,7 @@
         "typescript": "5.6.2",
         "url": "^0.11.0",
         "util": "^0.12.4",
-        "vite": "^5.4.9",
+        "vite": "^5.4.14",
         "vite-plugin-node-polyfills": "^0.22.0",
         "vite-plugin-svgr": "^4.2.0",
         "web-worker": "^1.3.0"
@@ -15151,9 +15151,10 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
-      "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "typescript": "5.6.2",
     "url": "^0.11.0",
     "util": "^0.12.4",
-    "vite": "^5.4.9",
+    "vite": "^5.4.14",
     "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-svgr": "^4.2.0",
     "web-worker": "^1.3.0"


### PR DESCRIPTION
## Description

This PR updates the Vite package to 5.4.14 to address an issue found in `npm audit` 
