### PR TITLE
Docs: Fix contributing doc test and formatting instruction

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,9 +53,8 @@ Follow these steps when submitting a PR to ensure it meets the project’s stand
 
 ### 1. Run Tests and Format Your Code
 
-Navigate to the `frontend` folder and run the following commands:
+Run the following commands from your project directory:
 
-- `cd frontend`
 - `make frontend-test` - Run the test suite
 - `make frontend-lint` - Format your code to match the project
 


### PR DESCRIPTION
Fixes #2833

`Makefile` is present at root level of the project that is having PHONY for frontend lint and test commands also.

```
f@f:~/w/oss/headlamp$ make frontend-lint
cd frontend && npm run lint -- --max-warnings 0 && npm run format-check

> headlamp@0.1.0 lint
> eslint --cache -c package.json --ext .js,.ts,.tsx src/ ../app/electron ../plugins/headlamp-plugin --ignore-pattern ../plugins/headlamp-plugin/template --ignore-pattern ../plugins/headlamp-plugin/lib/ --max-warnings 0

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=4.7.4 <5.6.0

YOUR TYPESCRIPT VERSION: 5.6.2

Please only submit bug reports when using the officially supported version.

=============

> headlamp@0.1.0 format-check
> prettier --config package.json --check --cache src ../app/electron ../app/tsconfig.json ../app/scripts ../plugins/headlamp-plugin/bin ../plugins/headlamp-plugin/config ../plugins/headlamp-plugin/template ../plugins/headlamp-plugin/test*.js ../plugins/headlamp-plugin/*.json ../plugins/headlamp-plugin/*.js

Checking formatting...
All matched files use Prettier code style!
f@f:~/w/oss/headlamp$ 
```