### PR TITLE
charts: make in-cluster arg configurable

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -69,6 +69,7 @@ $ helm install my-headlamp headlamp/headlamp \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| config.inCluster | bool | `true` | Run Headlamp in-cluster |
 | config.baseURL | string | `""` | Base URL path for Headlamp UI |
 | config.pluginsDir | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from |
 | config.extraArgs | array | `[]` | Additional arguments for Headlamp server |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -125,7 +125,9 @@ spec:
           {{- end }}
           {{- end }}
           args:
+            {{- if .Values.config.inCluster }}
             - "-in-cluster"
+            {{- end }}
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -26,6 +26,7 @@ fullnameOverride: ""
 initContainers: []
 
 config:
+  inCluster: true
   # -- base url path at which headlamp should run
   baseURL: ""
   oidc:


### PR DESCRIPTION
Fixes #2958 

- [x] Added suggested changes.(Read the `in-cluster` argument from `values.yml` dynamically.)
- [x] Updated docs