### PR TITLE
backend: headlamp.go: fix incorrect implementation of JWT token expir…

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -723,7 +723,7 @@ func parseClusterAndToken(r *http.Request) (string, string) {
 }
 
 func decodePayload(payload string) (map[string]interface{}, error) {
-	payloadBytes, err := base64.RawStdEncoding.DecodeString(payload)
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(payload)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -854,10 +854,19 @@ func TestParseClusterAndToken(t *testing.T) {
 
 func TestIsTokenAboutToExpire(t *testing.T) {
 	// Token that expires in 4 minutes
-	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MTIzNjE2MDB9.7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM" //nolint:gosec,lll
+	header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+	originalPayload := "eyJleHAiOjE2MTIzNjE2MDB9" //nolint:gosec
+	signature := ".7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM"
 
+	token := header + originalPayload + signature
 	result := isTokenAboutToExpire(token)
 	assert.True(t, result)
+
+	modifiedPayload := strings.Replace(originalPayload, "J", "-", 1)
+
+	token = header + modifiedPayload + signature
+	result = isTokenAboutToExpire(token)
+	assert.False(t, result, "Expected to return false when payload decoding fails due to URL-safe characters")
 }
 
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {


### PR DESCRIPTION
## Description 

replaces `RawStdEncoding` to `RawURLEncoding` this will fix the failure of JWT token containing character - or _,

fix #2481