### PR TITLE
frontend: EditorDialog: Show error reason on failure

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -280,7 +280,8 @@ export default function EditorDialog(props: EditorDialogProps) {
                 apiVersion,
               });
             }
-            setError(msg);
+            const errorDetail = value.reason?.message || msg;
+            setError(errorDetail);
             setOpen?.(true);
             // throw msg;
             throw new Error(msg);


### PR DESCRIPTION
This change gives additional information to the user about resource creation failures, using the reason provided in the value object. The message in the UI will fall back to the original message when a reason is not provided in the object.

Fixes: #3047 

### Testing

- [X] Click on the 'Create' button in Headlamp and try to create a resource with an invalid name (i.e. config-map!)
- [X] Note the failure message includes the error reason as expected

![image](https://github.com/user-attachments/assets/943c32e9-a927-4e4f-90ab-99db38d09817)