### PR TITLE
frontend: Update useSidebarItems hooks to support extending default sidebar items

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.test.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.test.tsx
@@ -105,6 +105,28 @@ describe('useSidebarItems', () => {
     `);
   });
 
+  it('should add entries to existing items', () => {
+    const customEntries = {
+      custom1: {
+        name: 'custom1',
+        label: 'Custom 1',
+        url: '/custom1',
+        parent: 'storage',
+      },
+    };
+
+    const store = mockStore(customEntries, []);
+    const { result } = renderHook(() => useSidebarItems(), {
+      wrapper: wrapper(store),
+    });
+
+    expect(
+      result.current
+        .find(it => it.name === customEntries.custom1.parent)
+        ?.subList?.find(it => it.name === customEntries.custom1.name)
+    ).toBeDefined();
+  });
+
   it('should apply customSidebarFilters', () => {
     const customEntries = {
       custom1: { name: 'custom1', label: 'Custom 1', url: '/custom1' },


### PR DESCRIPTION
Fixes the regression to be able to handle custom entries that extend default items

for example 

```js
{
  name: "custom-entry",
  label: "Custom entry",
  parent: "network"
}
```

Should add it to the network item in "IN_CLUSTER" sidebar

Added a test case for this