### PR TITLE
frontend: node: Display taint value in status

### DIFF
--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -5,7 +5,7 @@ import { HoverInfoLabel } from '../common';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { UsageBarChart } from './Charts';
 import { NodeReadyLabel } from './Details';
-import { NodeTaintsLabel } from './utils';
+import { formatTaint, NodeTaintsLabel } from './utils';
 
 export default function NodeList() {
   const [nodeMetrics, metricsError] = Node.useMetrics();
@@ -70,8 +70,7 @@ export default function NodeList() {
         {
           id: 'taints',
           label: t('translation|Taints'),
-          getValue: node =>
-            node.spec?.taints?.map(taint => `${taint.key}:${taint.effect}`)?.join(', '),
+          getValue: node => node.spec?.taints?.map(taint => formatTaint(taint))?.join(', '),
           render: (item: Node) => <NodeTaintsLabel node={item} />,
         },
         {

--- a/frontend/src/components/node/utils.tsx
+++ b/frontend/src/components/node/utils.tsx
@@ -18,6 +18,10 @@ const PaddedChip = styled(Chip)({
   paddingBottom: '2px',
 });
 
+export function formatTaint(taint: { key: string; value?: string; effect: string }) {
+  return `${taint.key}${taint.value ? '=' + taint.value : ''}:${taint.effect}`;
+}
+
 export function NodeTaintsLabel(props: { node: Node }) {
   const { node } = props;
   const { t } = useTranslation(['glossary', 'translation']);
@@ -26,9 +30,10 @@ export function NodeTaintsLabel(props: { node: Node }) {
   }
   const limits: ReactNode[] = [];
   node.spec.taints.forEach(taint => {
+    const format = formatTaint(taint);
     limits.push(
-      <Tooltip title={`${taint.key}:${taint.effect}`} key={taint.key}>
-        <PaddedChip label={`${taint.key}:${taint.effect}`} variant="outlined" size="small" />
+      <Tooltip title={format} key={taint.key}>
+        <PaddedChip label={format} variant="outlined" size="small" />
       </Tooltip>
     );
   });

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -47,6 +47,7 @@ export interface KubeNode extends KubeObjectInterface {
     podCIDR: string;
     taints: {
       key: string;
+      value?: string;
       effect: string;
     }[];
     [otherProps: string]: any;


### PR DESCRIPTION
This change adds the 'value' field to the taint spec, allowing us to display the taint value in the node status on the list page.

Fixes: #2975 

### Testing
- [X] Open Headlamp and create a node with a taint value
- [X] Ensure that the value appears when you hover over the status

![image](https://github.com/user-attachments/assets/2d1ef56f-83ef-48aa-a268-71ee7e2cb76f)
