### PR TITLE
frontend: e2e-tests for `react-hotkeys` dependency

### DIFF
--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -29,6 +29,24 @@ test('main page should have Network tab', async ({ page }) => {
   await headlampPage.hasNetworkTab();
 });
 
+test('main page should have global search', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+
+  await headlampPage.authenticate();
+  await headlampPage.hasGlobalSearch();
+});
+
+test('react-hotkey for global search', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+
+  await headlampPage.authenticate();
+  const globalSearch = await headlampPage.hasGlobalSearch();
+
+  await page.keyboard.press('/');
+
+  await expect(globalSearch).toBeFocused();
+});
+
 test('service page should have headlamp service', async ({ page }) => {
   const headlampPage = new HeadlampPage(page);
   const servicesPage = new ServicesPage(page);

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -48,6 +48,16 @@ export class HeadlampPage {
     expect(await networkTab.textContent()).toBe('Security');
   }
 
+  async hasGlobalSearch() {
+    const globalSearch = this.page.getByPlaceholder('Search');
+
+    await expect(globalSearch).toBeVisible();
+    await expect(globalSearch).toHaveValue('');
+    await expect(globalSearch).not.toBeFocused();
+
+    return globalSearch;
+  }
+
   async checkPageContent(text: string) {
     await this.page.waitForSelector(`:has-text("${text}")`);
     const pageContent = await this.page.content();

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { podsPage } from './podsPage';
 
@@ -38,4 +38,39 @@ test('multi tab create delete pod', async ({ browser }) => {
 
   await realtimeUpdate1.deletePod(name);
   await realtimeUpdate2.confirmPodDeletion(name);
+});
+
+test('react-hotkey for logs search', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.authenticate();
+
+  await new podsPage(page).navigateToPods();
+
+  const podsTable = page.getByRole('table');
+  await expect(podsTable).toBeVisible();
+
+  const podLink = podsTable
+    .locator('tbody')
+    .nth(0)
+    .locator('tr')
+    .nth(0)
+    .locator('td')
+    .nth(1)
+    .locator('a');
+  const podName = await podLink.textContent();
+  await podLink.click();
+
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText(`Pod: ${podName}`);
+
+  const showLogsButton = page.getByRole('button', { name: 'Show Logs' });
+  await showLogsButton.click();
+
+  const terminal = page.locator('#xterm-container');
+  await expect(terminal).toBeVisible();
+
+  await page.keyboard.press('Control+Shift+F');
+
+  const searchInput = page.getByRole('textbox', { name: 'Find' });
+  await expect(searchInput).toBeVisible();
+  await expect(searchInput).toBeFocused();
 });


### PR DESCRIPTION
Fixes #2380 

https://github.com/user-attachments/assets/9b79483d-0308-4394-94f3-793620ae66d7

We are using `react-hotkeys` in one more place over [here](https://github.com/headlamp-k8s/headlamp/blob/f979bf5e11680455aaddf86d51d34623b2a29ee7/frontend/src/components/cluster/Chooser.tsx#L55) for multi-cluster search but before adding the test for that, we need to do #2460. 

Working on fixing that as well. So marking this as a draft for now.