### PR TITLE
frontend: Fix incorrect links in sidebar after switching clusters

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -13,7 +13,7 @@ import { has } from 'lodash';
 import React, { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import helpers from '../../helpers';
 import { getToken, setToken } from '../../lib/auth';
 import { useCluster, useClustersConf } from '../../lib/k8s';
@@ -71,6 +71,10 @@ export default function TopBar({}: TopBarProps) {
   const history = useHistory();
   const { appBarActions, appBarActionsProcessors } = useAppBarActionsProcessed();
 
+  // getToken may return stale value so we need to rerender on navigation
+  // TODO: create a useToken hook that always returns latest token
+  // eslint-disable-next-line no-unused-vars
+  const _location = useLocation();
   function hasToken() {
     return !!cluster ? !!getToken(cluster) : false;
   }

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -4,8 +4,9 @@ import ListItem, { ListItemProps } from '@mui/material/ListItem';
 import { useTheme } from '@mui/system';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
+import { useCluster } from '../../lib/k8s';
 import { createRouteURL, getRoute } from '../../lib/router';
-import { getCluster, getClusterPrefixedPath } from '../../lib/util';
+import { getClusterPrefixedPath } from '../../lib/util';
 import ListItemLink from './ListItemLink';
 import { SidebarEntry } from './sidebarSlice';
 
@@ -45,12 +46,13 @@ const SidebarItem = memo((props: SidebarItemProps) => {
   } = props;
   const hasSubtitle = !!subtitle;
   const theme = useTheme();
+  const cluster = useCluster();
 
   // const classes = useItemStyle({ fullWidth, hasSubtitle: !!subtitle });
 
   let fullURL = url;
-  if (fullURL && useClusterURL && getCluster()) {
-    fullURL = generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! });
+  if (fullURL && useClusterURL && cluster) {
+    fullURL = generatePath(getClusterPrefixedPath(url), { cluster });
   }
 
   if (!fullURL) {


### PR DESCRIPTION
How to reproduce:

 - Go to Security, click in each sub-item of the sidebar under it
 - Switch to another cluster using the top bar button
 - Go to Secrets and click the sub-items again -> the URL will be the one from the previous cluster

This was caused by the stale `cluster` value that wasn't being updated. Using `useCluster` hook fixes it

Also updated useCluster hook so it doesn't trigger a rerender on every navigation