### PR TITLE
backend: Do not include clusters with errors when loading them

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1160,6 +1160,13 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			continue
 		}
 
+		// This should not happen, but it's a defensive check.
+		if context.KubeContext == nil {
+			logger.Log(logger.LevelError, map[string]string{"context": context.Name},
+				errors.New("context.KubeContext is nil"), "error adding context")
+			continue
+		}
+
 		clusters = append(clusters, Cluster{
 			Name:     context.Name,
 			Server:   context.Cluster.Server,

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -361,6 +361,29 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 	assert.Equal(t, "default", minikubeCluster.Metadata["namespace"])
 }
 
+func TestInvalidKubeConfig(t *testing.T) {
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	absPath, err := filepath.Abs("./headlamp_testdata/kubeconfig_partialcontextvalid")
+	assert.NoError(t, err)
+
+	c := HeadlampConfig{
+		useInCluster:          false,
+		kubeConfigPath:        absPath,
+		enableDynamicClusters: true,
+		cache:                 cache,
+		kubeConfigStore:       kubeConfigStore,
+	}
+
+	err = kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, absPath, kubeconfig.KubeConfig)
+	assert.Error(t, err)
+
+	clusters := c.getClusters()
+
+	assert.Equal(t, 1, len(clusters))
+}
+
 //nolint:funlen
 func TestExternalProxy(t *testing.T) {
 	// Create a new server for testing

--- a/backend/cmd/headlamp_testdata/kubeconfig_partialcontextvalid
+++ b/backend/cmd/headlamp_testdata/kubeconfig_partialcontextvalid
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: test-cluster
+  cluster:
+    server: https://test-server:6443
+- name: invalid-cluster
+  cluster:
+    server: https://test-server:6443
+    certificate-authority-data: abc
+contexts:
+- context:
+    cluster: test-cluster
+    user: valid-user
+  name: valid-context
+- name: invalid-context
+  context:
+    cluster: test-cluster
+    user: invalid-user
+- name: invalid-cluster
+  context:
+    cluster: invalid-cluster
+    user: invalid-user
+users:
+- name: invalid-user
+  user:
+    client-certificate-data: abc
+    client-key-data: abc
+- name: valid-user
+  user:
+    client-certificate-data: dGVzdC1jZXJ0LWRhdGE=
+    client-key-data: dGVzdC1jZXJ0LWRhdGE=
+current-context: valid-context

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -385,8 +385,7 @@ func LoadContextsFromMultipleFiles(kubeConfigs string, source int) ([]Context, [
 
 // loadContextsFromData loads contexts from a kubeconfig data.
 // It unmarshals the kubeconfig data, extracts the contexts, and processes each context.
-// It returns all contexts, contextLoadErrors and any errors that occurred during the process.
-// It does not matter if a context has errors, it will be returned.
+// It returns valid contexts, contextLoadErrors and any errors that occurred during the process.
 func loadContextsFromData(data []byte, source int, skipProxySetup bool) ([]Context, []ContextLoadError, error) {
 	var contexts []Context //nolint:prealloc
 
@@ -412,6 +411,10 @@ func loadContextsFromData(data []byte, source int, skipProxySetup bool) ([]Conte
 				ContextName: context.Name,
 				Error:       err,
 			})
+
+			// Do not include any contexts with errors, else they may be
+			// processed as valid and make things fail.
+			continue
 		}
 
 		contexts = append(contexts, context)

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -72,7 +72,7 @@ func TestLoadContextsFromKubeConfigFile(t *testing.T) {
 		require.NoError(t, err, "Expected no error for auth error file")
 		require.NotEmpty(t, contextErrors, "Expected context errors for invalid auth file")
 		require.Equal(t, contextErrors[0].ContextName, "invalid-context")
-		require.Equal(t, 2, len(contexts), "Expected 1 context from invalid auth file")
+		require.Equal(t, 0, len(contexts), "Expected no contexts from invalid auth file")
 	})
 
 	t.Run("partially_valid_contexts", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestLoadContextsFromKubeConfigFile(t *testing.T) {
 		contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
 		require.NoError(t, err, "Expected no error for partially valid file")
 		require.NotEmpty(t, contextErrors, "Expected some context errors for partially valid file")
-		require.Equal(t, 3, len(contexts), "Expected 3 contexts from the partially valid file")
+		require.Equal(t, 1, len(contexts), "Expected 1 contexts from the partially valid file")
 		require.Equal(t, "valid-context", contexts[0].Name, "Expected context name to be 'valid-context'")
 	})
 }
@@ -173,7 +173,7 @@ users:
 		contexts, contextErrors, err := kubeconfig.LoadContextsFromBase64String(base64String, kubeconfig.DynamicCluster)
 		require.NoError(t, err, "Expected no error for partially valid base64")
 		require.NotEmpty(t, contextErrors, "Expected some context errors for partially valid base64")
-		require.Equal(t, 2, len(contexts), "Expected 2 valid contexts from partially valid base64")
+		require.Equal(t, 1, len(contexts), "Expected 1 valid context from partially valid base64")
 		assert.Equal(t, "valid-context", contexts[0].Name, "Expected context name to be 'valid-context'")
 	})
 }


### PR DESCRIPTION
We were loading clusters and checking if they had errors, but we'd still include them in the final list.

This PR also changes the tests since it seeems like some parts of the code were expecting the list of contexts to be always returned regardless of whether they had invalid contexts or not (this is how the tests were written), while other parts were assuming only [valid contexts](https://gitkraken.dev/link/dnNjb2RlOi8vZWFtb2Rpby5naXRsZW5zL2xpbmsvci9hNTgzYjliNTNhOWU3MTY0NTM2MDMwNGQzNjYyNzhhNjEwMTg0Y2ZlL2YvYmFja2VuZC9wa2cva3ViZWNvbmZpZy9rdWJlY29uZmlnLmdvP3VybD1odHRwcyUzQSUyRiUyRmdpdGh1Yi5jb20lMkZoZWFkbGFtcC1rOHMlMkZoZWFkbGFtcCZsaW5lcz0zMzk%3D?origin=gitlens) were [returned](https://gitkraken.dev/link/dnNjb2RlOi8vZWFtb2Rpby5naXRsZW5zL2xpbmsvci9hNTgzYjliNTNhOWU3MTY0NTM2MDMwNGQzNjYyNzhhNjEwMTg0Y2ZlL2YvYmFja2VuZC9wa2cva3ViZWNvbmZpZy9rdWJlY29uZmlnLmdvP3VybD1odHRwcyUzQSUyRiUyRmdpdGh1Yi5jb20lMkZoZWFkbGFtcC1rOHMlMkZoZWFkbGFtcCZsaW5lcz0zNDg%3D?origin=gitlens).

Hopefully this fixes the mysterious crashes we have reported. I will add tests if I can.

Thanks to [Per0x1de-1337](https://github.com/Per0x1de-1337) for the help in debugging this issue.

## How to test:
1. Add a new context to your kube config with a name, an invalid server, and an invalid user.
2. Verify that Headlamp crashes before this patch
3. Verify that Headlamp does not crash after this patch

Test also adding clusters dynamically (you can use the dynamic cluster plugin), both valid and invalid ones. Make sure the valid ones work, make sure the invalid ones show an error.
Test the same but adding the clusters in desktop mode from the Add Cluster button.