### PR TITLE
Frontend: Add stories for chart componenets

### DIFF
--- a/frontend/src/components/cluster/Charts/ResourceCharts.stories.tsx
+++ b/frontend/src/components/cluster/Charts/ResourceCharts.stories.tsx
@@ -1,0 +1,212 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { KubeMetrics } from '../../../lib/k8s/cluster';
+import Node from '../../../lib/k8s/node';
+import Pod from '../../../lib/k8s/pod';
+import { CircularChartProps } from '../../common/Resource/CircularChart';
+import { CpuCircularChart, MemoryCircularChart } from './ResourceCharts';
+
+interface ResourceCircularChartProps {
+  chart_props: CircularChartProps;
+  resource: 'memory' | 'cpu';
+}
+
+const Template1: StoryFn<ResourceCircularChartProps> = (args: ResourceCircularChartProps) => {
+  if (args.resource === 'memory') {
+    return <MemoryCircularChart {...args.chart_props} />;
+  } else {
+    return <CpuCircularChart {...args.chart_props} />;
+  }
+};
+
+const meta: Meta = {
+  title: 'Cluster/ResourceCharts',
+  component: Template1,
+  decorators: [Story => <Story />],
+};
+
+export default meta;
+
+// Base objects for mock data
+const baseNodeData = {
+  kind: 'Node',
+  apiVersion: 'v1',
+  metadata: {
+    uid: '1',
+    resourceVersion: '1',
+    creationTimestamp: '2021-01-01T00:00:00Z',
+    namespace: 'default',
+  },
+  spec: {
+    podCIDR: '10.244.0.0/24',
+    taints: [],
+  },
+  status: {
+    capacity: {
+      cpu: '2', // 2 CPU cores
+      memory: '8Gi', // 8GB memory
+      ephemeralStorage: '100Gi',
+      hugepages_1Gi: '0',
+      hugepages_2Mi: '0',
+      pods: '110',
+    },
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastHeartbeatTime: '2021-01-01T00:00:00Z',
+        lastTransitionTime: '2021-01-01T00:00:00Z',
+        message: 'Node is ready',
+        reason: 'KubeletReady',
+      },
+    ],
+  },
+};
+
+const basePodData = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    uid: '1',
+    resourceVersion: '1',
+    creationTimestamp: '2021-01-01T00:00:00Z',
+    namespace: 'default',
+  },
+  spec: {
+    containers: [],
+    nodeName: 'node-1',
+  },
+  status: {
+    phase: 'Running',
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastTransitionTime: '2021-01-01T00:00:00Z',
+        lastProbeTime: '2021-01-01T00:00:00Z',
+        message: 'Pod is ready',
+        reason: 'PodReady',
+      },
+    ],
+    containerStatuses: [],
+    startTime: '2021-01-01T00:00:00Z',
+  },
+};
+
+// Mock data
+const mockNode = new Node({
+  ...baseNodeData,
+  metadata: {
+    ...baseNodeData.metadata,
+    name: 'node-1',
+  },
+});
+
+const mockNodeMetrics: KubeMetrics = {
+  metadata: {
+    name: 'node-1',
+    uid: '1',
+    resourceVersion: '1',
+    creationTimestamp: '2021-01-01T00:00:00Z',
+    namespace: 'default',
+  },
+  usage: {
+    cpu: '500m', // 0.5 CPU
+    memory: '2Gi', // 2GB memory
+  },
+  status: {
+    capacity: {
+      cpu: '2',
+      memory: '8Gi',
+    },
+  },
+};
+
+const mockPod = new Pod({
+  ...basePodData,
+  metadata: {
+    ...basePodData.metadata,
+    name: 'pod-1',
+  },
+});
+
+const mockPodMetrics: KubeMetrics = {
+  metadata: {
+    name: 'pod-1',
+    uid: '1',
+    resourceVersion: '1',
+    creationTimestamp: '2021-01-01T00:00:00Z',
+    namespace: 'default',
+  },
+  usage: {
+    cpu: '200m', // 0.2 CPU
+    memory: '500Mi', // 500MB memory
+  },
+  status: {
+    capacity: {
+      cpu: '1',
+      memory: '1Gi',
+    },
+  },
+};
+
+// Memory Chart Stories
+export const MemoryChartWithMetrics = Template1.bind({});
+MemoryChartWithMetrics.args = {
+  chart_props: {
+    items: [mockNode],
+    itemsMetrics: [mockNodeMetrics],
+    noMetrics: false,
+  },
+  resource: 'memory',
+};
+
+export const MemoryChartNoMetrics = Template1.bind({});
+MemoryChartNoMetrics.args = {
+  chart_props: {
+    items: [mockNode],
+    itemsMetrics: null,
+    noMetrics: true,
+  },
+  resource: 'memory',
+};
+
+export const MemoryChartPod = Template1.bind({});
+MemoryChartPod.args = {
+  chart_props: {
+    items: [mockPod],
+    itemsMetrics: [mockPodMetrics],
+    noMetrics: false,
+  },
+  resource: 'memory',
+};
+
+// CPU Chart Stories
+export const CpuChartWithMetrics = Template1.bind({});
+CpuChartWithMetrics.args = {
+  chart_props: {
+    items: [mockNode],
+    itemsMetrics: [mockNodeMetrics],
+    noMetrics: false,
+  },
+  resource: 'cpu',
+};
+
+export const CpuChartNoMetrics = Template1.bind({});
+CpuChartNoMetrics.args = {
+  chart_props: {
+    items: [mockNode],
+    itemsMetrics: null,
+    noMetrics: true,
+  },
+  resource: 'cpu',
+};
+
+export const CpuChartPod = Template1.bind({});
+CpuChartPod.args = {
+  chart_props: {
+    items: [mockPod],
+    itemsMetrics: [mockPodMetrics],
+    noMetrics: false,
+  },
+  resource: 'cpu',
+};

