### PR TITLE
headlamp-plugin: Add fuse.js dependency

### DIFF
--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -94,6 +94,7 @@
         "file-loader": "^6.2.0",
         "filemanager-webpack-plugin": "^7.0.0",
         "fs-extra": "^9.1.0",
+        "fuse.js": "^7.0.0",
         "https-browserify": "^1.0.0",
         "humanize-duration": "^3.27.2",
         "i18next": "^23.15.1",
@@ -14948,6 +14949,14 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -98,6 +98,7 @@
     "file-loader": "^6.2.0",
     "filemanager-webpack-plugin": "^7.0.0",
     "fs-extra": "^9.1.0",
+    "fuse.js": "^7.0.0",
     "https-browserify": "^1.0.0",
     "humanize-duration": "^3.27.2",
     "i18next": "^23.15.1",


### PR DESCRIPTION
To match frontend dependencies, and so
`npm run check-dependencies` passes again.


