### PR TITLE
frontend: NavigationTabs: Move early return after all hooks to prevent a crash

### DIFF
--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -48,11 +48,6 @@ export default function NavigationTabs() {
   const isSmallSideBar = useMediaQuery(theme.breakpoints.only('sm'));
   const { t } = useTranslation();
 
-  // Always show the navigation tabs when the sidebar is the small version
-  if (!isSmallSideBar && (sidebar.isSidebarOpen || isMobile)) {
-    return null;
-  }
-
   let defaultIndex = null;
   const listItems = useSidebarItems(sidebar.selected.sidebar ?? undefined);
   let navigationItem = listItems.find(item => item.name === sidebar.selected.item);
@@ -62,6 +57,11 @@ export default function NavigationTabs() {
       return null;
     }
     navigationItem = parent;
+  }
+
+  // Always show the navigation tabs when the sidebar is the small version
+  if (!isSmallSideBar && (sidebar.isSidebarOpen || isMobile)) {
+    return null;
   }
 
   const subList = navigationItem.subList;

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -49,7 +49,9 @@ export default function NavigationTabs() {
   const { t } = useTranslation();
 
   let defaultIndex = null;
-  const listItems = useSidebarItems(sidebar.selected.sidebar ?? undefined);
+  const listItemsOriginal = useSidebarItems(sidebar.selected.sidebar ?? undefined);
+  // Making a copy because we're going to mutate it later in here
+  const listItems = structuredClone(listItemsOriginal);
   let navigationItem = listItems.find(item => item.name === sidebar.selected.item);
   if (!navigationItem) {
     const parent = findParentOfSubList(listItems, sidebar.selected.item);


### PR DESCRIPTION
Fixes regressions introduced in #2717

First is a page crash when sidebar is collapsed - early return in a react component before a hook was called caused a crash
Second is duplicated entries in NavigationTabs - mutation of the sidebar entries inside NavigationTabs was causing issues

How to test:
Open/close sidebar
Navigate around