### PR TITLE
backend: Add toolchain for those without latest go

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,7 @@
 module github.com/headlamp-k8s/headlamp/backend
 
 go 1.24
+toolchain go1.24.0
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
Otherwise this means people need to manually update their go versions.

This also means we need a go 1.24.x not 1.24.0. This is easier to maintain rather than having to update at each golang patch release. This is so we don't specify go 1.24.0

Details: https://go.dev/doc/toolchain#config


## testing

- tried this with Linux Ubuntu 22.04 and an older go 1.23 patch release installed and a newer one written in the go mod




