### PR TITLE
frontend: Add clusterChooser componnent stories

### DIFF
--- a/frontend/src/components/cluster/ClusterChooser.stories.tsx
+++ b/frontend/src/components/cluster/ClusterChooser.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, StoryFn } from '@storybook/react';
+import ClusterChooser from './ClusterChooser';
+
+export default {
+  title: 'cluster/ClusterChooser',
+  component: ClusterChooser,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A button component for selecting clusters. Shows the current cluster name and handles click events.',
+      },
+    },
+  },
+  argTypes: {
+    cluster: {
+      control: 'text',
+      description: 'The name of the current cluster',
+    },
+    clickHandler: {
+      action: 'clicked',
+      description: 'Callback fired when the button is clicked',
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = args => {
+  const defaultProps = {
+    clickHandler: () => {},
+    ...args,
+  };
+  return <ClusterChooser {...defaultProps} />;
+};
+
+export const Normal = Template.bind({});
+Normal.args = {
+  cluster: 'my-cluster',
+};
+
+export const LongClusterName = Template.bind({});
+LongClusterName.args = {
+  cluster: 'very-long-kubernetes-cluster-name-that-should-be-truncated',
+};
+
+export const NoCluster = Template.bind({});
+NoCluster.args = {
+  cluster: undefined,
+};
+
+export const SpecialCharacters = Template.bind({});
+SpecialCharacters.args = {
+  cluster: 'test-cluster!@#$%^&*()',
+};

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooser.LongClusterName.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooser.LongClusterName.stories.storyshot
@@ -1,0 +1,19 @@
+<body>
+  <div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-tsm8af-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="css-k5l2zq"
+        title="very-long-kubernetes-cluster-name-that-should-be-truncated"
+      >
+        Cluster: very-long-kubernetes-cluster-name-that-should-be-truncated
+      </span>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooser.NoCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooser.NoCluster.stories.storyshot
@@ -1,0 +1,18 @@
+<body>
+  <div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-tsm8af-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="css-k5l2zq"
+      >
+        Cluster: {{cluster}}
+      </span>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooser.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooser.Normal.stories.storyshot
@@ -1,0 +1,19 @@
+<body>
+  <div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-tsm8af-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="css-k5l2zq"
+        title="my-cluster"
+      >
+        Cluster: my-cluster
+      </span>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooser.SpecialCharacters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooser.SpecialCharacters.stories.storyshot
@@ -1,0 +1,19 @@
+<body>
+  <div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-tsm8af-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="css-k5l2zq"
+        title="test-cluster!@#$%^&*()"
+      >
+        Cluster: test-cluster!@#$%^&*()
+      </span>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>


### PR DESCRIPTION
References #931

Added `clusterChooser` components stories.

Here's storybook video of current state:
[Screencast from 2025-02-01 03-55-16.webm](https://github.com/user-attachments/assets/2cb22695-0d97-4878-83e3-f110ed5408c8)