### PR TITLE
docs: remove redundant backend, frontend build commands before building app

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -63,13 +63,7 @@ You can build the app for Linux, Windows, or Mac.
 Do so on the platform you are building for. That is build the mac app on a Mac,
 and the linux app on a linux box.
 
-First, we need to
-
-```bash
-make backend frontend
-```
-
-Then choose the relevant command.
+Choose the relevant command:
 
 ```bash
 make app-linux


### PR DESCRIPTION
The purpose behind this PR was that I noticed at this place:

https://github.com/headlamp-k8s/headlamp/blob/bdd56af4d8e96c9b094f05d7b72e8b01126a16d9/docs/development/index.md?plain=1#L69

before building the app, `make backend frontend` has been called and then `make app-linux` or whatever command user prefers gets called. 

However, at [this](https://github.com/headlamp-k8s/headlamp/blob/bdd56af4d8e96c9b094f05d7b72e8b01126a16d9/Makefile#L49) place, when we call `app-linux` for e.g., it calls `app-build` which inturn calls `frontend/build` which inturn calls `make frontend`. So the need for calling `make frontend` was definitely not necessary before building the app as all the OS specific commands already do the frontend build behind the scenes before building the app.

And regarding the `make backend` command, I wasn't really sure as to why is it necessary to be done before building the app. So I thought of removing it from over here. However, if anyone knows the reason why this was added then I will revert it ASAP.

Thanks. 