### PR TITLE
backend: Update golang@1.24 and golangci-lint@v1.64

### DIFF
--- a/.github/workflows/app-artifacts-linux.yml
+++ b/.github/workflows/app-artifacts-linux.yml
@@ -27,7 +27,7 @@ jobs:
         node-version: 20.x
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
-        go-version: '1.22.*'
+        go-version: '1.24.*'
     - name: App linux
       run: |
         make app-linux

--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -35,7 +35,7 @@ jobs:
           frontend/package-lock.json
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
-        go-version: '1.22.*'
+        go-version: '1.24.*'
         cache-dependency-path: |
           backend/go.sum
     - name: Dependencies

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -41,7 +41,7 @@ jobs:
           headlamp/frontend/package-lock.json
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
-        go-version: '1.22.*'
+        go-version: '1.24.*'
         cache-dependency-path: |
           headlamp/backend/go.sum
     - name: Dependencies

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -37,7 +37,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
-        go-version: '1.22.*'
+        go-version: '1.24.*'
     - name: App linux
       run: |
         make app-linux
@@ -54,7 +54,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
-        go-version: '1.22.*'
+        go-version: '1.24.*'
     - name: Dependencies
       uses: crazy-max/ghaction-chocolatey@e80bd39bb49cae70b67ea53d52d00833a7255c21 # v1.7.0
       with:
@@ -74,7 +74,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
-        go-version: '1.22.*'
+        go-version: '1.24.*'
     - name: Dependencies
       run: brew install make
     - name: App Mac

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -30,7 +30,7 @@ jobs:
     
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: '1.22.*'
+          go-version: '1.24.*'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -47,9 +47,9 @@ jobs:
           kubectl wait deployment -n headlamp headlamp --for condition=Available=True --timeout=30s    
 
       - name: setup and run golangci-lint 
-        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # 6.5.0
         with:
-          version: v1.54
+          version: v1.64
           working-directory: backend
           skip-cache: true
           args: --timeout 3m

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG IMAGE_BASE=alpine:3.20.4@sha256:780405de0f7cf99f985dd5a4f04dfc5aae71509d89505c1ba48a88d95a0ceb7f
 FROM ${IMAGE_BASE} as image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.22@sha256:0ca97f4ab335f4b284a5b8190980c7cdc21d320d529f2b643e8a8733a69bfb6b as backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.24@sha256:2b1cbf278ce05a2a310a3d695ebb176420117a8cfcfcc4e5e68a1bef5f6354da as backend-build
 
 WORKDIR /headlamp
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 all: backend frontend
 
 tools/golangci-lint: backend/go.mod backend/go.sum
-	GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54
+	GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64
 
 backend-lint: tools/golangci-lint
 	cd backend && ./tools/golangci-lint run

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - whitespace
     - wsl
   disable:
-    - exportloopref
     - gci
     - gochecknoglobals
     - godox

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -17,14 +17,11 @@ linters:
     - gofmt
     - gofumpt
     - goimports
-    - golint
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - govet
     - misspell
@@ -49,7 +46,7 @@ linters:
     - gci
     - gochecknoglobals
     - godox
