### PR TITLE
frontend: global searchbar: Fix multiple clusterSettings items

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -199,9 +199,12 @@ export function GlobalSearchContent({
     () =>
       filteredRoutes
         .filter(([, route]) => route.name && !route.path.includes(':'))
-        .filter(([, route]) => {
+        .filter(([key, route]) => {
           const clusterRoute = route.useClusterURL ?? true;
-
+          // settingsCluster is an old route that is just a redirect and shouldn't be included in the search results
+          if (key === 'settingsCluster') {
+            return false;
+          }
           return clusterRoute ? selectedClusters.length > 0 : true;
         })
         .map(([name, route]) => ({


### PR DESCRIPTION
Fixes #2902 

Fixed by only displaying the `cluster settings` page once.