### PR TITLE
frontend: headlamp-plugin: Update dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,7 @@
         "i18next-browser-languagedetector": "^8.0.0",
         "js-base64": "^3.7.2",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.1.0",
+        "jsonpath-plus": "^10.2.0",
         "lodash": "^4.17.21",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
@@ -1313,9 +1313,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -9576,9 +9576,9 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -9644,13 +9644,13 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
       "dependencies": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "js-base64": "^3.7.2",
     "js-yaml": "^4.1.0",
-    "jsonpath-plus": "^10.1.0",
+    "jsonpath-plus": "^10.2.0",
     "lodash": "^4.17.21",
     "material-react-table": "^2.13.3",
     "monaco-editor": "^0.52.0",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -106,7 +106,7 @@
         "jest-websocket-mock": "^2.5.0",
         "js-base64": "^3.7.2",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.1.0",
+        "jsonpath-plus": "^10.2.0",
         "lint-staged": "^10.5.4",
         "lodash": "^4.17.21",
         "material-react-table": "^2.13.3",
@@ -3966,9 +3966,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -19413,9 +19413,9 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -19494,13 +19494,13 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
       "dependencies": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -30321,9 +30321,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "engines": {
         "node": ">=18.17"
       }

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -11460,6 +11460,17 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
+    "node_modules/css-select/node_modules/nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/css-tree": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
@@ -21485,17 +21496,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.13",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
@@ -26771,11 +26771,14 @@
       }
     },
     "node_modules/react-scripts/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dependencies": {
-        "boolbase": "~1.0.0"
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/react-scripts/node_modules/pretty-format": {
@@ -27560,6 +27563,17 @@
         "domhandler": "^4.0.0",
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
+      }
+    },
+    "node_modules/renderkid/node_modules/nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/replace-ext": {
@@ -29321,6 +29335,17 @@
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/svgo/node_modules/nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/swc-loader": {

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -110,7 +110,7 @@
     "jest-websocket-mock": "^2.5.0",
     "js-base64": "^3.7.2",
     "js-yaml": "^4.1.0",
-    "jsonpath-plus": "^10.1.0",
+    "jsonpath-plus": "^10.2.0",
     "lint-staged": "^10.5.4",
     "lodash": "^4.17.21",
     "material-react-table": "^2.13.3",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -161,6 +161,7 @@
     "yargs": "^16.2.0"
   },
   "overrides": {
+    "nth-check": "2.0.1",
     "typescript": "5.6.2"
   },
   "files": [


### PR DESCRIPTION
These changes: 
- Updates jsonpath-plus to the desired 10.2.0 version
- Updates undici to the desired 6.21.1 version
- Overrides nth-check to the desired 2.0.1 version

### Testing
- [X] Run `make frontend-test` and ensure that all the tests pass