### PR TITLE
frontend: app: Pass backendToken via IPC

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -48,9 +48,6 @@ const startUrl = (
     pathname: frontendPath,
     protocol: 'file:',
     slashes: true,
-    query: {
-      backendToken: backendToken,
-    },
   })
 )
   // Windows paths use backslashes and for consistency we want to use forward slashes.
@@ -1198,6 +1195,10 @@ function startElecron() {
       if (!!newLocale && i18n.language !== newLocale) {
         i18n.changeLanguage(newLocale);
       }
+    });
+
+    ipcMain.on('request-backend-token', () => {
+      mainWindow?.webContents.send('backend-token', backendToken);
     });
 
     /**

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'pluginsLoaded',
       'run-command',
       'plugin-manager',
+      'request-backend-token',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);
@@ -27,6 +28,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'command-stderr',
       'command-exit',
       'plugin-manager',
+      'backend-token',
     ];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -2,11 +2,16 @@ import { GlobalStyles } from '@mui/material';
 import { SnackbarProvider } from 'notistack';
 import React from 'react';
 import { BrowserRouter, HashRouter } from 'react-router-dom';
-import helpers from '../../helpers';
+import helpers, { setBackendToken } from '../../helpers';
 import Plugins from '../../plugin/Plugins';
 import ReleaseNotes from '../common/ReleaseNotes/ReleaseNotes';
 import Layout from './Layout';
 import { PreviousRouteProvider } from './RouteSwitcher';
+
+window.desktopApi?.send('request-backend-token');
+window.desktopApi?.receive('backend-token', (token: string) => {
+  setBackendToken(token);
+});
 
 export default function AppContainer() {
   const Router = ({ children }: React.PropsWithChildren<{}>) =>

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -362,14 +362,17 @@ export function getWebsocketMultiplexerEnabled(): boolean {
 
 /**
  * The backend token to use when making API calls from Headlamp when running as an app.
- * The app opens the index.html?backendToken=... and passes the token to the frontend
- * in this way. The token is then used in the getHeadlampAPIHeaders function below.
+ * The token is requested from the main process via IPC once the renderer is ready,
+ * and stored for use in the getHeadlampAPIHeaders function below.
  *
- * The app also passes the token to the headlamp-server via HEADLAMP_BACKEND_TOKEN env var.
+ * The app also sets HEADLAMP_BACKEND_TOKEN in the headlamp-server environment,
+ * which the server checks to validate requests containing this same token.
  */
-const backendToken =
-  import.meta.env.REACT_APP_HEADLAMP_BACKEND_TOKEN ||
-  new URLSearchParams(window.location.search).get('backendToken');
+let backendToken: string | null = null;
+
+export function setBackendToken(token: string | null) {
+  backendToken = import.meta.env.REACT_APP_HEADLAMP_BACKEND_TOKEN || token;
+}
 
 /**
  * Returns headers for making API calls to the headlamp-server backend.


### PR DESCRIPTION
This change removes the backendToken from the URL and instead passes it via IPC. This ensures that restarting the app does not create new instances with unique URLs.

Fixes: #2846 

### Testing
- [X] Expose parseKubeConfig at the bottom of `clusterApi.ts`:
```ts
(window as any).parseKubeConfig = parseKubeConfig
```
- [X] Start Headlamp using `npm run dev` and proxy fetch to print a stack trace with headers for each call by entering the following in the console:
```ts
window.fetch = new Proxy(window.fetch, {
  apply: (target, thisArg, args) => {
    console.groupCollapsed("+++ Intercepted Network Request");
    console.log("URL:", args[0]);
    console.log("Options:", args[1]);
    console.trace("+++ Request Stack Trace:");
    console.groupEnd();
    return target.apply(thisArg, args);
  }
});
```
- [X] Manually call parseKubeConfig by entering the following in the console:
```ts
window.parseKubeConfig({ kubeconfig: "test-kubeconfig-data" });
```
- [X] Inspect the call headers and ensure that backendToken is passed as a header with the key `X-HEADLAMP_BACKEND-TOKEN`