### PR TITLE
frontend: logViewer: Add toggle button for word break

### DIFF
--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "Head back <1>home</1>.",
   "Error Details": "",
   "Copy": "",
+  "Disable Word Break": "",
+  "Enable Word Break": "",
   "Find": "Finden",
   "Download": "Herunterladen",
   "No results": "Keine Ergebnisse",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "Head back <1>home</1>.",
   "Error Details": "Error Details",
   "Copy": "Copy",
+  "Disable Word Break": "Disable Word Break",
+  "Enable Word Break": "Enable Word Break",
   "Find": "Find",
   "Download": "Download",
   "No results": "No results",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "Head back <1>home</1>.",
   "Error Details": "Detalles del error",
   "Copy": "Copiar",
+  "Disable Word Break": "",
+  "Enable Word Break": "",
   "Find": "Buscar",
   "Download": "Descargar",
   "No results": "Sin resultados",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "Head back <1>home</1>.",
   "Error Details": "",
   "Copy": "",
+  "Disable Word Break": "",
+  "Enable Word Break": "",
   "Find": "Trouver",
   "Download": "Télécharger",
   "No results": "Aucun résultat",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "Torna alla <1>home</1>.",
   "Error Details": "Dettagli errore",
   "Copy": "Copia",
+  "Disable Word Break": "",
+  "Enable Word Break": "",
   "Find": "Trova",
   "Download": "Scarica",
   "No results": "Nessun risultato",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "Voltar ao <1>início</1>.",
   "Error Details": "Detalhes do erro",
   "Copy": "Copiar",
+  "Disable Word Break": "",
+  "Enable Word Break": "",
   "Find": "Pesquisar",
   "Download": "Descarregar",
   "No results": "Sem resultados",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -160,6 +160,8 @@
   "Head back <1>home</1>.": "返回<1>首頁</1>。",
   "Error Details": "錯誤詳情",
   "Copy": "複製",
+  "Disable Word Break": "",
+  "Enable Word Break": "",
   "Find": "查詢",
   "Download": "下載",
   "No results": "無結果",


### PR DESCRIPTION
This PR adds a toggle button for the Logs Viewer window that allows the text to be formatted for word break.

similar to requested feature from https://github.com/headlamp-k8s/headlamp/issues/2657

WIP:

- not sure if this should be enabled by default


### How to test

- Open headlamp into a cluster 
- Navigate to pods
- Click on any pod
- Open the "View logs" button
- Click the toggle "Word break" button
- Log text format should change