### PR TITLE
frontend: Fix word breaking for min content columns

### DIFF
--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -457,7 +457,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -549,7 +549,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -641,7 +641,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -733,7 +733,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -825,7 +825,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -328,7 +328,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -364,7 +364,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -400,7 +400,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -436,7 +436,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -328,7 +328,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -364,7 +364,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -400,7 +400,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -436,7 +436,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -263,7 +263,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -289,7 +289,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -315,7 +315,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
@@ -341,7 +341,7 @@
             </a>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -464,6 +464,7 @@ const Row = memo(
 
 const MemoCell = memo(
   ({ cell, table }: { cell: MRT_Cell<any, unknown>; table: any; isRowSelected: boolean }) => {
+    const column = cell.column.columnDef as TableColumn<any, unknown>;
     return (
       <MRT_TableBodyCell
         staticRowIndex={-1}
@@ -474,8 +475,8 @@ const MemoCell = memo(
           whiteSpace: 'normal',
           width: 'unset',
           minWidth: 'unset',
-          wordBreak: 'break-word',
-          ...(cell.column.columnDef.muiTableBodyCellProps as TableCellProps)?.sx,
+          wordBreak: column.gridTemplate === 'min-content' ? 'normal' : 'break-word',
+          ...(column.muiTableBodyCellProps as TableCellProps)?.sx,
         }}
       />
     );

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -613,12 +613,12 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fn2omc-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1d5c0c2-MuiTableCell-root"
               >
                 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
@@ -710,12 +710,12 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fn2omc-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1d5c0c2-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -966,7 +966,7 @@
                       mycustomresource
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                     >
                       <p
                         aria-label="2021-12-15T14:57:13.000Z"
@@ -1063,7 +1063,7 @@
                       myotherresource
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                     >
                       <p
                         aria-label="2021-12-15T14:57:13.000Z"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -724,7 +724,7 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fvjjgn-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2021-12-15T14:57:13.000Z"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -601,7 +601,7 @@
                       mycustomresource
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                     >
                       <p
                         aria-label="2021-12-15T14:57:13.000Z"
@@ -698,7 +698,7 @@
                       myotherresource
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                     >
                       <p
                         aria-label="2021-12-15T14:57:13.000Z"

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -934,7 +934,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1072,7 +1072,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1210,7 +1210,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1348,7 +1348,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1486,7 +1486,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -999,7 +999,7 @@
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2023-05-02T04:34:53.000Z"

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -836,12 +836,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1jzgucv-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-11bde8u-MuiTableCell-root"
                 >
                   0/1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ce2yy2-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ugiodz-MuiTableCell-root"
                 >
                   1
                 </td>
@@ -884,7 +884,7 @@
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2025-02-03T09:00:00.000Z"
@@ -976,12 +976,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1jzgucv-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-11bde8u-MuiTableCell-root"
                 >
                   2/2
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ce2yy2-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ugiodz-MuiTableCell-root"
                 >
                   2
                 </td>
@@ -1024,7 +1024,7 @@
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2025-02-01T10:00:00.000Z"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -615,7 +615,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -522,7 +522,7 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wktavs-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -558,7 +558,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -741,7 +741,7 @@
                 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -684,7 +684,7 @@
                 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -871,22 +871,22 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2qtihd-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-q3ahrg-MuiTableCell-root"
               >
                 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-xt17is-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-whujl3-MuiTableCell-root"
               >
                 10
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-m5d1yl-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-vim8hm-MuiTableCell-root"
               >
                 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-10-20T11:10:58.000Z"

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -489,7 +489,7 @@
                 test
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
@@ -585,7 +585,7 @@
                 test
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -749,7 +749,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
@@ -866,7 +866,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -821,12 +821,12 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17ancoo-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-mwldxs-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wktavs-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bu5bql-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -842,7 +842,7 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yy2sbb-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19r0ciz-MuiTableCell-root"
               >
                 8h
               </td>
@@ -869,7 +869,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -961,12 +961,12 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17ancoo-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-mwldxs-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wktavs-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bu5bql-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -982,7 +982,7 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yy2sbb-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19r0ciz-MuiTableCell-root"
               >
                 8h
               </td>
@@ -1009,7 +1009,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -1101,12 +1101,12 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17ancoo-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-mwldxs-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wktavs-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bu5bql-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1122,7 +1122,7 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yy2sbb-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19r0ciz-MuiTableCell-root"
               >
                 8h
               </td>
@@ -1149,7 +1149,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
@@ -1241,12 +1241,12 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17ancoo-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-mwldxs-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wktavs-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bu5bql-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1262,7 +1262,7 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yy2sbb-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19r0ciz-MuiTableCell-root"
               >
                 8h
               </td>
@@ -1289,7 +1289,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -618,7 +618,7 @@
                 holder
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -546,7 +546,7 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -469,7 +469,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2024-08-16T11:12:37.179Z"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -847,7 +847,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
                 >
                   <div
                     class="recharts-responsive-container css-a9n7s9"
@@ -894,7 +894,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-151iij4-MuiTableCell-root"
                 />
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2022-01-01T00:00:00.000Z"
@@ -976,7 +976,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
                 >
                   <div
                     class="recharts-responsive-container css-a9n7s9"
@@ -1023,7 +1023,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-151iij4-MuiTableCell-root"
                 />
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -931,17 +931,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 1 (3mo ago)
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 0/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label="Back-off pulling image "doesnotexist:nover""
@@ -957,13 +957,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -984,7 +984,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1076,17 +1076,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 0/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1102,17 +1102,17 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               >
                 16.32 m
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               >
                 46.4 Mi
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               />
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1sa0g84-MuiTableCell-root"
@@ -1131,7 +1131,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1223,17 +1223,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 0/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1249,13 +1249,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -1276,7 +1276,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1368,17 +1368,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 337 (3mo ago)
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 0/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
@@ -1394,13 +1394,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -1421,7 +1421,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1513,17 +1513,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 0/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1539,13 +1539,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -1566,7 +1566,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1658,17 +1658,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1684,13 +1684,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -1711,7 +1711,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1803,17 +1803,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1829,13 +1829,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -1856,7 +1856,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
@@ -1948,17 +1948,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-e2ym6r-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1liseb-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-aqqgdj-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-92cw21-MuiTableCell-root"
               >
                 1/1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okjmrx-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
                   aria-label=""
@@ -1974,13 +1974,13 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ki6f8i-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ku5618-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ileoid-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-imu1r7-MuiTableCell-root"
               />
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-163w04e-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p13dmr-MuiTableCell-root"
               >
                 0.0.0.2
               </td>
@@ -2001,7 +2001,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -723,22 +723,22 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-3y0d35-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-tghf5d-MuiTableCell-root"
               >
                 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1sk30s5-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-muciiw-MuiTableCell-root"
               >
                 N/A
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1rtjrfp-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1xb0jz7-MuiTableCell-root"
               >
                 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-10-06T05:17:14.000Z"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -514,17 +514,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-t6cb94-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-3jqzo4-MuiTableCell-root"
               >
                 1000000
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-p8mhsd-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-15pd70x-MuiTableCell-root"
               >
                 False
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-10-26T13:46:17.000Z"

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -943,7 +943,7 @@ pod-template-hash=b123456
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2023-07-07T05:36:02.000Z"
@@ -1085,7 +1085,7 @@ pod-template-hash=a123456
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2023-05-25T05:15:05.000Z"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -690,7 +690,7 @@
                 </div>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-10-25T11:48:48.000Z"

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -464,7 +464,7 @@
                 handler
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -668,17 +668,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-3svv6a-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ny9u8f-MuiTableCell-root"
               >
                 bla
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fn2omc-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1d5c0c2-MuiTableCell-root"
               >
                 0
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
@@ -770,17 +770,17 @@
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-3svv6a-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ny9u8f-MuiTableCell-root"
               >
                 test
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fn2omc-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1d5c0c2-MuiTableCell-root"
               >
                 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -951,7 +951,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
@@ -1093,7 +1093,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
@@ -1222,7 +1222,7 @@
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -644,7 +644,7 @@
                 true
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -638,7 +638,7 @@
                 undefined
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -738,7 +738,7 @@
                 True
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
               >
                 <p
                   aria-label="2023-11-23T07:18:45.000Z"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -462,12 +462,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -549,12 +549,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -636,12 +636,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -723,12 +723,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -810,12 +810,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -897,12 +897,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -462,12 +462,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -549,12 +549,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -636,12 +636,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -723,12 +723,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -810,12 +810,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
@@ -897,12 +897,12 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pz3ayj-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lkvg7y-MuiTableCell-root"
                 >
                   1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-1icg04k-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-f23cwk-MuiTableCell-root"
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"


### PR DESCRIPTION
Table column size adjustment PR #2802 and word-break PR #2811 weren't tested together and resulted in a messy table

This PR fixes that, table now won't break lines when width is min-content

Before

![image](https://github.com/user-attachments/assets/9ac7abae-0cff-440f-a689-d13a48ff1b9f)

After

![image](https://github.com/user-attachments/assets/06ff8ad5-8cec-44a2-82af-bb61e2327434)