-    - goerr113
+    - err113
     - goheader
     - gomodguard
     - nlreturn

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -243,6 +243,7 @@ func TestDynamicClusters(t *testing.T) {
 			handler := createHeadlampHandler(&c)
 
 			var resp *httptest.ResponseRecorder
+
 			for _, clusterReq := range tc.clusters {
 				r, err := getResponseFromRestrictedEndpoint(handler, "POST", "/cluster", clusterReq)
 				if err != nil {
@@ -261,6 +262,7 @@ func TestDynamicClusters(t *testing.T) {
 					}
 
 					configuredClusters := c.getClusters()
+
 					var cluster *Cluster
 
 					// Get cluster we created
@@ -287,11 +289,14 @@ func TestDynamicClusters(t *testing.T) {
 
 			if resp.Code == http.StatusCreated {
 				var clusterConfig clientConfig
+
 				err = json.Unmarshal(resp.Body.Bytes(), &clusterConfig)
 				if err != nil {
 					t.Fatal(err)
 				}
+
 				var config clientConfig
+
 				err = json.Unmarshal(configResp.Body.Bytes(), &config)
 				if err != nil {
 					t.Fatal(err)
@@ -361,6 +366,7 @@ func TestExternalProxy(t *testing.T) {
 	// Create a new server for testing
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
+
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
 			t.Fatal(err)
@@ -855,7 +861,7 @@ func TestParseClusterAndToken(t *testing.T) {
 func TestIsTokenAboutToExpire(t *testing.T) {
 	// Token that expires in 4 minutes
 	header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-	originalPayload := "eyJleHAiOjE2MTIzNjE2MDB9" //nolint:gosec
+	originalPayload := "eyJleHAiOjE2MTIzNjE2MDB9"
 	signature := ".7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM"
 
 	token := header + originalPayload + signature

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -128,6 +128,7 @@ func TestDialWebSocket(t *testing.T) {
 				return true // Allow all connections for testing
 			},
 		}
+
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			t.Logf("Upgrade error: %v", err)
@@ -141,6 +142,7 @@ func TestDialWebSocket(t *testing.T) {
 			if err != nil {
 				break
 			}
+
 			err = ws.WriteMessage(mt, message)
 			if err != nil {
 				break
@@ -235,6 +237,7 @@ func TestUpdateStatus(t *testing.T) {
 			conn.updateStatus(state, nil)
 		}(i)
 	}
+
 	wg.Wait()
 
 	// Verify final state is valid
@@ -312,6 +315,7 @@ func createTestWebSocketConn() (*websocket.Conn, *httptest.Server) {
 				return true
 			},
 		}
+
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -324,6 +328,7 @@ func createTestWebSocketConn() (*websocket.Conn, *httptest.Server) {
 			if err != nil {
 				break
 			}
+
 			err = ws.WriteMessage(messageType, message)
 			if err != nil {
 				break
@@ -428,6 +433,7 @@ func createMockKubeAPIServer() *httptest.Server {
 				return true
 			},
 		}
+
 		c, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -441,6 +447,7 @@ func createMockKubeAPIServer() *httptest.Server {
 			if err != nil {
 				break
 			}
+
 			if err := c.WriteMessage(websocket.TextMessage, msg); err != nil {
 				break
 			}
@@ -542,7 +549,6 @@ func TestEstablishClusterConnection(t *testing.T) {
 	assert.Nil(t, conn)
 }
 
-//nolint:funlen
 func TestReconnect(t *testing.T) {
 	store := kubeconfig.NewContextStore()
 	m := NewMultiplexer(store)
@@ -713,6 +719,7 @@ func TestReadClientMessage_InvalidMessage(t *testing.T) {
 			if err != nil {
 				return
 			}
+
 			err = ws.WriteMessage(messageType, p)
 			if err != nil {
 				return
@@ -851,7 +858,6 @@ func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 	<-done
 }
 
-//nolint:funlen
 func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
 	m := NewMultiplexer(kubeconfig.NewContextStore())
 

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -66,8 +66,6 @@ func (c *HeadlampConfig) setKeyInCache(key string, context kubeconfig.Context) e
 
 // Handles stateless cluster requests if kubeconfig is set and dynamic clusters are enabled.
 // It returns context key which is used to store the context in the cache.
-//
-//nolint:funlen
 func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) (string, error) {
 	var key string
 

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -90,7 +90,6 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 	}
 }
 
-//nolint:funlen
 func TestStatelessClusterApiRequest(t *testing.T) {
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
 	require.NoError(t, err)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/headlamp-k8s/headlamp/backend
 
-go 1.22.8
+go 1.24
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -193,8 +193,8 @@ func defaultPluginDir() string {
 	}
 
 	fileMode := 0o755
-	err = os.MkdirAll(pluginsConfigDir, fs.FileMode(fileMode))
 
+	err = os.MkdirAll(pluginsConfigDir, fs.FileMode(fileMode))
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "creating plugins directory")
 

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -35,10 +35,12 @@ func TestParse(t *testing.T) {
 	t.Run("from_env", func(t *testing.T) {
 		os.Setenv("HEADLAMP_CONFIG_OIDC_CLIENT_SECRET", "superSecretBotsStayAwayPlease")
 		defer os.Unsetenv("HEADLAMP_CONFIG_OIDC_CLIENT_SECRET")
+
 		args := []string{
 			"go run ./cmd", "-in-cluster",
 		}
 		conf, err := config.Parse(args)
+
 		require.NoError(t, err)
 		require.NotNil(t, conf)
 
@@ -48,10 +50,12 @@ func TestParse(t *testing.T) {
 	t.Run("both_args_and_env", func(t *testing.T) {
 		os.Setenv("HEADLAMP_CONFIG_PORT", "1234")
 		defer os.Unsetenv("HEADLAMP_CONFIG_PORT")
+
 		args := []string{
 			"go run ./cmd", "--port=9876",
 		}
 		conf, err := config.Parse(args)
+
 		require.NoError(t, err)
 		require.NotNil(t, conf)
 
@@ -64,6 +68,7 @@ func TestParse(t *testing.T) {
 			"go run ./cmd", "-oidc-client-id=noClient",
 		}
 		conf, err := config.Parse(args)
+
 		require.Error(t, err)
 		require.Nil(t, conf)
 
@@ -75,6 +80,7 @@ func TestParse(t *testing.T) {
 			"go run ./cmd", "--base-url=testingthis",
 		}
 		conf, err := config.Parse(args)
+
 		require.Error(t, err)
 		require.Nil(t, conf)
 
@@ -84,10 +90,12 @@ func TestParse(t *testing.T) {
 	t.Run("kubeconfig_from_default_env", func(t *testing.T) {
 		os.Setenv("KUBECONFIG", "~/.kube/test_config.yaml")
 		defer os.Unsetenv("KUBECONFIG")
+
 		args := []string{
 			"go run ./cmd",
 		}
 		conf, err := config.Parse(args)
+
 		require.NoError(t, err)
 		require.NotNil(t, conf)
 
@@ -99,6 +107,7 @@ func TestParse(t *testing.T) {
 			"go run ./cmd", "--enable-dynamic-clusters",
 		}
 		conf, err := config.Parse(args)
+
 		require.NoError(t, err)
 		require.NotNil(t, conf)
 

--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -137,8 +137,8 @@ func (h *Handler) ListRelease(w http.ResponseWriter, r *http.Request) {
 	res := ListReleaseResponse{
 		Releases: releases,
 	}
-	err = json.NewEncoder(w).Encode(res)
 
+	err = json.NewEncoder(w).Encode(res)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"request": "list_releases"},
 			err, "encoding response")
@@ -257,7 +257,6 @@ func (h *Handler) GetReleaseHistory(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	err = json.NewEncoder(w).Encode(resp)
-
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"request": "get_release_history", "releaseName": req.Name},
 			err, "encoding response")
@@ -319,7 +318,6 @@ func (h *Handler) UninstallRelease(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	err = json.NewEncoder(w).Encode(response)
-
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"request": "uninstall_release", "releaseName": req.Name},
 			err, "encoding response")
@@ -592,7 +590,6 @@ func (h *Handler) installRelease(req InstallRequest) {
 	}
 
 	err = yaml.Unmarshal(decodedBytes, &values)
-
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"chart": req.Chart, "releaseName": req.Name},
 			err, "unmarshalling values")

--- a/backend/pkg/kubeconfig/file.go
+++ b/backend/pkg/kubeconfig/file.go
@@ -18,10 +18,9 @@ func WriteToFile(config clientcmdapi.Config, path string) error {
 	if _, err := os.Stat(configFile); err == nil {
 		// if it exists, write a new config file with a timestamp
 		fileName := "config_" + now + ".yaml"
-
 		newKubeConfigFile := filepath.Join(path, fileName)
-		err = clientcmd.WriteToFile(config, newKubeConfigFile)
 
+		err = clientcmd.WriteToFile(config, newKubeConfigFile)
 		if err != nil {
 			return errors.Wrap(err, "failed to write new kubeconfig file")
 		}

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -71,10 +71,12 @@ func periodicallyWatchSubfolders(watcher *fsnotify.Watcher, path string, interva
 
 					return err
 				}
+
 				for _, entry := range entries {
 					watcher.Events <- fsnotify.Event{Name: filepath.Join(path, entry.Name()), Op: fsnotify.Create}
 				}
 			}
+
 			return nil
 		})
 	}

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWatch(t *testing.T) { //nolint:funlen
+func TestWatch(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary directory if it doesn't exist

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -212,7 +212,7 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 	stopChan, readyChan := make(chan struct{}), make(chan struct{}, 1)
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 
-	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf(p.Port + ":" + p.TargetPort)},
+	forwarder, err := portforward.New(dialer, []string{p.Port + ":" + p.TargetPort},
 		stopChan, readyChan, out, errOut)
 	if err != nil {
 		return fmt.Errorf("portforward request: failed to create portforward: %v", err)

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -15,7 +15,7 @@ See [platforms](../platforms.md) to find out which browsers, OS and flavors of K
 These are the required dependencies to get started. Other dependencies are pulled in by the golang or node package managers (see frontend/package.json, app/package.json, backend/go.mod and Dockerfile).
 
 - [Node.js](https://nodejs.org/en/download/) Latest LTS (20.11.1 at time of writing). Many of us use [nvm](https://github.com/nvm-sh/nvm) for installing multiple versions of Node.
-- [Go](https://go.dev/doc/install), (1.22 at time of writing)
+- [Go](https://go.dev/doc/install), (1.24 at time of writing)
 - [Make](https://www.gnu.org/software/make/) (GNU). Often installed by default. On Windows this can be installed with the "chocolatey" package manager that is installed with node.
 - [Kubernetes](https://kubernetes.io/), we suggest [minikube](https://minikube.sigs.k8s.io/docs/) as one good K8s installation for testing locally. Other k8s installations are supported (see [platforms](../platforms.md).
 


### PR DESCRIPTION
- **backend/.golangci.yml: Remove deprecated linters**
- **backend: Upgrade golangci-lint@v1.64 and fix formatting**
- **github: Dockerfile: Update golang to 1.24**


### Testing

- `make backend-lint` passing locally.
- smoke testing of headlamp app locally
- all tests pass in CI


We need a newer golang for some security fixes and also for this PR:
- https://github.com/headlamp-k8s/headlamp/issues/2892
