### PR TITLE
frontend: Fix DetailsDrawer to not mutate url when in app mode

### DIFF
--- a/frontend/src/components/common/Resource/DetailsDrawer.tsx
+++ b/frontend/src/components/common/Resource/DetailsDrawer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';
+import helpers from '../../../helpers';
 import { setSelectedResource } from '../../../redux/drawerModeSlice';
 import { useTypedSelector } from '../../../redux/reducers/reducers';
 import { KubeObjectDetails } from '../../resourceMap/details/KubeNodeDetails';
@@ -18,6 +19,8 @@ export default function DetailsDrawer() {
   const isDetailDrawerEnabled = useTypedSelector(state => state.drawerMode.isDetailDrawerEnabled);
 
   function handleCloseDrawerReset() {
+    if (helpers.isElectron()) return;
+
     const currentPlacement = location.pathname;
     const pathname = currentPlacement;
 


### PR DESCRIPTION
Fixes a bug in details drawer in app mode

How to test/reproduce:

 - Go to ConfigMaps (or any other resource)
 - Click on one resource
 - Close the details drawer
 - Click on the same resource again

The spinner will show, check the `window.location.href` it will have url path set instead of the hash router