### PR TITLE
headlamp-plugin: Fix building

### DIFF
--- a/frontend/src/components/resourceMap/graphViewSlice.tsx
+++ b/frontend/src/components/resourceMap/graphViewSlice.tsx
@@ -19,7 +19,7 @@ export interface IconDefinition {
   color?: string;
 }
 
-interface GraphViewSliceState {
+export interface GraphViewSliceState {
   graphSources: GraphSource[];
   kindIcons: Record<string, IconDefinition>;
 }

--- a/frontend/src/redux/drawerModeSlice.ts
+++ b/frontend/src/redux/drawerModeSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-interface DrawerModeState {
+export interface DrawerModeState {
   isDetailDrawerEnabled: boolean;
   selectedResource: { kind: string; metadata: { name: string; namespace?: string } } | undefined;
 }

--- a/frontend/src/redux/overviewChartsSlice.ts
+++ b/frontend/src/redux/overviewChartsSlice.ts
@@ -11,7 +11,7 @@ export interface OverviewChartsProcessor {
   processor: (charts: OverviewChart[]) => OverviewChart[];
 }
 
-interface OverviewChartsState {
+export interface OverviewChartsState {
   processors: OverviewChartsProcessor[];
 }
 

--- a/plugins/headlamp-plugin/vite-types.d.ts
+++ b/plugins/headlamp-plugin/vite-types.d.ts
@@ -9,6 +9,8 @@ declare module '*.svg?react' {
 
 declare const vi: any;
 
+declare module 'vitest';
+
 interface ImportMeta {
   env: any;
   glob: any;


### PR DESCRIPTION
There were some private types that had to be exported for proper declaration generation and also vitest module stub types were added