### PR TITLE
frontend: EditorDialog: Handle null YAML in docs tab

### DIFF
--- a/frontend/src/components/common/Resource/DocsViewer.tsx
+++ b/frontend/src/components/common/Resource/DocsViewer.tsx
@@ -98,6 +98,8 @@ function DocsViewer(props: DocsViewerProps) {
     <>
       {docsLoading ? (
         <Loader title={t('Loading documentation')} />
+      ) : docs.length === 0 ? (
+        <Empty>{t('No documentation available.')}</Empty>
       ) : (
         docs.map((docSpec: any, idx: number) => {
           if (!docSpec.error && !docSpec.data) {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -234,6 +234,7 @@ export default function EditorDialog(props: EditorDialogProps) {
       res.format = 'yaml';
       try {
         res.obj = yaml.loadAll(code) as KubeObjectInterface[];
+        res.obj = res.obj.filter(obj => !!obj);
         return res;
       } catch (e) {
         res.error = new Error((e as Error).message || t('Invalid YAML'));

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -204,7 +204,17 @@
           >
             <div
               class="MuiBox-root css-94bk7g"
-            />
+            >
+              <div
+                class="MuiBox-root css-19midj6"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                >
+                  No documentation available.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -240,7 +240,17 @@
           >
             <div
               class="MuiBox-root css-94bk7g"
-            />
+            >
+              <div
+                class="MuiBox-root css-19midj6"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                >
+                  No documentation available.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -192,6 +192,7 @@
   "Error deleting {{ itemsLength }} items.": "Fehler beim Löschen von {{ itemsLength }} Elementen.",
   "Delete items": "Elemente löschen",
   "Loading documentation": "Dokumentation laden",
+  "No documentation available.": "",
   "No documentation for type {{ docsType }}.": "Keine Dokumentation für Typ {{ docsType }}.",
   "Showing documentation for: {{ docsType }}": "Zeige die Dokumentation für: {{ docsType }}",
   "Applying changes to {{ itemName }}…": "Wende Änderungen an {{ itemName }} an…",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -192,6 +192,7 @@
   "Error deleting {{ itemsLength }} items.": "Error deleting {{ itemsLength }} items.",
   "Delete items": "Delete items",
   "Loading documentation": "Loading documentation",
+  "No documentation available.": "No documentation available.",
   "No documentation for type {{ docsType }}.": "No documentation for type {{ docsType }}.",
   "Showing documentation for: {{ docsType }}": "Showing documentation for: {{ docsType }}",
   "Applying changes to {{ itemName }}…": "Applying changes to {{ itemName }}…",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -193,6 +193,7 @@
   "Error deleting {{ itemsLength }} items.": "",
   "Delete items": "",
   "Loading documentation": "Cargando documentación",
+  "No documentation available.": "",
   "No documentation for type {{ docsType }}.": "Sin documentación para el tipo {{ docsType }}.",
   "Showing documentation for: {{ docsType }}": "Mostrando documentación para: {{ docsType }}",
   "Applying changes to {{ itemName }}…": "Aplicando cambios a {{ itemName }}…",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -193,6 +193,7 @@
   "Error deleting {{ itemsLength }} items.": "",
   "Delete items": "",
   "Loading documentation": "Chargement de la documentation",
+  "No documentation available.": "",
   "No documentation for type {{ docsType }}.": "Pas de documentation pour le type {{ docsType }}.",
   "Showing documentation for: {{ docsType }}": "Afficher la documentation pour : {{ docsType }}",
   "Applying changes to {{ itemName }}…": "Appliquer les changements à {{ itemName }}…",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -193,6 +193,7 @@
   "Error deleting {{ itemsLength }} items.": "",
   "Delete items": "",
   "Loading documentation": "A carregar documentação",
+  "No documentation available.": "",
   "No documentation for type {{ docsType }}.": "Sem documentação para o tipo {{ docsType }}.",
   "Showing documentation for: {{ docsType }}": "A mostrar documentação para: {{ docsType }}",
   "Applying changes to {{ itemName }}…": "A aplicar modificações a {{ itemName }}…",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -191,6 +191,7 @@
   "Error deleting {{ itemsLength }} items.": "刪除 {{ itemsLength }} 個項目時出錯。",
   "Delete items": "刪除項目",
   "Loading documentation": "讀取文件",
+  "No documentation available.": "",
   "No documentation for type {{ docsType }}.": "類型 {{ docsType }} 沒有文件。",
   "Showing documentation for: {{ docsType }}": "顯示文件：{{ docsType }}",
   "Applying changes to {{ itemName }}…": "正在應用更改到 {{ itemName }}…",


### PR DESCRIPTION
This change gracefully handles comments from the editor dialog in the documentation tab, preventing the app from crashing.

Fixes: #2854 

### Testing
- [X] Open a cluster in Headlamp and click the 'Create' button in the sidebar
- [X] Click on the 'Documentation' tab with the default comment
- [X] Ensure the app does not crash and that the tab displays "No documentation available."

![image](https://github.com/user-attachments/assets/b1ecba3c-2deb-414f-8fc6-e24d3ecba010)