### PR TITLE
frontend: OauthPopup: fixed deprecated type

### DIFF
--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -1,5 +1,5 @@
 import Button from '@mui/material/Button';
-import React, { ReactChild } from 'react';
+import React, { ReactNode } from 'react';
 
 interface OauthPopupProps {
   width?: number;
@@ -8,7 +8,7 @@ interface OauthPopupProps {
   title?: string;
   onClose?: () => any;
   onCode: (params: any) => any;
-  children?: ReactChild;
+  children?: ReactNode;
   button: typeof Button;
 }
 


### PR DESCRIPTION
## Description

Fixed deprecated type `ReactChild` to `ReactNode`

## Screenshots of tests passing 

All tests are passing correctly 

![Screenshot from 2025-02-02 14-08-10](https://github.com/user-attachments/assets/8266f1fa-24a5-40a6-8b3c-8cc9dbbc506e)
