### PR TITLE
app: fix headless mode not running

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1398,9 +1398,14 @@ function attachServerEventHandlers(serverProcess: ChildProcessWithoutNullStreams
 }
 
 if (isHeadlessMode) {
-  serverProcess = startServer(['-html-static-dir', path.join(process.resourcesPath, './frontend')]);
-  attachServerEventHandlers(serverProcess);
-  shell.openExternal(`http://localhost:${defaultPort}`);
+  startServer(['-html-static-dir', path.join(process.resourcesPath, './frontend')]).then(
+    serverProcess => {
+      attachServerEventHandlers(serverProcess);
+
+      // Give 1s for backend to start
+      setTimeout(() => shell.openExternal(`http://localhost:${defaultPort}`), 1000);
+    }
+  );
 } else {
   startElecron();
 }


### PR DESCRIPTION
When I tried running both the version of headlamp in the Arch AUR (not official) and the AppImage in this repo I would get an error about a function not existing. This complete makes headlamp useless for my usecase in WSL2 (in one of the computers I tested).

This PR address these issues and performs the following changes:
## 1. Correctly uses promise when on headless mode

In https://github.com/headlamp-k8s/headlamp/blob/v0.28.1/app/electron/main.ts#L1413 , we are not awaiting the Promise returned on the previous line, so it caused the exception I first mentioned in the issue. It happened because `serverProcess` was `null` when reaching the `attachServerEventHandlers` function. Solved by chaining a `then` at the end of it

## 2. Create a temporary directory for the static assets

When using on Arch, after fixing the first exception, I got a permission denied with the AUR package. With the AppImage, it said the system was readonly. It tries to patch the baseURL in place, which is not possible for squashFS on AppImages.
The fix I provided creates a temporary folder in the system temp location, copies the assets there and uses that temporary directory as the new static assets directory, that is allowed to be written by the process

## 3. Add a timeout to starting the browser

I felt the need to add a timer to starting the frontend on the browser as it always opened before the backend was serving requests. This is just a simple timer before trying to open the browser with the link


----

Feel free to scrutinize my code as I am not a Go developer and also not very familiar with Electron

Fixes #2892 