### PR TITLE
frontend: Fix test warnings and misconfiguration

### DIFF
--- a/frontend/src/components/App/Notifications/Notifications.stories.tsx
+++ b/frontend/src/components/App/Notifications/Notifications.stories.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
@@ -45,6 +46,23 @@ export default {
       </MemoryRouter>
     ),
   ],
+  parameters: {
+    msw: {
+      handlers: {
+        storyBase: [
+          http.get('http://localhost:4466/clusters/staging-cluster/api/v1/events', () =>
+            HttpResponse.error()
+          ),
+          http.get('http://localhost:4466/clusters/dev-cluster/api/v1/events', () =>
+            HttpResponse.error()
+          ),
+          http.get('http://localhost:4466/clusters/prod-cluster/api/v1/events', () =>
+            HttpResponse.error()
+          ),
+        ],
+      },
+    },
+  },
 } as Meta;
 
 const Template: StoryFn = () => <Notifications />;

--- a/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
@@ -25,6 +25,9 @@ export default {
           http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
             HttpResponse.json({})
           ),
+          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/grpcroutes', () =>
+            HttpResponse.error()
+          ),
           http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
             HttpResponse.error()
           ),

--- a/frontend/src/components/gateway/GRPCRouteList.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteList.stories.tsx
@@ -32,6 +32,9 @@ export default {
           http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
             HttpResponse.error()
           ),
+          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/grpcroutes', () =>
+            HttpResponse.error()
+          ),
         ],
       },
     },

--- a/frontend/src/components/gateway/HTTPRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/HTTPRouteDetails.stories.tsx
@@ -25,7 +25,7 @@ export default {
           http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes', () =>
             HttpResponse.json({})
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes', () =>
+          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/httproutes', () =>
             HttpResponse.error()
           ),
           http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>

--- a/frontend/src/components/gateway/HTTPRouteList.stories.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.stories.tsx
@@ -29,7 +29,7 @@ export default {
               items: [DEFAULT_HTTP_ROUTE],
             })
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes', () =>
+          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/httproutes', () =>
             HttpResponse.error()
           ),
         ],

--- a/frontend/src/plugin/pluginLib.test.ts
+++ b/frontend/src/plugin/pluginLib.test.ts
@@ -2,7 +2,7 @@ import './index'; // this import will init window.pluginLib
 import { describe, expect, it } from 'vitest';
 
 describe('pluginLib variable', () => {
-  it('should stay the same for plugin compatibility', () => {
-    expect(window.pluginLib).toMatchFileSnapshot('__snapshots__/pluginLib.snapshot');
+  it('should stay the same for plugin compatibility', async () => {
+    await expect(window.pluginLib).toMatchFileSnapshot('__snapshots__/pluginLib.snapshot');
   });
 });

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -191,7 +191,7 @@ describe('Storybook Tests', () => {
 
           document.body.removeAttribute('style');
 
-          expect(document.body).toMatchFileSnapshot(snapshotPath);
+          await expect(document.body).toMatchFileSnapshot(snapshotPath);
         });
       });
     });


### PR DESCRIPTION
I've noticed that we have some warnings and misconfigured mocked handlers. 

This PR fixes awaiting of `toMatchFileSnapshot` and fixes missing or incorrect msw handlers