### PR TITLE
frontend: Fix broken link for involved objects in the overview

### DIFF
--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -165,7 +165,9 @@ class Event extends KubeObject<KubeEvent> {
         kind: this.involvedObject.kind,
         metadata: {
           name: this.involvedObject.name,
-          namespace: this.involvedObject.namespace,
+          namespace: InvolvedObjectClass.isNamespaced
+            ? this.involvedObject.namespace ?? this.getNamespace()
+            : undefined,
         } as KubeMetadata,
       });
     }


### PR DESCRIPTION
Seems like some objects can get related to the event without having a namespace but when they do need them for the link to work.

## Steps to reproduce:

1. Copy the contents of:
https://raw.githubusercontent.com/Azure-Samples/aks-store-demo/main/aks-store-all-in-one.yaml
2. Paste the contents in the Create dialog in Headlamp and press apply
3. Go to the overview -> crash! (before this patch)