### PR TITLE
docs: Change ingress.className on README to ingress.ingressClassName

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -171,7 +171,7 @@ config:
 | service.type | string | `"ClusterIP"` | Kubernetes service type |
 | service.port | int | `80` | Kubernetes service port |
 | ingress.enabled | bool | `false` | Enable ingress |
-| ingress.className | string | `""` | Ingress class name |
+| ingress.ingressClassName | string | `""` | Ingress class name |
 | ingress.annotations | object | `{}` | Ingress annotations (e.g., kubernetes.io/tls-acme: "true") |
 | ingress.labels | object | `{}` | Additional labels for the Ingress resource |
 | ingress.hosts | list | `[]` | Ingress hosts configuration |


### PR DESCRIPTION
This reflects the actual parameter name on `values.yaml`.

I was installing this chart today and was basing myself off of the ArtifactHub docs to enable the ingress, but I noticed the `ingress.ingressClassName` parameter was actually documented as `ingress.className`.

It's up to you folks whether to update this on the documentation or to change the actual parameter name on `values.yaml`. I'm available if you need any more input.