### PR TITLE
backend: Move wsMultiplexer handler so it's not skipped without dynamic cluster feature

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -534,6 +534,9 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	// Configuration
 	r.HandleFunc("/config", config.getConfig).Methods("GET")
 
+	// Websocket connections
+	r.HandleFunc("/wsMultiplexer", config.multiplexer.HandleClientWebSocket)
+
 	config.addClusterSetupRoute(r)
 
 	oauthRequestMap := make(map[string]*OauthConfig)
@@ -1663,14 +1666,8 @@ func (c *HeadlampConfig) addClusterSetupRoute(r *mux.Router) {
 	// Delete a cluster
 	r.HandleFunc("/cluster/{name}", c.deleteCluster).Methods("DELETE")
 
-	// Websocket connections
-	// r.HandleFunc("/wsMutliplexer", c.multiplexer.HandleClientWebSocket)
-
 	// Rename a cluster
 	r.HandleFunc("/cluster/{name}", c.renameCluster).Methods("PUT")
-
-	// Websocket connections
-	r.HandleFunc("/wsMultiplexer", c.multiplexer.HandleClientWebSocket)
 }
 
 /*


### PR DESCRIPTION
Fixes #2849

By default in helm charts 'dynamic clusters' feature is not enabled. In the code then /wsMultiplexer handler was skipped

How to reproduce:

Locally:
 - Run `./backend/headlamp-server -html-static-dir ./frontend/build `
 - Open any page see that /wsMultiplexer is failing

in cluster Helm:

 - Run `helm install my-headlamp headlamp/headlamp --namespace kube-system`
 - Expose the service through Ingress
 - /wsMultiplexer is failing