--- a/frontend/src/components/cluster/Charts/ResourceCharts.tsx
+++ b/frontend/src/components/cluster/Charts/ResourceCharts.tsx
@@ -1,0 +1,81 @@
+import '../../../i18n/config';
+import { useTranslation } from 'react-i18next';
+import { KubeMetrics } from '../../../lib/k8s/cluster';
+import Node from '../../../lib/k8s/node';
+import Pod from '../../../lib/k8s/pod';
+import { parseCpu, parseRam, TO_GB, TO_ONE_CPU } from '../../../lib/units';
+import ResourceCircularChart, {
+  CircularChartProps as ResourceCircularChartProps,
+} from '../../common/Resource/CircularChart';
+
+export function MemoryCircularChart(props: ResourceCircularChartProps) {
+  const { noMetrics } = props;
+  const { t } = useTranslation(['translation', 'glossary']);
+
+  function memoryUsedGetter(item: KubeMetrics) {
+    return parseRam(item.usage.memory) / TO_GB;
+  }
+
+  function memoryAvailableGetter(item: Node | Pod) {
+    return parseRam(item.status?.capacity?.memory) / TO_GB;
+  }
+
+  function getLegend(used: number, available: number) {
+    if (available === 0 || available === -1) {
+      return '';
+    }
+
+    const availableLabel = `${available.toFixed(2)} GB`;
+    if (noMetrics) {
+      return availableLabel;
+    }
+
+    return `${used.toFixed(2)} / ${availableLabel}`;
+  }
+
+  return (
+    <ResourceCircularChart
+      getLegend={getLegend}
+      resourceUsedGetter={memoryUsedGetter}
+      resourceAvailableGetter={memoryAvailableGetter}
+      title={noMetrics ? t('glossary|Memory') : t('translation|Memory Usage')}
+      {...props}
+    />
+  );
+}
+
+export function CpuCircularChart(props: ResourceCircularChartProps) {
+  const { noMetrics } = props;
+  const { t } = useTranslation(['translation', 'glossary']);
+
+  function cpuUsedGetter(item: KubeMetrics) {
+    return parseCpu(item.usage.cpu) / TO_ONE_CPU;
+  }
+
+  function cpuAvailableGetter(item: Node | Pod) {
+    return parseCpu(item.status?.capacity?.cpu) / TO_ONE_CPU;
+  }
+
+  function getLegend(used: number, available: number) {
+    if (available === 0 || available === -1) {
+      return '';
+    }
+
+    const availableLabel = t('translation|{{ available }} units', { available });
+    if (noMetrics) {
+      return availableLabel;
+    }
+
+    return `${used.toFixed(2)} / ${availableLabel}`;
+  }
+
+  return (
+    <ResourceCircularChart
+      getLegend={getLegend}
+      resourceUsedGetter={cpuUsedGetter}
+      resourceAvailableGetter={cpuAvailableGetter}
+      title={noMetrics ? t('glossary|CPU') : t('translation|CPU Usage')}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/cluster/Charts/StatusCharts.stories.tsx
+++ b/frontend/src/components/cluster/Charts/StatusCharts.stories.tsx
@@ -1,0 +1,203 @@
+import { Meta, StoryFn } from '@storybook/react';
+import Node from '../../../lib/k8s/node';
+import Pod from '../../../lib/k8s/pod';
+import { NodesStatusCircleChart, PodsStatusCircleChart } from './StatusCharts';
+
+const meta: Meta = {
+  title: 'Cluster/StatusCharts',
+  decorators: [Story => <Story />],
+};
+
+export default meta;
+
+// Base objects for mock data
+const basePodData = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    uid: '1',
+    resourceVersion: '1',
+    creationTimestamp: '2021-01-01T00:00:00Z',
+    namespace: 'default',
+  },
+  spec: {
+    containers: [],
+    nodeName: 'node-1',
+  },
+  status: {
+    phase: 'Running',
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastTransitionTime: '2021-01-01T00:00:00Z',
+        lastProbeTime: '2021-01-01T00:00:00Z',
+        message: 'Pod is ready',
+        reason: 'PodReady',
+      },
+    ],
+    containerStatuses: [],
+    startTime: '2021-01-01T00:00:00Z',
+  },
+};
+
+const baseNodeData = {
+  kind: 'Node',
+  apiVersion: 'v1',
+  metadata: {
+    uid: '1',
+    resourceVersion: '1',
+    creationTimestamp: '2021-01-01T00:00:00Z',
+    namespace: 'default',
+  },
+  spec: {
+    podCIDR: '10.244.0.0/24',
+    taints: [],
+  },
+  status: {
+    capacity: {
+      cpu: '2',
+      memory: '8Gi',
+      ephemeralStorage: '100Gi',
+      hugepages_1Gi: '0',
+      hugepages_2Mi: '0',
+      pods: '110',
+    },
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastHeartbeatTime: '2021-01-01T00:00:00Z',
+        lastTransitionTime: '2021-01-01T00:00:00Z',
+        message: 'Node is ready',
+        reason: 'KubeletReady',
+      },
+    ],
+  },
+};
+
+// Pod Stories
+type PodStatusProps = { items: Pod[] | null };
+const PodTemplate: StoryFn<PodStatusProps> = args => <PodsStatusCircleChart {...args} />;
+
+export const PodsStatusWithMixedStates = PodTemplate.bind({});
+PodsStatusWithMixedStates.args = {
+  items: [
+    new Pod({
+      ...basePodData,
+      metadata: {
+        ...basePodData.metadata,
+        name: 'pod-1',
+      },
+    }),
+    new Pod({
+      ...basePodData,
+      metadata: {
+        ...basePodData.metadata,
+        name: 'pod-2',
+        uid: '2',
+      },
+      status: {
+        ...basePodData.status,
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+            lastTransitionTime: '2021-01-01T00:00:00Z',
+            lastProbeTime: '2021-01-01T00:00:00Z',
+            message: 'Pod is not ready',
+            reason: 'PodNotReady',
+          },
+        ],
+      },
+    }),
+    new Pod({
+      ...basePodData,
+      metadata: {
+        ...basePodData.metadata,
+        name: 'pod-3',
+        uid: '3',
+      },
+      status: {
+        ...basePodData.status,
+        phase: 'Succeeded',
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            lastTransitionTime: '2021-01-01T00:00:00Z',
+            lastProbeTime: '2021-01-01T00:00:00Z',
+            message: 'Pod completed successfully',
+            reason: 'PodSucceeded',
+          },
+        ],
+      },
+    }),
+  ],
+};
+
+export const PodsStatusEmpty = PodTemplate.bind({});
+PodsStatusEmpty.args = {
+  items: [],
+};
+
+export const PodsStatusLoading = PodTemplate.bind({});
+PodsStatusLoading.args = {
+  items: null,
+};
+
+// Node Stories
+type NodeStatusProps = { items: Node[] | null };
+const NodeTemplate: StoryFn<NodeStatusProps> = args => <NodesStatusCircleChart {...args} />;
+
+export const NodesStatusWithMixedStates = NodeTemplate.bind({});
+NodesStatusWithMixedStates.args = {
+  items: [
+    new Node({
+      ...baseNodeData,
+      metadata: {
+        ...baseNodeData.metadata,
+        name: 'node-1',
+      },
+    }),
+    new Node({
+      ...baseNodeData,
+      metadata: {
+        ...baseNodeData.metadata,
+        name: 'node-2',
+        uid: '2',
+      },
+      status: {
+        ...baseNodeData.status,
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+            lastHeartbeatTime: '2021-01-01T00:00:00Z',
+            lastTransitionTime: '2021-01-01T00:00:00Z',
+            message: 'Node is not ready',
+            reason: 'KubeletNotReady',
+          },
+        ],
+      },
+    }),
+    new Node({
+      ...baseNodeData,
+      metadata: {
+        ...baseNodeData.metadata,
+        name: 'node-3',
+        uid: '3',
+      },
+    }),
+  ],
+};
+
+export const NodesStatusEmpty = NodeTemplate.bind({});
+NodesStatusEmpty.args = {
+  items: [],
+};
+
+export const NodesStatusLoading = NodeTemplate.bind({});
+NodesStatusLoading.args = {
+  items: null,
+};

