### PR TITLE
headlamp-plugin: Ensure the dist files are all copied on npm run start

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -435,8 +435,6 @@ async function start() {
   const config = (await viteConfigPromise).default;
   const vite = await vitePromise;
 
-  await copyToPluginsFolder(config);
-
   if (config.build) {
     config.build.watch = {};
     config.build.sourcemap = 'inline';
@@ -446,11 +444,14 @@ async function start() {
   if (config.plugins) {
     config.plugins.push({
       name: 'headlamp-copy-extra-dist',
-      closeBundle: async () => {
+      buildEnd: async () => {
         await copyExtraDistFiles();
       },
     });
   }
+
+  // Then add the plugins from copyToPluginsFolder which includes ViteStaticCopy
+  await copyToPluginsFolder(config);
 
   try {
     await vite.build(config);


### PR DESCRIPTION
Only the index.js and package.json were being copied to the plugin folder. This was because the copy of the extra dist files was happening on "close bundle" rather than on "build end", i.e. it was happening only after copying the static files.

This patch fixes that and also moves the setting up of the static copy to after the setting up of the extra-dist-files logic. This has no real effect but makes the code more readable since it's ordered like it actually is processed.