### PR TITLE
backend: Do not include clusters with errors when loading them

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -412,11 +412,14 @@ func loadContextsFromData(data []byte, source int, skipProxySetup bool) ([]Conte
 				ContextName: context.Name,
 				Error:       err,
 			})
+
+			// Do not include any contexts with errors, else they may be
+			// processed as valid and make things fail.
+			continue
 		}
 
 		contexts = append(contexts, context)
 	}
-
 	return contexts, contextErrors, nil
 }
 


### PR DESCRIPTION
We were loading clusters and checking if they had errors, but we'd still include them in the final list.

Hopefully this fixes the mysterious crashes we have reported. I will add tests if I can.

Solved with @joaquimrocha 