### PR TITLE
Show plugin package URL for user confirmation

### DIFF
--- a/app/electron/locales/de/app.json
+++ b/app/electron/locales/de/app.json
@@ -1,4 +1,11 @@
 {
+  "Failed to fetch plugin info": "",
+  "An error occurred while fetching plugin info from {{  URL }}.": "",
+  "Yes": "",
+  "No": "",
+  "Plugin Installation": "",
+  "Do you want to install the plugin \"{{ pluginName }}\"?": "",
+  "You are about to install a plugin from: {{ url }}\nDo you want to proceed?": "",
   "About": "Über",
   "Quit": "Beenden",
   "Select All": "Alles auswählen",

--- a/app/electron/locales/en/app.json
+++ b/app/electron/locales/en/app.json
@@ -1,4 +1,11 @@
 {
+  "Failed to fetch plugin info": "",
+  "An error occurred while fetching plugin info from {{  URL }}.": "",
+  "Yes": "",
+  "No": "",
+  "Plugin Installation": "",
+  "Do you want to install the plugin \"{{ pluginName }}\"?": "",
+  "You are about to install a plugin from: {{ url }}\nDo you want to proceed?": "",
   "About": "About",
   "Quit": "Quit",
   "Select All": "Select All",

--- a/app/electron/locales/es/app.json
+++ b/app/electron/locales/es/app.json
@@ -1,4 +1,11 @@
 {
+  "Failed to fetch plugin info": "",
+  "An error occurred while fetching plugin info from {{  URL }}.": "",
+  "Yes": "",
+  "No": "",
+  "Plugin Installation": "",
+  "Do you want to install the plugin \"{{ pluginName }}\"?": "",
+  "You are about to install a plugin from: {{ url }}\nDo you want to proceed?": "",
   "About": "Acerca",
   "Quit": "Salir",
   "Select All": "Seleccionar Todo",

--- a/app/electron/locales/fr/app.json
+++ b/app/electron/locales/fr/app.json
@@ -1,4 +1,11 @@
 {
+  "Failed to fetch plugin info": "",
+  "An error occurred while fetching plugin info from {{  URL }}.": "",
+  "Yes": "",
+  "No": "",
+  "Plugin Installation": "",
+  "Do you want to install the plugin \"{{ pluginName }}\"?": "",
+  "You are about to install a plugin from: {{ url }}\nDo you want to proceed?": "",
   "About": "À propos",
   "Quit": "Quitter",
   "Select All": "Tout sélectionner",

--- a/app/electron/locales/pt/app.json
+++ b/app/electron/locales/pt/app.json
@@ -1,4 +1,11 @@
 {
+  "Failed to fetch plugin info": "",
+  "An error occurred while fetching plugin info from {{  URL }}.": "",
+  "Yes": "",
+  "No": "",
+  "Plugin Installation": "",
+  "Do you want to install the plugin \"{{ pluginName }}\"?": "",
+  "You are about to install a plugin from: {{ url }}\nDo you want to proceed?": "",
   "About": "Acerca",
   "Quit": "Sair",
   "Select All": "Seleccionar tudo",

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -273,45 +273,46 @@ class PluginManagerEventListeners {
       }),
     };
 
-    return dialog
-      .showMessageBox(mainWindow, dialogOptions)
-      .then(({ response }) => {
-        console.log('User response:', response);
-        if (response === 1) {
-          // User clicked "No"
-          this.cache[identifier] = {
-            action: 'INSTALL',
-            progress: { type: 'error', message: 'installation cancelled due to user consent' },
-            percentage: 0,
-            controller,
-          };
-          return { type: 'error', message: 'Installation cancelled due to user consent' };
-        }
+    let userChoice: number;
+    try {
+      const answer = await dialog.showMessageBox(mainWindow, dialogOptions);
+      userChoice = answer.response;
+    } catch (error) {
+      console.error('Error during installation process:', error);
+      return { type: 'error', message: 'An error occurred during the installation process' };
+    }
 
-        // User clicked "Yes", proceed with installation
-        this.cache[identifier] = {
-          action: 'INSTALL',
-          progress: { type: 'info', message: 'installing plugin' },
-          percentage: 10,
-          controller,
-        };
+    console.log('User response:', userChoice);
+    if (userChoice === 1) {
+      // User clicked "No"
+      this.cache[identifier] = {
+        action: 'INSTALL',
+        progress: { type: 'error', message: 'installation cancelled due to user consent' },
+        percentage: 0,
+        controller,
+      };
+      return { type: 'error', message: 'Installation cancelled due to user consent' };
+    }
 
-        PluginManager.installFromPluginPkg(
-          pluginInfo,
-          destinationFolder,
-          headlampVersion,
-          progress => {
-            updateCache(progress);
-          },
-          controller.signal
-        );
+    // User clicked "Yes", proceed with installation
+    this.cache[identifier] = {
+      action: 'INSTALL',
+      progress: { type: 'info', message: 'installing plugin' },
+      percentage: 10,
+      controller,
+    };
 
-        return { type: 'info', message: 'Installation started' };
-      })
-      .catch(error => {
-        console.error('Error during installation process:', error);
-        return { type: 'error', message: 'An error occurred during the installation process' };
-      });
+    PluginManager.installFromPluginPkg(
+      pluginInfo,
+      destinationFolder,
+      headlampVersion,
+      progress => {
+        updateCache(progress);
+      },
+      controller.signal
+    );
+
+    return { type: 'info', message: 'Installation started' };
   }
   /**
    * Handles the update process.

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -264,11 +264,13 @@ class PluginManagerEventListeners {
 
     const dialogOptions: MessageBoxOptions = {
       type: 'question',
-      buttons: ['Yes', 'No'],
+      buttons: [i18n.t('Yes'), i18n.t('No')],
       defaultId: 1,
-      title: 'Plugin Installation',
-      message: 'Do you want to install this plugin?',
-      detail: `You are about to install ${pluginName} plugin from: ${pluginInfo.archiveURL}\nDo you want to proceed?`,
+      title: i18n.t('Plugin Installation'),
+      message: i18n.t('Do you want to install the plugin "{{ pluginName }}"?', { pluginName }),
+      detail: i18n.t('You are about to install a plugin from: {{ url }}\nDo you want to proceed?', {
+        url: pluginInfo.archiveURL,
+      }),
     };
 
     return dialog

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -515,9 +515,9 @@ async function fetchPluginInfo(URL, progressCallback, signal) {
   } catch (e) {
     if (progressCallback) {
       progressCallback({ type: 'error', message: e.message });
-    } else {
-      throw e;
     }
+
+    throw e;
   }
 }
 

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -392,7 +392,9 @@ async function downloadExtractPlugin(URL, headlampVersion, progressCallback, sig
   }
 
   const tempDir = await fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
-  const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true });
+  // Defaulting to '' should never happen if recursive is true. So this is for the type
+  // checker only.
+  const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true }) ?? '';
 
   if (progressCallback) {
     progressCallback({ type: 'info', message: 'Downloading Plugin' });


### PR DESCRIPTION
When installing a plugin, we are showing the plugin's ArtifactHub URL to the user for confirmation and this is not very interesting since all plugins are listed from ArtifactHub, in fact, what the user should confirm is the origin of the plugin package, because it's from that package that we will deploy the plugin.

## How to test:
- [ ] Go to the plugin catalog and select a plugin
- [ ] Click the install button and verify that the message shows the plugin's package URL instead of the ArtifactHub one
- [ ] Click No -> Verify the process is successfully aborted (there's an existing bug which shows the "reload now" button in the notification even when there's an error or cancellation)
- [ ] Click Yes -> The plugin is successfully installed