--- a/frontend/src/components/cluster/Charts/StatusCharts.tsx
+++ b/frontend/src/components/cluster/Charts/StatusCharts.tsx
@@ -1,86 +1,9 @@
-import '../../i18n/config';
+import '../../../i18n/config';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { KubeMetrics } from '../../lib/k8s/cluster';
-import Node from '../../lib/k8s/node';
-import Pod from '../../lib/k8s/pod';
-import { parseCpu, parseRam, TO_GB, TO_ONE_CPU } from '../../lib/units';
-import ResourceCircularChart, {
-  CircularChartProps as ResourceCircularChartProps,
-} from '../common/Resource/CircularChart';
-import TileChart from '../common/TileChart';
-
-export function MemoryCircularChart(props: ResourceCircularChartProps) {
-  const { noMetrics } = props;
-  const { t } = useTranslation(['translation', 'glossary']);
-
-  function memoryUsedGetter(item: KubeMetrics) {
-    return parseRam(item.usage.memory) / TO_GB;
-  }
-
-  function memoryAvailableGetter(item: Node | Pod) {
-    return parseRam(item.status?.capacity?.memory) / TO_GB;
-  }
-
-  function getLegend(used: number, available: number) {
-    if (available === 0 || available === -1) {
-      return '';
-    }
-
-    const availableLabel = `${available.toFixed(2)} GB`;
-    if (noMetrics) {
-      return availableLabel;
-    }
-
-    return `${used.toFixed(2)} / ${availableLabel}`;
-  }
-
-  return (
-    <ResourceCircularChart
-      getLegend={getLegend}
-      resourceUsedGetter={memoryUsedGetter}
-      resourceAvailableGetter={memoryAvailableGetter}
-      title={noMetrics ? t('glossary|Memory') : t('translation|Memory Usage')}
-      {...props}
-    />
-  );
-}
-
-export function CpuCircularChart(props: ResourceCircularChartProps) {
-  const { noMetrics } = props;
-  const { t } = useTranslation(['translation', 'glossary']);
-
-  function cpuUsedGetter(item: KubeMetrics) {
-    return parseCpu(item.usage.cpu) / TO_ONE_CPU;
-  }
-
-  function cpuAvailableGetter(item: Node | Pod) {
-    return parseCpu(item.status?.capacity?.cpu) / TO_ONE_CPU;
-  }
-
-  function getLegend(used: number, available: number) {
-    if (available === 0 || available === -1) {
-      return '';
-    }
-
-    const availableLabel = t('translation|{{ available }} units', { available });
-    if (noMetrics) {
-      return availableLabel;
-    }
-
-    return `${used.toFixed(2)} / ${availableLabel}`;
-  }
-
-  return (
-    <ResourceCircularChart
-      getLegend={getLegend}
-      resourceUsedGetter={cpuUsedGetter}
-      resourceAvailableGetter={cpuAvailableGetter}
-      title={noMetrics ? t('glossary|CPU') : t('translation|CPU Usage')}
-      {...props}
-    />
-  );
-}
+import Node from '../../../lib/k8s/node';
+import Pod from '../../../lib/k8s/pod';
+import TileChart from '../../common/TileChart';
 
 export function PodsStatusCircleChart(props: { items: Pod[] | null }) {
   const theme = useTheme();

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartNoMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartNoMetrics.stories.storyshot
@@ -1,0 +1,36 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-cmkit5-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-qrw4x1"
+      >
+        <div
+          class="MuiBox-root css-1sl8dhm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+            >
+              CPU
+            </p>
+            <div
+              class="MuiContainer-root MuiContainer-maxWidthLg css-64uahr-MuiContainer-root"
+            />
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+          >
+            2 units
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        />
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartPod.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartPod.stories.storyshot
@@ -15,14 +15,12 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              CPU Usage
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
-          >
-            Progress so far
-          </p>
+          />
         </div>
         <div
           class="MuiBox-root css-0"
@@ -69,15 +67,49 @@
                     <g
                       class="recharts-layer recharts-pie-sector"
                       tabindex="-1"
-                    />
+                    >
+                      <path
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,0,
+    NaN,NaN
+  L NaN,NaN
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                        fill="#000"
+                        name="used"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
                     <g
                       class="recharts-layer recharts-pie-sector"
                       tabindex="-1"
-                    />
-                    <g
-                      class="recharts-layer recharts-pie-sector"
-                      tabindex="-1"
-                    />
+                    >
+                      <path
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M NaN,NaN
+    A 44.800000000000004,44.800000000000004,0,
+    0,0,
+    NaN,NaN
+  L NaN,NaN
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            NaN,NaN Z"
+                        fill="#e0e0e0"
+                        name="total"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
                   </g>
                   <text
                     class="recharts-text recharts-label"
@@ -92,7 +124,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      …
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartWithMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartWithMetrics.stories.storyshot
@@ -15,13 +15,13 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              CPU Usage
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            Progress so far
+            0.50 / 2 units
           </p>
         </div>
         <div
@@ -74,10 +74,6 @@
                       class="recharts-layer recharts-pie-sector"
                       tabindex="-1"
                     />
-                    <g
-                      class="recharts-layer recharts-pie-sector"
-                      tabindex="-1"
-                    />
                   </g>
                   <text
                     class="recharts-text recharts-label"
@@ -92,7 +88,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      25.0 %
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartNoMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartNoMetrics.stories.storyshot
@@ -1,0 +1,36 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-cmkit5-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-qrw4x1"
+      >
+        <div
+          class="MuiBox-root css-1sl8dhm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+            >
+              Memory
+            </p>
+            <div
+              class="MuiContainer-root MuiContainer-maxWidthLg css-64uahr-MuiContainer-root"
+            />
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+          >
+            8.00 GB
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        />
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartPod.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartPod.stories.storyshot
@@ -15,14 +15,12 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              Memory Usage
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
-          >
-            Progress so far
-          </p>
+          />
         </div>
         <div
           class="MuiBox-root css-0"
@@ -69,15 +67,49 @@
                     <g
                       class="recharts-layer recharts-pie-sector"
                       tabindex="-1"
-                    />
+                    >
+                      <path
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,0,
+    NaN,NaN
+  L NaN,NaN
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                        fill="#000"
+                        name="used"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
                     <g
                       class="recharts-layer recharts-pie-sector"
                       tabindex="-1"
-                    />
-                    <g
-                      class="recharts-layer recharts-pie-sector"
-                      tabindex="-1"
-                    />
+                    >
+                      <path
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M NaN,NaN
+    A 44.800000000000004,44.800000000000004,0,
+    0,0,
+    NaN,NaN
+  L NaN,NaN
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            NaN,NaN Z"
+                        fill="#e0e0e0"
+                        name="total"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
                   </g>
                   <text
                     class="recharts-text recharts-label"
@@ -92,7 +124,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      …
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartWithMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartWithMetrics.stories.storyshot
@@ -15,13 +15,13 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              Memory Usage
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            Progress so far
+            2.00 / 8.00 GB
           </p>
         </div>
         <div
@@ -74,10 +74,6 @@
                       class="recharts-layer recharts-pie-sector"
                       tabindex="-1"
                     />
-                    <g
-                      class="recharts-layer recharts-pie-sector"
-                      tabindex="-1"
-                    />
                   </g>
                   <text
                     class="recharts-text recharts-label"
@@ -92,7 +88,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      25.0 %
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusEmpty.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusEmpty.stories.storyshot
@@ -15,13 +15,13 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              Nodes
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            Progress so far
+            0 / 0 Ready
           </p>
         </div>
         <div
@@ -92,7 +92,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      0 %
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusLoading.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusLoading.stories.storyshot
@@ -1,0 +1,62 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-cmkit5-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-qrw4x1"
+      >
+        <div
+          class="MuiBox-root css-1sl8dhm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+            >
+              Nodes
+            </p>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+          />
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="MuiBox-root css-2esbmj"
+          >
+            <div
+              class="MuiBox-root css-5cned0"
+            >
+              <span
+                class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-wdedfu-MuiCircularProgress-root"
+                role="progressbar"
+                style="width: 40px; height: 40px;"
+                title="Loading data for "
+              >
+                <svg
+                  class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="20.2"
+                    stroke-width="3.6"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusWithMixedStates.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusWithMixedStates.stories.storyshot
@@ -15,13 +15,13 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              Nodes
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            Progress so far
+            2 / 3 Ready
           </p>
         </div>
         <div
@@ -92,7 +92,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      66.7 %
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusEmpty.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusEmpty.stories.storyshot
@@ -15,13 +15,13 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              Pods
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            Progress so far
+            0 / 0 Requested
           </p>
         </div>
         <div
@@ -92,7 +92,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      0 %
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusLoading.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusLoading.stories.storyshot
@@ -1,0 +1,62 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-cmkit5-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-qrw4x1"
+      >
+        <div
+          class="MuiBox-root css-1sl8dhm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+            >
+              Pods
+            </p>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+          />
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="MuiBox-root css-2esbmj"
+          >
+            <div
+              class="MuiBox-root css-5cned0"
+            >
+              <span
+                class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-wdedfu-MuiCircularProgress-root"
+                role="progressbar"
+                style="width: 40px; height: 40px;"
+                title="Loading data for "
+              >
+                <svg
+                  class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="20.2"
+                    stroke-width="3.6"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusWithMixedStates.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusWithMixedStates.stories.storyshot
@@ -15,13 +15,13 @@
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
             >
-              My chart
+              Pods
             </p>
           </div>
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            Progress so far
+            2 / 3 Requested
           </p>
         </div>
         <div
@@ -92,7 +92,7 @@
                       dy="0.355em"
                       x="61"
                     >
-                      10%
+                      66.7 %
                     </tspan>
                   </text>
                 </g>

--- a/frontend/src/components/cluster/Charts/index.ts
+++ b/frontend/src/components/cluster/Charts/index.ts
@@ -1,0 +1,4 @@
+import { CpuCircularChart, MemoryCircularChart } from './ResourceCharts';
+import { NodesStatusCircleChart, PodsStatusCircleChart } from './StatusCharts';
+
+export { MemoryCircularChart, CpuCircularChart, PodsStatusCircleChart, NodesStatusCircleChart };

--- a/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
@@ -91,7 +91,7 @@
                                 <desc />
                                 <defs>
                                   <clippath
-                                    id="recharts1-clip"
+                                    id="recharts-id"
                                   >
                                     <rect
                                       height="102"
@@ -191,7 +191,7 @@
                                 <desc />
                                 <defs>
                                   <clippath
-                                    id="recharts3-clip"
+                                    id="recharts-id"
                                   >
                                     <rect
                                       height="102"
@@ -293,7 +293,7 @@
                                 <desc />
                                 <defs>
                                   <clippath
-                                    id="recharts5-clip"
+                                    id="recharts-id"
                                   >
                                     <rect
                                       height="102"
@@ -399,7 +399,7 @@
                                 <desc />
                                 <defs>
                                   <clippath
-                                    id="recharts7-clip"
+                                    id="recharts-id"
                                   >
                                     <rect
                                       height="102"

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent100.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent100.stories.storyshot
@@ -27,7 +27,7 @@
           <desc />
           <defs>
             <clippath
-              id="recharts13-clip"
+              id="recharts-id"
             >
               <rect
                 height="150"

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent50.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.Percent50.stories.storyshot
@@ -27,7 +27,7 @@
           <desc />
           <defs>
             <clippath
-              id="recharts15-clip"
+              id="recharts-id"
             >
               <rect
                 height="150"

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -74,9 +74,14 @@ function replaceUseId(node: any) {
   const attributesToReplace = ['id', 'for', 'aria-described', 'aria-labelledby', 'aria-controls'];
   if (node.nodeType === Node.ELEMENT_NODE) {
     for (const attr of node.attributes) {
-      if (attributesToReplace.includes(attr.name) && attr.value.includes(':')) {
-        // Update the attribute value here
-        node.setAttribute(attr.name, ':mock-test-id:');
+      if (attributesToReplace.includes(attr.name)) {
+        if (attr.value.includes(':')) {
+          // Handle React useId generated IDs
+          node.setAttribute(attr.name, ':mock-test-id:');
+        } else if (attr.name === 'id' && attr.value.includes('recharts')) {
+          // Handle recharts generated IDs
+          node.setAttribute(attr.name, 'recharts-id');
+        }
       }
     }
   }


### PR DESCRIPTION
References #931 

Brief overview:
- `Charts.tsx` originally had 4 chart components, from which `CpuCircularChart` and `MemoryCirclularChart` components had similar props, while `PodStatusCircularChart` and `NodeStatusCircularChart` had similar props.
- So, refactored chart.tsx into `ResourceCharts` and `StatusCharts`
- Created `.Stories.tsx` for both.
- Created index file and updated imports (if any).

@illume PR is currently ready for review, needed your opinion weather we should have done this separation of files or not? 
IMO it was too messy to deal this in single story file so refatrored a bit. Thanks !

Here's storybook video of current state:
[Screencast from 2025-01-31 23-57-28.webm](https://github.com/user-attachments/assets/b1e2f548-17e0-4ea9-87fc-bff2c9a47998)
