### PR TITLE
Makefile: adds `backend-lint-fix` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ tools/golangci-lint: backend/go.mod backend/go.sum
 backend-lint: tools/golangci-lint
 	cd backend && ./tools/golangci-lint run
 
+backend-lint-fix: tools/golangci-lint
+	cd backend && ./tools/golangci-lint run --fix
+
 frontend/build:
 	make frontend
 


### PR DESCRIPTION
## Description

-> Adds a new command `backend-lint-fix` 
-> This command is the updated version of the existing command `backend-lint` 
-> The difference is it has `--fix` flag which fixes the line-space errors, indentation, and missing full-stop errors itself. 