### PR TITLE
portforward: Fix recursive loading

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -140,7 +140,16 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		p.Port = strconv.Itoa(freePort)
 	}
 
-	kContext, err := kubeConfigStore.GetContext(p.Cluster)
+	// Get user ID from header if present
+	userID := r.Header.Get("X-HEADLAMP-USER-ID")
+
+	// If user ID is present, append it to cluster name
+	clusterName := p.Cluster
+	if userID != "" {
+		clusterName = p.Cluster + userID
+	}
+
+	kContext, err := kubeConfigStore.GetContext(clusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"cluster": p.Cluster},
 			err, "getting kubeconfig context")
@@ -319,7 +328,16 @@ func StopOrDeletePortForward(cache cache.Cache[interface{}], w http.ResponseWrit
 		return
 	}
 
-	err = stopOrDeletePortForward(cache, p.Cluster, p.ID, p.StopOrDelete)
+	// Get user ID from header if present
+	userID := r.Header.Get("X-HEADLAMP-USER-ID")
+
+	// If user ID is present, append it to cluster name
+	clusterName := p.Cluster
+	if userID != "" {
+		clusterName = p.Cluster + userID
+	}
+
+	err = stopOrDeletePortForward(cache, clusterName, p.ID, p.StopOrDelete)
 	if err == nil {
 		if _, err := w.Write([]byte("stopped")); err != nil {
 			logger.Log(logger.LevelError, nil, err, "writing response")
@@ -342,7 +360,16 @@ func GetPortForwards(cache cache.Cache[interface{}], w http.ResponseWriter, r *h
 		return
 	}
 
-	ports := getPortForwardList(cache, cluster)
+	// Get user ID from header if present
+	userID := r.Header.Get("X-HEADLAMP-USER-ID")
+
+	// If user ID is present, append it to cluster name
+	clusterName := cluster
+	if userID != "" {
+		clusterName = cluster + userID
+	}
+
+	ports := getPortForwardList(cache, clusterName)
 
 	w.Header().Set("Content-Type", "application/json")
 
@@ -372,7 +399,16 @@ func GetPortForwardByID(cache cache.Cache[interface{}], w http.ResponseWriter, r
 		return
 	}
 
-	p, err := getPortForwardByID(cache, cluster, id)
+	// Get user ID from header if present
+	userID := r.Header.Get("X-HEADLAMP-USER-ID")
+
+	// If user ID is present, append it to cluster name
+	clusterName := cluster
+	if userID != "" {
+		clusterName = cluster + userID
+	}
+
+	p, err := getPortForwardByID(cache, clusterName, id)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting portforward by id")
 		http.Error(w, "no portforward running with id "+id, http.StatusNotFound)

--- a/frontend/src/lib/k8s/api/v1/portForward.ts
+++ b/frontend/src/lib/k8s/api/v1/portForward.ts
@@ -1,4 +1,5 @@
 import helpers from '../../../../helpers';
+import { findKubeconfigByClusterName, getUserIdFromLocalStorage } from '../../../../stateless';
 import { getToken } from '../../../auth';
 import { JSON_HEADERS } from './constants';
 
@@ -45,7 +46,7 @@ export interface PortForwardRequest {
  * @returns The response from the API.
  * @throws {Error} if the request fails.
  */
-export function startPortForward(
+export async function startPortForward(
   cluster: string,
   namespace: string,
   podname: string,
@@ -56,6 +57,17 @@ export function startPortForward(
   address: string = '',
   id: string = ''
 ): Promise<PortForward> {
+  const kubeconfig = await findKubeconfigByClusterName(cluster);
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${getToken(cluster)}`,
+    ...JSON_HEADERS,
+  };
+
+  // This means cluster is dynamically configured.
+  if (kubeconfig !== null) {
+    headers['X-HEADLAMP-USER-ID'] = getUserIdFromLocalStorage();
+  }
+
   const request: PortForwardRequest = {
     cluster,
     namespace,
@@ -69,10 +81,7 @@ export function startPortForward(
   };
   return fetch(`${helpers.getAppUrl()}portforward`, {
     method: 'POST',
-    headers: new Headers({
-      Authorization: `Bearer ${getToken(cluster)}`,
-      ...JSON_HEADERS,
-    }),
+    headers: new Headers(headers),
     body: JSON.stringify(request),
   }).then((response: Response) => {
     return response.json().then(data => {
@@ -95,11 +104,21 @@ export function startPortForward(
  * @returns The response from the API.
  * @throws {Error} if the request fails.
  */
-export function stopOrDeletePortForward(
+export async function stopOrDeletePortForward(
   cluster: string,
   id: string,
   stopOrDelete: boolean = true
 ): Promise<string> {
+  const kubeconfig = await findKubeconfigByClusterName(cluster);
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  };
+
+  // This means cluster is dynamically configured.
+  if (kubeconfig !== null) {
+    headers['X-HEADLAMP-USER-ID'] = getUserIdFromLocalStorage();
+  }
+
   return fetch(`${helpers.getAppUrl()}portforward`, {
     method: 'DELETE',
     body: JSON.stringify({
@@ -126,8 +145,16 @@ export function stopOrDeletePortForward(
  *
  * @returns the list of port forwards for the cluster.
  */
-export function listPortForward(cluster: string): Promise<PortForward[]> {
-  return fetch(`${helpers.getAppUrl()}portforward/list?cluster=${cluster}`).then(response =>
-    response.json()
-  );
+export async function listPortForward(cluster: string): Promise<PortForward[]> {
+  const kubeconfig = await findKubeconfigByClusterName(cluster);
+  const headers: HeadersInit = {};
+
+  // This means cluster is dynamically configured.
+  if (kubeconfig !== null) {
+    headers['X-HEADLAMP-USER-ID'] = getUserIdFromLocalStorage();
+  }
+
+  return fetch(`${helpers.getAppUrl()}portforward/list?cluster=${cluster}`, {
+    headers: new Headers(headers),
+  }).then(response => response.json());
 }


### PR DESCRIPTION
This change modifies both frontend and backend port forwarding code to properly handle dynamic clusters by passing the user ID through a header instead of modifying cluster names directly. The frontend adds the header for dynamic clusters, and the backend appends the user ID to cluster names when the header is present.

Fixes: #1834, #2510

### Testing

- Run backend `go run ./cmd -dev -enable-dynamic-clusters`
- Run frontend `npm start`
- Run app `npm run dev-only-app`
- Have a cluster in kubeconfig.
- Load another cluster using add cluster button
- Create deploy for testing
```bash
echo 'apiVersion: apps/v1
kind: Deployment
metadata:
  name: debug-deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: debug
  template:
    metadata:
      labels:
        app: debug
    spec:
      containers:
      - name: debug
        image: nginxdemos/hello
        ports:
        - containerPort: 80' | kubectl apply -f -
 ```
- Go to pod and try port forward 