### PR TITLE
CI: Fix CI crash - Update actions/cache action to v4.2.1

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -43,7 +43,7 @@ jobs:
       run: kubectl get pods -A
     - name: Restore image-cache Folder
       id: cache-image-restore
-      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       with:
         path: ~/image-cache
         # cache the container image. All the paths this PR depends on except the e2e-tests folder for the key.
@@ -170,7 +170,7 @@ jobs:
     - name: Cache image-cache Folder
       if: steps.cache-image-restore.outputs.cache-hit != 'true'
       id: cache-image-save
-      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       with:
         path: ~/image-cache
         key: ${{ steps.cache-image-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
Currently our CI is crashing because of an old deprecated version of the `actions/cache`. 

[Example](https://github.com/headlamp-k8s/headlamp/actions/runs/13399139353/job/37425471463)
> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

This PR updates it to the latest version pinned by a SHA hash.

According to the 'migration guide](https://github.com/actions/cache/discussions/1510) there are no breaking changes 
